### PR TITLE
Add optimization for 64-bit division by constant to mitigate a performance regression on JDK 11 + Graal and GraalVM CE

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,12 @@ sbt clean 'jsoniter-scala-benchmark/jmh:run -prof perfasm -wi 10 -i 10 .*Adt.*re
 
 More info about extras, options and ability to generate flame graphs see in [Sbt-JMH docs](https://github.com/ktoso/sbt-jmh)
 
+Other benchmarks with results for jsoniter-scala:
+- [comparison with best binary parsers and serializer for Scala](https://github.com/dkomanov/scala-serialization/pull/8)
+- [comparison with the state of art filter that during "building structural indices converts control flow into data
+   flow, thereby largely eliminating inherently unpredictable branches in the program and exploiting the parallelism
+   available in modern processors"](https://github.com/guillaumebort/mison/pull/1)
+
 ### Publish locally
 
 Publish to local Ivy repo:
@@ -300,12 +306,6 @@ Publish to local Maven repo:
 ```sh
 sbt publishM2
 ```
-
-Other benchmarks with results for jsoniter-scala:
-- [comparison with best binary parsers and serializer for Scala](https://github.com/dkomanov/scala-serialization/pull/8)
-- [comparison with the state of art filter that during "building structural indices converts control flow into data
-   flow, thereby largely eliminating inherently unpredictable branches in the program and exploiting the parallelism
-   available in modern processors"](https://github.com/guillaumebort/mison/pull/1)
 
 ### Release
 

--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1602,7 +1602,7 @@ final class JsonWriter private[jsoniter_scala](
         write8Digits(r1, write8Digits(r2, pos - 15, buf, ds), buf, ds)
       }
     }
-
+  // FIXME: remove all these div* after fix of the performance regression in GraalVM CE, check: https://github.com/oracle/graal/issues/593
   private[this] def div5(x: Long): Long = { // divide positive long by 5
     val l = (x & 0xFFFFFFFFL) * 3435973836L
     val h = (x >>> 32) * 3435973836L

--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1609,11 +1609,13 @@ final class JsonWriter private[jsoniter_scala](
     ((x + l >>> 32) + l + h >>> 32) + h >> 2
   }
 
-  private[this] def div10(x: Long): Long = { // divide positive long by 10
-    val l = (x & 0xFFFFFFFFL) * 3435973836L
-    val h = (x >>> 32) * 3435973836L
-    ((x + l >>> 32) + l + h >>> 32) + h >> 3
-  }
+  private[this] def div10(x: Long): Long =
+    if (x.toInt == x) x * 3435973837L >> 35 // divide positive int by 10
+    else { // divide positive long by 10
+      val l = (x & 0xFFFFFFFFL) * 3435973836L
+      val h = (x >>> 32) * 3435973836L
+      ((x + l >>> 32) + l + h >>> 32) + h >> 3
+    }
 
   private[this] def div100000000(x: Long): Long = { // divide positive long by 100000000
     val xLow = x & 0xFFFFFFFFL

--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1603,22 +1603,22 @@ final class JsonWriter private[jsoniter_scala](
       }
     }
 
-  private[this] def div5(x: Long): Long = {
+  private[this] def div5(x: Long): Long = { // divide positive long by 5
     val l = (x & 0xFFFFFFFFL) * 3435973836L
     val h = (x >>> 32) * 3435973836L
-    (((x + l >>> 32) + l + h) >>> 32) + h >> 2
+    ((x + l >>> 32) + l + h >>> 32) + h >> 2
   }
 
-  private[this] def div10(x: Long): Long = {
+  private[this] def div10(x: Long): Long = { // divide positive long by 10
     val l = (x & 0xFFFFFFFFL) * 3435973836L
     val h = (x >>> 32) * 3435973836L
-    (((x + l >>> 32) + l + h) >>> 32) + h >> 3
+    ((x + l >>> 32) + l + h >>> 32) + h >> 3
   }
 
-  private[this] def div100000000(x: Long): Long = {
+  private[this] def div100000000(x: Long): Long = { // divide positive long by 100000000
     val xLow = x & 0xFFFFFFFFL
     val xHigh = x >>> 32
-    (((xLow * 2221002493L >>> 32) + xLow * 2882303761L + xHigh * 2221002493L) >>> 32) + xHigh * 2882303761L >> 26
+    ((xLow * 2221002493L >>> 32) + xLow * 2882303761L + xHigh * 2221002493L >>> 32) + xHigh * 2882303761L >> 26
   }
 
   private[this] def multiplePowOf2(q0: Int, q: Int): Boolean = (q0 & ((1 << q) - 1)) == 0

--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1614,8 +1614,7 @@ final class JsonWriter private[jsoniter_scala](
     val xHigh = x >>> 32
     val yLow = y & 0xFFFFFFFFL
     val yHigh = y >>> 32
-    val mid = xHigh * yLow + ((xLow * yLow) >>> 32)
-    xHigh * yHigh + (mid >>> 32) + ((xLow * yHigh + (mid & 0xFFFFFFFFL)) >>> 32)
+    xHigh * yHigh + ((xHigh * yLow + xLow * yHigh + ((xLow * yLow) >>> 32)) >>> 32)
   }
 
   private[this] def multiplePowOf2(q0: Int, q: Int): Boolean = (q0 & ((1 << q) - 1)) == 0

--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1618,7 +1618,7 @@ final class JsonWriter private[jsoniter_scala](
   private[this] def div100000000(x: Long): Long = { // divide positive long by 100000000
     val xLow = x & 0xFFFFFFFFL
     val xHigh = x >>> 32
-    ((xLow * 2221002493L >>> 32) + xLow * 2882303761L + xHigh * 2221002493L >>> 32) + xHigh * 2882303761L >> 26
+    (xLow * 2882303763L + xHigh * 2221002493L >>> 32) + xHigh * 2882303761L >> 26
   }
 
   private[this] def multiplePowOf2(q0: Int, q: Int): Boolean = (q0 & ((1 << q) - 1)) == 0

--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1566,8 +1566,8 @@ final class JsonWriter private[jsoniter_scala](
     }
 
   private def fullMulPow5DivPow2(m: Long, i: Int, j: Int, ss: Array[Int]): Long = {
+    val mLow = m & 0x7FFFFFFF
     val mHigh = m >>> 31
-    val mLow = m & 0x7fffffff
     val idx = i << 2
     val s3 = ss(idx + 3)
     val s2 = ss(idx + 2)
@@ -1603,18 +1603,22 @@ final class JsonWriter private[jsoniter_scala](
       }
     }
 
-  private[this] def div5(x: Long): Long = umulh(x, -3689348814741910323L) >> 2
+  private[this] def div5(x: Long): Long = {
+    val l = (x & 0xFFFFFFFFL) * 3435973836L
+    val h = (x >>> 32) * 3435973836L
+    (((x + l >>> 32) + l + h) >>> 32) + h >> 2
+  }
 
-  private[this] def div10(x: Long): Long = umulh(x, -3689348814741910323L) >> 3
+  private[this] def div10(x: Long): Long = {
+    val l = (x & 0xFFFFFFFFL) * 3435973836L
+    val h = (x >>> 32) * 3435973836L
+    (((x + l >>> 32) + l + h) >>> 32) + h >> 3
+  }
 
-  private[this] def div100000000(x: Long): Long = umulh(x, -6067343680855748867L) >> 26
-
-  private[this] def umulh(x: Long, y: Long): Long = {
+  private[this] def div100000000(x: Long): Long = {
     val xLow = x & 0xFFFFFFFFL
     val xHigh = x >>> 32
-    val yLow = y & 0xFFFFFFFFL
-    val yHigh = y >>> 32
-    xHigh * yHigh + ((xHigh * yLow + xLow * yHigh + ((xLow * yLow) >>> 32)) >>> 32)
+    (((xLow * 2221002493L >>> 32) + xLow * 2882303761L + xHigh * 2221002493L) >>> 32) + xHigh * 2882303761L >> 26
   }
 
   private[this] def multiplePowOf2(q0: Int, q: Int): Boolean = (q0 & ((1 << q) - 1)) == 0

--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1618,7 +1618,7 @@ final class JsonWriter private[jsoniter_scala](
   private[this] def div100000000(x: Long): Long = { // divide positive long by 100000000
     val xLow = x & 0xFFFFFFFFL
     val xHigh = x >>> 32
-    (xLow * 2882303763L + xHigh * 2221002493L >>> 32) + xHigh * 2882303761L >> 26
+    (xLow * 2882303762L + xHigh * 2221002493L >>> 32) + xHigh * 2882303761L >> 26
   }
 
   private[this] def multiplePowOf2(q0: Int, q: Int): Boolean = (q0 & ((1 << q) - 1)) == 0

--- a/jsoniter-scala-core/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriterSpec.scala
+++ b/jsoniter-scala-core/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriterSpec.scala
@@ -535,6 +535,9 @@ class JsonWriterSpec extends WordSpec with Matchers with PropertyChecks {
       check(3.3554432E7f)
       //(1 to Int.MaxValue).par.foreach { n =>
       forAll(minSuccessful(100000)) { (n: Int) =>
+        check(n * Math.pow(10, n & 15).toFloat)
+      }
+      forAll(minSuccessful(100000)) { (n: Int) =>
         val x = java.lang.Float.floatToRawIntBits(n)
         if (java.lang.Float.isFinite(x)) check(x)
       }
@@ -600,6 +603,9 @@ class JsonWriterSpec extends WordSpec with Matchers with PropertyChecks {
       check(1.9430376160308388E16)
       check(-6.9741824662760956E19)
       check(4.3816050601147837E18)
+      forAll(minSuccessful(100000)) { (n: Int) =>
+        check(n * Math.pow(10, n & 31))
+      }
       forAll(minSuccessful(100000)) { (n: Long) =>
         val x = java.lang.Float.floatToRawIntBits(n)
         if (java.lang.Double.isFinite(x)) check(x)


### PR DESCRIPTION
All results below are from my notebook with `Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz`.

Before (JDK 11 + Graal):
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                                                 (size)   Mode  Cnt       Score       Error  Units
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc                           128  thrpt   15   30526.832 ±   210.604  ops/s
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:CPI                       128  thrpt    3       1.074 ±     0.087   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-dcache-load-misses     128  thrpt    3      39.494 ±   435.788   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-dcache-loads           128  thrpt    3   12719.136 ±  3488.017   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-dcache-stores          128  thrpt    3    7202.283 ±  2280.565   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-icache-load-misses     128  thrpt    3      10.373 ±   178.087   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-load-misses           128  thrpt    3       1.059 ±     9.950   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-loads                 128  thrpt    3       1.699 ±     6.465   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-store-misses          128  thrpt    3       0.292 ±     2.170   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-stores                128  thrpt    3       1.761 ±    19.873   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:branch-misses             128  thrpt    3       9.798 ±   112.458   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:branches                  128  thrpt    3   11555.182 ±  2675.133   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:cycles                    128  thrpt    3  120053.126 ±  7863.268   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-load-misses          128  thrpt    3       0.579 ±     5.511   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-loads                128  thrpt    3   12896.567 ±  5218.657   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-store-misses         128  thrpt    3       0.115 ±     1.221   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-stores               128  thrpt    3    7217.091 ±  2210.582   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:iTLB-load-misses          128  thrpt    3       0.176 ±     2.641   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:iTLB-loads                128  thrpt    3       1.412 ±    10.239   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:instructions              128  thrpt    3  111831.033 ± 13426.670   #/op
```

After (JDK 11 + Graal):
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                                                 (size)   Mode  Cnt       Score       Error  Units
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc                           128  thrpt   15   96488.312 ±   466.794  ops/s
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:CPI                       128  thrpt    3       0.254 ±     0.010   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-dcache-load-misses     128  thrpt    3      12.468 ±    53.936   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-dcache-loads           128  thrpt    3   16989.139 ±  1600.469   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-dcache-stores          128  thrpt    3    8260.509 ±  1244.937   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-icache-load-misses     128  thrpt    3       4.110 ±    32.130   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-load-misses           128  thrpt    3       0.277 ±     2.232   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-loads                 128  thrpt    3       0.785 ±    11.332   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-store-misses          128  thrpt    3       0.165 ±     1.685   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-stores                128  thrpt    3       0.672 ±     9.131   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:branch-misses             128  thrpt    3       5.793 ±    12.683   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:branches                  128  thrpt    3   15916.359 ±  1243.397   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:cycles                    128  thrpt    3   39104.927 ±  4420.023   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-load-misses          128  thrpt    3       0.169 ±     1.286   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-loads                128  thrpt    3   16997.787 ±  2919.664   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-store-misses         128  thrpt    3       0.016 ±     0.184   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-stores               128  thrpt    3    8249.974 ±   808.598   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:iTLB-load-misses          128  thrpt    3       0.110 ±     1.910   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:iTLB-loads                128  thrpt    3       0.644 ±    11.866   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:instructions              128  thrpt    3  154196.449 ± 11542.197   #/op
```

But it affects performance with JDK 8 on CPUs that emit imul instructions instead of idiv.

Before (JDK 8):
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                                                 (size)   Mode  Cnt       Score      Error  Units
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc                           128  thrpt   15   95928.102 ± 1295.170  ops/s
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:CPI                       128  thrpt    3       0.274 ±    0.018   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-dcache-load-misses     128  thrpt    3      10.593 ±   26.678   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-dcache-loads           128  thrpt    3   23837.756 ± 1561.156   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-dcache-stores          128  thrpt    3   13858.306 ± 2843.324   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-icache-load-misses     128  thrpt    3       3.064 ±   14.063   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-load-misses           128  thrpt    3       0.326 ±    1.617   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-loads                 128  thrpt    3       0.496 ±    3.435   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-store-misses          128  thrpt    3       0.204 ±    1.080   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-stores                128  thrpt    3       1.052 ±    3.690   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:branch-misses             128  thrpt    3       3.897 ±   13.466   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:branches                  128  thrpt    3   11007.718 ±  935.951   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:cycles                    128  thrpt    3   38364.235 ± 4085.152   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-load-misses          128  thrpt    3       0.092 ±    0.468   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-loads                128  thrpt    3   23903.832 ± 2845.992   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-store-misses         128  thrpt    3       0.004 ±    0.077   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-stores               128  thrpt    3   13911.953 ± 2598.601   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:iTLB-load-misses          128  thrpt    3       0.073 ±    0.300   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:iTLB-loads                128  thrpt    3       0.452 ±    5.196   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:instructions              128  thrpt    3  139883.830 ± 6673.647   #/op
```
After (JDK 8)

```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                                                 (size)   Mode  Cnt       Score       Error  Units
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc                           128  thrpt   15   85654.892 ±   599.488  ops/s
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:CPI                       128  thrpt    3       0.254 ±     0.062   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-dcache-load-misses     128  thrpt    3      11.725 ±    80.953   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-dcache-loads           128  thrpt    3   27244.816 ± 13685.550   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-dcache-stores          128  thrpt    3   14026.983 ±  6192.129   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:L1-icache-load-misses     128  thrpt    3      11.632 ±   131.726   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-load-misses           128  thrpt    3       0.793 ±     3.700   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-loads                 128  thrpt    3       2.687 ±     7.064   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-store-misses          128  thrpt    3       0.181 ±     1.697   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:LLC-stores                128  thrpt    3       0.340 ±     2.847   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:branch-misses             128  thrpt    3      13.146 ±    51.327   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:branches                  128  thrpt    3   15276.327 ±  8058.635   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:cycles                    128  thrpt    3   44214.528 ±  9167.485   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-load-misses          128  thrpt    3       0.058 ±     0.732   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-loads                128  thrpt    3   27104.819 ± 14599.201   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-store-misses         128  thrpt    3       0.011 ±     0.058   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:dTLB-stores               128  thrpt    3   13983.818 ±  4944.400   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:iTLB-load-misses          128  thrpt    3       0.060 ±     0.128   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:iTLB-loads                128  thrpt    3       0.171 ±     0.861   #/op
[info] ArrayOfDoublesBenchmark.writeJsoniterScalaPrealloc:instructions              128  thrpt    3  174027.252 ± 63988.411   #/op
```