### PR TITLE
Change DSL-JSON setup so it's aligned with other Scala libraries

### DIFF
--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/CommonParams.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/CommonParams.scala
@@ -2,7 +2,6 @@ package com.github.plokhotnyuk.jsoniter_scala.macros
 
 import java.util.concurrent.TimeUnit
 
-import com.dslplatform.json.JsonWriter
 import org.openjdk.jmh.annotations._
 
 @State(Scope.Thread)
@@ -23,6 +22,4 @@ import org.openjdk.jmh.annotations._
 @OutputTimeUnit(TimeUnit.SECONDS)
 abstract class CommonParams {
   val preallocatedBuf: Array[Byte] = new Array(32768)
-  val preallocatedOutputStream: PreallocByteArrayOutputStream = new PreallocByteArrayOutputStream(preallocatedBuf)
-  val preallocatedWriter: JsonWriter = DslPlatformJson.dslJson.newWriter(preallocatedBuf)
 }

--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/DslPlatformJson.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/DslPlatformJson.scala
@@ -1,22 +1,37 @@
 package com.github.plokhotnyuk.jsoniter_scala.macros
 
-import com.dslplatform.json.DslJson
-import java.io.OutputStream
+import com.dslplatform.json._
+
+import scala.reflect.ClassTag
 
 object DslPlatformJson {
-  val dslJson = new DslJson[Any]
-}
+  private val dslJson = new DslJson[Any]
+  implicit val (encoderAnyRef, decoderAnyRef) = setupCodecs[AnyRefs]
+  implicit val (encoderDM, decoderDM) = setupCodecs[DistanceMatrix]
 
-class PreallocByteArrayOutputStream(private[this] val buf: Array[Byte]) extends OutputStream {
-  var count = 0
-
-  override def write(b: Int): Unit = {
-    buf(count) = b.toByte
-    count += 1
+  private val tlWriter = new ThreadLocal[JsonWriter] {
+    override def initialValue(): JsonWriter = dslJson.newWriter()
+  }
+  private val tlReader = new ThreadLocal[JsonReader[_]] {
+    override def initialValue(): JsonReader[_] = dslJson.newReader()
   }
 
-  override def write(b: Array[Byte], off: Int, len: Int): Unit = {
-    System.arraycopy(b, off, buf, count, len)
-    count += len
+  private def setupCodecs[T](implicit ct: ClassTag[T]): (JsonWriter.WriteObject[T], JsonReader.ReadObject[T]) = {
+    val encoder = dslJson.tryFindWriter(ct.runtimeClass).asInstanceOf[JsonWriter.WriteObject[T]]
+    val decoder = dslJson.tryFindReader(ct.runtimeClass).asInstanceOf[JsonReader.ReadObject[T]]
+    encoder -> decoder
+  }
+
+  def decodeDslJson[T](bytes: Array[Byte])(implicit decoder: JsonReader.ReadObject[T]): T = {
+    val reader = tlReader.get().process(bytes, bytes.length)
+    reader.read()
+    decoder.read(reader)
+  }
+
+  def encodeDslJson[T](obj: T)(implicit encoder: JsonWriter.WriteObject[T]): JsonWriter = {
+    val writer = tlWriter.get()
+    writer.reset()
+    encoder.write(writer, obj)
+    writer
   }
 }

--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmark.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmark.scala
@@ -1,9 +1,7 @@
 package com.github.plokhotnyuk.jsoniter_scala.macros
 
-import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets._
 
-import com.dslplatform.json._
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.github.plokhotnyuk.jsoniter_scala.macros.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.macros.DslPlatformJson._
@@ -24,7 +22,7 @@ class GoogleMapsAPIBenchmark extends CommonParams {
   def readCirce(): DistanceMatrix = decode[DistanceMatrix](new String(jsonBytes, UTF_8)).fold(throw _, x => x)
 
   @Benchmark
-  def readDslJsonScala(): DistanceMatrix = dslJson.decode[DistanceMatrix](jsonBytes)
+  def readDslJsonJava(): DistanceMatrix = decodeDslJson[DistanceMatrix](jsonBytes)
 
   @Benchmark
   def readJacksonScala(): DistanceMatrix = jacksonMapper.readValue[DistanceMatrix](jsonBytes)
@@ -39,18 +37,10 @@ class GoogleMapsAPIBenchmark extends CommonParams {
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)
 
   @Benchmark
-  def writeDslJsonScala(): Array[Byte] = {
-    val baos = new ByteArrayOutputStream
-    dslJson.encode(obj, baos)
-    baos.toByteArray
-  }
+  def writeDslJsonJava(): Array[Byte] = encodeDslJson[DistanceMatrix](obj).toByteArray
 
   @Benchmark
-  def writeDslJsonScalaPrealloc(): Int = {
-    preallocatedOutputStream.count = 0
-    dslJson.encode(obj, preallocatedOutputStream)
-    preallocatedOutputStream.count
-  }
+  def writeDslJsonJavaPrealloc(): com.dslplatform.json.JsonWriter = encodeDslJson[DistanceMatrix](obj)
 
   @Benchmark
   def writeJacksonScala(): Array[Byte] = jacksonMapper.writeValueAsBytes(obj)

--- a/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmarkSpec.scala
@@ -7,7 +7,6 @@ class AnyRefsBenchmarkSpec extends BenchmarkSpecBase {
     "deserialize properly" in {
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonJava() shouldBe benchmark.obj
-      benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
       benchmark.readJsoniterScala() shouldBe benchmark.obj
       benchmark.readPlayJson() shouldBe benchmark.obj
@@ -15,9 +14,8 @@ class AnyRefsBenchmarkSpec extends BenchmarkSpecBase {
     "serialize properly" in {
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonJava()) shouldBe benchmark.jsonString
-      toString(benchmark.preallocatedBuf, benchmark.writeDslJsonJavaPrealloc()) shouldBe benchmark.jsonString
-      toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
-      toString(benchmark.preallocatedBuf, benchmark.writeDslJsonScalaPrealloc()) shouldBe benchmark.jsonString
+      val writer = benchmark.writeDslJsonJavaPrealloc()
+      toString(writer.getByteBuffer, writer.size()) shouldBe benchmark.jsonString
       toString(benchmark.writeJsoniterScala()) shouldBe benchmark.jsonString
       toString(benchmark.preallocatedBuf, benchmark.writeJsoniterScalaPrealloc()) shouldBe benchmark.jsonString
       toString(benchmark.writePlayJson()) shouldBe benchmark.jsonString

--- a/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmarkSpec.scala
@@ -6,15 +6,16 @@ class GoogleMapsAPIBenchmarkSpec extends BenchmarkSpecBase {
   "GoogleMapsAPIBenchmark" should {
     "deserialize properly" in {
       benchmark.readCirce() shouldBe benchmark.obj
-      benchmark.readDslJsonScala() shouldBe benchmark.obj
+      benchmark.readDslJsonJava() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
       benchmark.readJsoniterScala() shouldBe benchmark.obj
       benchmark.readPlayJson() shouldBe benchmark.obj
     }
     "serialize properly" in {
       toString(benchmark.writeCirce()) shouldBe GoogleMapsAPI.compactJsonString
-      toString(benchmark.writeDslJsonScala()) shouldBe GoogleMapsAPI.compactJsonString
-      toString(benchmark.preallocatedBuf, benchmark.writeDslJsonScalaPrealloc()) shouldBe GoogleMapsAPI.compactJsonString
+      toString(benchmark.writeDslJsonJava()) shouldBe GoogleMapsAPI.compactJsonString
+      val writer = benchmark.writeDslJsonJavaPrealloc()
+      toString(writer.getByteBuffer, writer.size()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.writeJacksonScala()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.writeJsoniterScala()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.preallocatedBuf, benchmark.writeJsoniterScalaPrealloc()) shouldBe GoogleMapsAPI.compactJsonString


### PR DESCRIPTION
I never actually ran benchmark for DSL-JSON on Scala up until now ;)

```
[info] AnyRefsBenchmark.readCirce                   thrpt    5   1165266,909 -   34269,116  ops/s
[info] AnyRefsBenchmark.readDslJsonJava             thrpt    5   6034401,846 -   68949,206  ops/s
[info] AnyRefsBenchmark.readJacksonScala            thrpt    5   1685795,773 -   75854,394  ops/s
[info] AnyRefsBenchmark.readJsoniterScala           thrpt    5   5890885,123 -   95926,133  ops/s
[info] AnyRefsBenchmark.readPlayJson                thrpt    5    359020,622 -    4860,489  ops/s
[info] AnyRefsBenchmark.writeCirce                  thrpt    5   1288835,046 -   16514,478  ops/s
[info] AnyRefsBenchmark.writeDslJsonJava            thrpt    5  10073666,500 -  434053,846  ops/s
[info] AnyRefsBenchmark.writeDslJsonJavaPrealloc    thrpt    5  10435042,415 - 2304250,779  ops/s
[info] AnyRefsBenchmark.writeJacksonScala           thrpt    5   3667112,400 -  251298,590  ops/s
[info] AnyRefsBenchmark.writeJsoniterScala          thrpt    5  14192939,072 -  385575,970  ops/s
[info] AnyRefsBenchmark.writeJsoniterScalaPrealloc  thrpt    5  17441103,176 -  512921,134  ops/s
[info] AnyRefsBenchmark.writePlayJson               thrpt    5    880244,919 -    5546,484  ops/s```