### PR TITLE
Add dsl json platform benchmarks

### DIFF
--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmark.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmark.scala
@@ -49,6 +49,13 @@ class AnyRefsBenchmark extends CommonParams {
   }
 
   @Benchmark
+  def writeDslJsonScalaPrealloc(): Int = {
+    preallocatedOutputStream.count = 0
+    dslJson.encode(obj, preallocatedOutputStream)
+    preallocatedOutputStream.count
+  }
+
+  @Benchmark
   def writeJacksonScala(): Array[Byte] = jacksonMapper.writeValueAsBytes(obj)
 
   @Benchmark

--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmark.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmark.scala
@@ -1,9 +1,12 @@
 package com.github.plokhotnyuk.jsoniter_scala.macros
 
+import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets._
 
+import com.dslplatform.json._
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.github.plokhotnyuk.jsoniter_scala.macros.CirceEncodersDecoders._
+import com.github.plokhotnyuk.jsoniter_scala.macros.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.macros.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.macros.PlayJsonFormats._
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsoniterCodecs._
@@ -24,6 +27,9 @@ class AnyRefsBenchmark extends CommonParams {
   def readCirce(): AnyRefs = decode[AnyRefs](new String(jsonBytes, UTF_8)).fold(throw _, x => x)
 
   @Benchmark
+  def readDslJsonScala(): AnyRefs = dslJson.decode[AnyRefs](jsonBytes)
+
+  @Benchmark
   def readJacksonScala(): AnyRefs = jacksonMapper.readValue[AnyRefs](jsonBytes)
 
   @Benchmark
@@ -34,6 +40,13 @@ class AnyRefsBenchmark extends CommonParams {
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)
+
+  @Benchmark
+  def writeDslJsonScala(): Array[Byte] = {
+    val baos = new ByteArrayOutputStream
+    dslJson.encode(obj, baos)
+    baos.toByteArray
+  }
 
   @Benchmark
   def writeJacksonScala(): Array[Byte] = jacksonMapper.writeValueAsBytes(obj)

--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmark.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmark.scala
@@ -27,6 +27,9 @@ class AnyRefsBenchmark extends CommonParams {
   def readCirce(): AnyRefs = decode[AnyRefs](new String(jsonBytes, UTF_8)).fold(throw _, x => x)
 
   @Benchmark
+  def readDslJsonJava(): AnyRefs = dslJson.deserialize(classOf[AnyRefs], jsonBytes, jsonBytes.length)
+
+  @Benchmark
   def readDslJsonScala(): AnyRefs = dslJson.decode[AnyRefs](jsonBytes)
 
   @Benchmark
@@ -40,6 +43,20 @@ class AnyRefsBenchmark extends CommonParams {
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)
+
+  @Benchmark
+  def writeDslJsonJava(): Array[Byte] = {
+    preallocatedWriter.reset()
+    dslJson.serialize(preallocatedWriter, classOf[AnyRefs], obj)
+    java.util.Arrays.copyOf(preallocatedBuf, preallocatedWriter.size())
+  }
+
+  @Benchmark
+  def writeDslJsonJavaPrealloc(): Int = {
+    preallocatedWriter.reset()
+    dslJson.serialize(preallocatedWriter, classOf[AnyRefs], obj)
+    preallocatedWriter.size()
+  }
 
   @Benchmark
   def writeDslJsonScala(): Array[Byte] = {

--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/CommonParams.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/CommonParams.scala
@@ -22,4 +22,5 @@ import org.openjdk.jmh.annotations._
 @OutputTimeUnit(TimeUnit.SECONDS)
 abstract class CommonParams {
   val preallocatedBuf: Array[Byte] = new Array(32768)
+  val preallocatedOutputStream: PreallocByteArrayOutputStream = new PreallocByteArrayOutputStream(preallocatedBuf)
 }

--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/CommonParams.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/CommonParams.scala
@@ -2,7 +2,6 @@ package com.github.plokhotnyuk.jsoniter_scala.macros
 
 import java.util.concurrent.TimeUnit
 
-import com.dslplatform.json.JsonWriter
 import org.openjdk.jmh.annotations._
 
 @State(Scope.Thread)
@@ -23,6 +22,4 @@ import org.openjdk.jmh.annotations._
 @OutputTimeUnit(TimeUnit.SECONDS)
 abstract class CommonParams {
   val preallocatedBuf: Array[Byte] = new Array(32768)
-  val preallocatedOutputStream: PreallocByteArrayOutputStream = new PreallocByteArrayOutputStream(preallocatedBuf)
-  val preallocatedWriter: JsonWriter = DslPlatformJson.dslJson.newWriter(preallocatedBuf)
 }

--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/CommonParams.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/CommonParams.scala
@@ -2,6 +2,7 @@ package com.github.plokhotnyuk.jsoniter_scala.macros
 
 import java.util.concurrent.TimeUnit
 
+import com.dslplatform.json.JsonWriter
 import org.openjdk.jmh.annotations._
 
 @State(Scope.Thread)
@@ -23,4 +24,5 @@ import org.openjdk.jmh.annotations._
 abstract class CommonParams {
   val preallocatedBuf: Array[Byte] = new Array(32768)
   val preallocatedOutputStream: PreallocByteArrayOutputStream = new PreallocByteArrayOutputStream(preallocatedBuf)
+  val preallocatedWriter: JsonWriter = DslPlatformJson.dslJson.newWriter(preallocatedBuf)
 }

--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/DslPlatformJson.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/DslPlatformJson.scala
@@ -1,22 +1,37 @@
 package com.github.plokhotnyuk.jsoniter_scala.macros
 
-import com.dslplatform.json.DslJson
-import java.io.OutputStream
+import com.dslplatform.json._
+
+import scala.reflect.ClassTag
 
 object DslPlatformJson {
-  val dslJson = new DslJson[Any]
-}
+  private val dslJson = new DslJson[Any]
+  implicit val (encoderAnyRef, decoderAnyRef) = setupCodecs[AnyRefs]
+  implicit val (encoderDM, decoderDM) = setupCodecs[DistanceMatrix]
 
-class PreallocByteArrayOutputStream(private[this] val buf: Array[Byte]) extends OutputStream {
-  var count = 0
-
-  override def write(b: Int): Unit = {
-    buf(count) = b.toByte
-    count += 1
+  private val tlWriter = new ThreadLocal[JsonWriter] {
+    override def initialValue(): JsonWriter = dslJson.newWriter()
+  }
+  private val tlReader = new ThreadLocal[JsonReader[_]] {
+    override def initialValue(): JsonReader[_] = dslJson.newReader()
   }
 
-  override def write(b: Array[Byte], off: Int, len: Int): Unit = {
-    System.arraycopy(b, off, buf, count, len)
-    count += len
+  private def setupCodecs[T](implicit ct: ClassTag[T]): (JsonWriter.WriteObject[T], JsonReader.ReadObject[T]) = {
+    val encoder = dslJson.tryFindWriter(ct.runtimeClass).asInstanceOf[JsonWriter.WriteObject[T]]
+    val decoder = dslJson.tryFindReader(ct.runtimeClass).asInstanceOf[JsonReader.ReadObject[T]]
+    encoder -> decoder
+  }
+
+  def decodeDslJson[T](bytes: Array[Byte])(implicit decoder: JsonReader.ReadObject[T]): T = {
+    val reader = tlReader.get().process(bytes, bytes.length)
+    reader.read()
+    decoder.read(reader)
+  }
+
+  def encodeDslJson[T](obj: T)(implicit encoder: JsonWriter.WriteObject[T]): JsonWriter = {
+    val writer = tlWriter.get()
+    writer.reset()
+    encoder.write(writer, obj)
+    writer
   }
 }

--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/DslPlatformJson.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/DslPlatformJson.scala
@@ -1,0 +1,7 @@
+package com.github.plokhotnyuk.jsoniter_scala.macros
+
+import com.dslplatform.json.DslJson
+
+object DslPlatformJson {
+  val dslJson = new DslJson[Any]
+}

--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/DslPlatformJson.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/DslPlatformJson.scala
@@ -1,7 +1,22 @@
 package com.github.plokhotnyuk.jsoniter_scala.macros
 
 import com.dslplatform.json.DslJson
+import java.io.OutputStream
 
 object DslPlatformJson {
   val dslJson = new DslJson[Any]
+}
+
+class PreallocByteArrayOutputStream(private[this] val buf: Array[Byte]) extends OutputStream {
+  var count = 0
+
+  override def write(b: Int): Unit = {
+    buf(count) = b.toByte
+    count += 1
+  }
+
+  override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+    System.arraycopy(b, off, buf, count, len)
+    count += len
+  }
 }

--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmark.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmark.scala
@@ -46,6 +46,13 @@ class GoogleMapsAPIBenchmark extends CommonParams {
   }
 
   @Benchmark
+  def writeDslJsonScalaPrealloc(): Int = {
+    preallocatedOutputStream.count = 0
+    dslJson.encode(obj, preallocatedOutputStream)
+    preallocatedOutputStream.count
+  }
+
+  @Benchmark
   def writeJacksonScala(): Array[Byte] = jacksonMapper.writeValueAsBytes(obj)
 
   @Benchmark

--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmark.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmark.scala
@@ -1,9 +1,7 @@
 package com.github.plokhotnyuk.jsoniter_scala.macros
 
-import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets._
 
-import com.dslplatform.json._
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.github.plokhotnyuk.jsoniter_scala.macros.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.macros.DslPlatformJson._
@@ -24,7 +22,7 @@ class GoogleMapsAPIBenchmark extends CommonParams {
   def readCirce(): DistanceMatrix = decode[DistanceMatrix](new String(jsonBytes, UTF_8)).fold(throw _, x => x)
 
   @Benchmark
-  def readDslJsonScala(): DistanceMatrix = dslJson.decode[DistanceMatrix](jsonBytes)
+  def readDslJsonJava(): DistanceMatrix = decodeDslJson[DistanceMatrix](jsonBytes)
 
   @Benchmark
   def readJacksonScala(): DistanceMatrix = jacksonMapper.readValue[DistanceMatrix](jsonBytes)
@@ -39,18 +37,10 @@ class GoogleMapsAPIBenchmark extends CommonParams {
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)
 
   @Benchmark
-  def writeDslJsonScala(): Array[Byte] = {
-    val baos = new ByteArrayOutputStream
-    dslJson.encode(obj, baos)
-    baos.toByteArray
-  }
+  def writeDslJsonJava(): Array[Byte] = encodeDslJson[DistanceMatrix](obj).toByteArray
 
   @Benchmark
-  def writeDslJsonScalaPrealloc(): Int = {
-    preallocatedOutputStream.count = 0
-    dslJson.encode(obj, preallocatedOutputStream)
-    preallocatedOutputStream.count
-  }
+  def writeDslJsonJavaPrealloc(): com.dslplatform.json.JsonWriter = encodeDslJson[DistanceMatrix](obj)
 
   @Benchmark
   def writeJacksonScala(): Array[Byte] = jacksonMapper.writeValueAsBytes(obj)

--- a/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmark.scala
+++ b/benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmark.scala
@@ -1,9 +1,12 @@
 package com.github.plokhotnyuk.jsoniter_scala.macros
 
+import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets._
 
+import com.dslplatform.json._
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.github.plokhotnyuk.jsoniter_scala.macros.CirceEncodersDecoders._
+import com.github.plokhotnyuk.jsoniter_scala.macros.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.macros.GoogleMapsAPI._
 import com.github.plokhotnyuk.jsoniter_scala.macros.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsoniterCodecs._
@@ -21,6 +24,9 @@ class GoogleMapsAPIBenchmark extends CommonParams {
   def readCirce(): DistanceMatrix = decode[DistanceMatrix](new String(jsonBytes, UTF_8)).fold(throw _, x => x)
 
   @Benchmark
+  def readDslJsonScala(): DistanceMatrix = dslJson.decode[DistanceMatrix](jsonBytes)
+
+  @Benchmark
   def readJacksonScala(): DistanceMatrix = jacksonMapper.readValue[DistanceMatrix](jsonBytes)
 
   @Benchmark
@@ -31,6 +37,13 @@ class GoogleMapsAPIBenchmark extends CommonParams {
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)
+
+  @Benchmark
+  def writeDslJsonScala(): Array[Byte] = {
+    val baos = new ByteArrayOutputStream
+    dslJson.encode(obj, baos)
+    baos.toByteArray
+  }
 
   @Benchmark
   def writeJacksonScala(): Array[Byte] = jacksonMapper.writeValueAsBytes(obj)

--- a/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmarkSpec.scala
@@ -6,6 +6,7 @@ class AnyRefsBenchmarkSpec extends BenchmarkSpecBase {
   "AnyRefsBenchmark" should {
     "deserialize properly" in {
       benchmark.readCirce() shouldBe benchmark.obj
+      benchmark.readDslJsonJava() shouldBe benchmark.obj
       benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
       benchmark.readJsoniterScala() shouldBe benchmark.obj
@@ -13,6 +14,8 @@ class AnyRefsBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
+      toString(benchmark.writeDslJsonJava()) shouldBe benchmark.jsonString
+      toString(benchmark.preallocatedBuf, benchmark.writeDslJsonJavaPrealloc()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.preallocatedBuf, benchmark.writeDslJsonScalaPrealloc()) shouldBe benchmark.jsonString
       toString(benchmark.writeJsoniterScala()) shouldBe benchmark.jsonString

--- a/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmarkSpec.scala
@@ -6,13 +6,14 @@ class AnyRefsBenchmarkSpec extends BenchmarkSpecBase {
   "AnyRefsBenchmark" should {
     "deserialize properly" in {
       benchmark.readCirce() shouldBe benchmark.obj
+      benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
       benchmark.readJsoniterScala() shouldBe benchmark.obj
       benchmark.readPlayJson() shouldBe benchmark.obj
     }
     "serialize properly" in {
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
-      toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString
+      toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJsoniterScala()) shouldBe benchmark.jsonString
       toString(benchmark.preallocatedBuf, benchmark.writeJsoniterScalaPrealloc()) shouldBe benchmark.jsonString
       toString(benchmark.writePlayJson()) shouldBe benchmark.jsonString

--- a/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmarkSpec.scala
@@ -7,7 +7,6 @@ class AnyRefsBenchmarkSpec extends BenchmarkSpecBase {
     "deserialize properly" in {
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonJava() shouldBe benchmark.obj
-      benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
       benchmark.readJsoniterScala() shouldBe benchmark.obj
       benchmark.readPlayJson() shouldBe benchmark.obj
@@ -15,9 +14,8 @@ class AnyRefsBenchmarkSpec extends BenchmarkSpecBase {
     "serialize properly" in {
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonJava()) shouldBe benchmark.jsonString
-      toString(benchmark.preallocatedBuf, benchmark.writeDslJsonJavaPrealloc()) shouldBe benchmark.jsonString
-      toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
-      toString(benchmark.preallocatedBuf, benchmark.writeDslJsonScalaPrealloc()) shouldBe benchmark.jsonString
+      val writer = benchmark.writeDslJsonJavaPrealloc()
+      toString(writer.getByteBuffer, writer.size()) shouldBe benchmark.jsonString
       toString(benchmark.writeJsoniterScala()) shouldBe benchmark.jsonString
       toString(benchmark.preallocatedBuf, benchmark.writeJsoniterScalaPrealloc()) shouldBe benchmark.jsonString
       toString(benchmark.writePlayJson()) shouldBe benchmark.jsonString

--- a/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/AnyRefsBenchmarkSpec.scala
@@ -14,6 +14,7 @@ class AnyRefsBenchmarkSpec extends BenchmarkSpecBase {
     "serialize properly" in {
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
+      toString(benchmark.preallocatedBuf, benchmark.writeDslJsonScalaPrealloc()) shouldBe benchmark.jsonString
       toString(benchmark.writeJsoniterScala()) shouldBe benchmark.jsonString
       toString(benchmark.preallocatedBuf, benchmark.writeJsoniterScalaPrealloc()) shouldBe benchmark.jsonString
       toString(benchmark.writePlayJson()) shouldBe benchmark.jsonString

--- a/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmarkSpec.scala
@@ -6,12 +6,14 @@ class GoogleMapsAPIBenchmarkSpec extends BenchmarkSpecBase {
   "GoogleMapsAPIBenchmark" should {
     "deserialize properly" in {
       benchmark.readCirce() shouldBe benchmark.obj
+      benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
       benchmark.readJsoniterScala() shouldBe benchmark.obj
       benchmark.readPlayJson() shouldBe benchmark.obj
     }
     "serialize properly" in {
       toString(benchmark.writeCirce()) shouldBe GoogleMapsAPI.compactJsonString
+      toString(benchmark.writeDslJsonScala()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.writeJacksonScala()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.writeJsoniterScala()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.preallocatedBuf, benchmark.writeJsoniterScalaPrealloc()) shouldBe GoogleMapsAPI.compactJsonString

--- a/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmarkSpec.scala
@@ -6,15 +6,16 @@ class GoogleMapsAPIBenchmarkSpec extends BenchmarkSpecBase {
   "GoogleMapsAPIBenchmark" should {
     "deserialize properly" in {
       benchmark.readCirce() shouldBe benchmark.obj
-      benchmark.readDslJsonScala() shouldBe benchmark.obj
+      benchmark.readDslJsonJava() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
       benchmark.readJsoniterScala() shouldBe benchmark.obj
       benchmark.readPlayJson() shouldBe benchmark.obj
     }
     "serialize properly" in {
       toString(benchmark.writeCirce()) shouldBe GoogleMapsAPI.compactJsonString
-      toString(benchmark.writeDslJsonScala()) shouldBe GoogleMapsAPI.compactJsonString
-      toString(benchmark.preallocatedBuf, benchmark.writeDslJsonScalaPrealloc()) shouldBe GoogleMapsAPI.compactJsonString
+      toString(benchmark.writeDslJsonJava()) shouldBe GoogleMapsAPI.compactJsonString
+      val writer = benchmark.writeDslJsonJavaPrealloc()
+      toString(writer.getByteBuffer, writer.size()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.writeJacksonScala()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.writeJsoniterScala()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.preallocatedBuf, benchmark.writeJsoniterScalaPrealloc()) shouldBe GoogleMapsAPI.compactJsonString

--- a/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/GoogleMapsAPIBenchmarkSpec.scala
@@ -14,6 +14,7 @@ class GoogleMapsAPIBenchmarkSpec extends BenchmarkSpecBase {
     "serialize properly" in {
       toString(benchmark.writeCirce()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.writeDslJsonScala()) shouldBe GoogleMapsAPI.compactJsonString
+      toString(benchmark.preallocatedBuf, benchmark.writeDslJsonScalaPrealloc()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.writeJacksonScala()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.writeJsoniterScala()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.preallocatedBuf, benchmark.writeJsoniterScalaPrealloc()) shouldBe GoogleMapsAPI.compactJsonString

--- a/build.sbt
+++ b/build.sbt
@@ -123,6 +123,7 @@ lazy val benchmark = project
   .settings(
     crossScalaVersions := Seq("2.12.5", "2.11.12"),
     libraryDependencies ++= Seq(
+      "com.dslplatform" %% "dsl-json-scala" % "1.7.1",
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.4",
       "com.fasterxml.jackson.module" % "jackson-module-afterburner" % "2.9.4",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.9.4",


### PR DESCRIPTION
Results from my notebook (Intel® Core™ i7-7700HQ CPU @ 2.8GHz (max 3.8GHz), RAM 16Gb DDR4-2400, Ubuntu 16.04, Linux notebook 4.13.0-32-generic, Oracle JDK 64-bit builds 1.8.0_161-b12): 
```
[info] Benchmark                                     Mode  Cnt         Score         Error  Units
[info] AnyRefsBenchmark.readCirce                   thrpt    5   1656302.172 ±  101073.908  ops/s
[info] AnyRefsBenchmark.readDslJsonJava             thrpt    5   9603513.592 ± 1478031.812  ops/s
[info] AnyRefsBenchmark.readJacksonScala            thrpt    5   2494703.128 ±  148352.637  ops/s
[info] AnyRefsBenchmark.readJsoniterScala           thrpt    5   9842344.345 ±  391884.902  ops/s
[info] AnyRefsBenchmark.readPlayJson                thrpt    5    621175.896 ±   50391.858  ops/s
[info] AnyRefsBenchmark.writeCirce                  thrpt    5   2016789.498 ±  201426.559  ops/s
[info] AnyRefsBenchmark.writeDslJsonJava            thrpt    5  18950616.383 ± 2044511.333  ops/s
[info] AnyRefsBenchmark.writeDslJsonJavaPrealloc    thrpt    5  20280086.333 ±  143141.722  ops/s
[info] AnyRefsBenchmark.writeJacksonScala           thrpt    5   6097592.491 ±  203816.741  ops/s
[info] AnyRefsBenchmark.writeJsoniterScala          thrpt    5  27384240.926 ±  657494.558  ops/s
[info] AnyRefsBenchmark.writeJsoniterScalaPrealloc  thrpt    5  27825415.764 ±  444248.689  ops/s
[info] AnyRefsBenchmark.writePlayJson               thrpt    5   1078746.173 ±   27447.825  ops/s
```