### PR TITLE
Add benchmarks for enumeratum enums

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,6 +118,9 @@ lazy val `jsoniter-scala-benchmark` = project
   .settings(
     crossScalaVersions := Seq("2.12.6"),
     libraryDependencies ++= Seq(
+      "com.beachape" %% "enumeratum" % "1.5.13",
+      "com.beachape" %% "enumeratum-circe" % "1.5.13",
+      "com.beachape" %% "enumeratum-play-json" % "1.5.13",
       "com.avsystem.commons" %% "commons-core" % "1.30.0",
       "com.lihaoyi" %% "upickle" % "0.6.6",
       "com.dslplatform" %% "dsl-json-scala" % "1.8.0",

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/ArrayOfEnumeratumADTsBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/ArrayOfEnumeratumADTsBenchmark.scala
@@ -1,0 +1,99 @@
+package com.github.plokhotnyuk.jsoniter_scala.macros
+
+import java.nio.charset.StandardCharsets._
+
+//import com.avsystem.commons.serialization.json._
+import com.github.plokhotnyuk.jsoniter_scala.core._
+//import com.github.plokhotnyuk.jsoniter_scala.macros.AVSystemCodecs._
+import com.github.plokhotnyuk.jsoniter_scala.macros.CirceEncodersDecoders._
+//import com.github.plokhotnyuk.jsoniter_scala.macros.JacksonSerDesers._
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsoniterCodecs._
+//import com.github.plokhotnyuk.jsoniter_scala.macros.PlayJsonFormats._
+//import com.github.plokhotnyuk.jsoniter_scala.macros.UPickleReaderWriters._
+import io.circe.parser._
+import io.circe.syntax._
+import org.openjdk.jmh.annotations.{Benchmark, Param, Setup}
+import play.api.libs.json.Json
+//import upickle.default._
+import enumeratum._
+
+import scala.collection.immutable
+
+sealed trait EnumeratumSuit extends EnumEntry
+
+object EnumeratumSuit extends Enum[EnumeratumSuit] with CirceEnum[EnumeratumSuit] with PlayJsonEnum[EnumeratumSuit] {
+  val values: immutable.IndexedSeq[EnumeratumSuit] = findValues
+
+  case object Hearts extends EnumeratumSuit
+
+  case object Spades extends EnumeratumSuit
+
+  case object Diamonds extends EnumeratumSuit
+
+  case object Clubs extends EnumeratumSuit
+}
+
+class ArrayOfEnumeratumADTsBenchmark extends CommonParams {
+  @Param(Array("1", "10", "100", "1000", "10000", "100000", "1000000"))
+  var size: Int = 10
+  var obj: Array[EnumeratumSuit] = _
+  var jsonString: String = _
+  var jsonBytes: Array[Byte] = _
+  var preallocatedOff: Int = 128
+  var preallocatedBuf: Array[Byte] = _
+
+  @Setup
+  def setup(): Unit = {
+    obj = (1 to size).map(i => (i * 1498724053) & 3 match {
+      case 0 => EnumeratumSuit.Hearts
+      case 1 => EnumeratumSuit.Spades
+      case 2 => EnumeratumSuit.Diamonds
+      case 3 => EnumeratumSuit.Clubs
+    }).toArray
+    jsonString = obj.mkString("[\"", "\",\"", "\"]")
+    jsonBytes = jsonString.getBytes(UTF_8)
+    preallocatedBuf = new Array[Byte](jsonBytes.length + preallocatedOff + 100/*to avoid possible out of bounds error*/)
+  }
+/* FIXME: AVSystem GenCodec hasn't integration with enumeratum
+  @Benchmark
+  def readAVSystemGenCodec(): Array[EnumeratumSuit] = JsonStringInput.read[Array[EnumeratumSuit]](new String(jsonBytes, UTF_8))
+*/
+  @Benchmark
+  def readCirce(): Array[EnumeratumSuit] = decode[Array[EnumeratumSuit]](new String(jsonBytes, UTF_8)).fold(throw _, x => x)
+/* FIXME: Jackson-module-scala hasn't integration with enumeratum
+  @Benchmark
+  def readJacksonScala(): Array[EnumeratumSuit] = jacksonMapper.readValue[Array[EnumeratumSuit]](jsonBytes)
+*/
+  @Benchmark
+  def readJsoniterScala(): Array[EnumeratumSuit] = readFromArray[Array[EnumeratumSuit]](jsonBytes)
+
+  @Benchmark
+  def readPlayJson(): Array[EnumeratumSuit] = Json.parse(jsonBytes).as[Array[EnumeratumSuit]]
+
+/* FIXME: the latest version of UPickle hasn't integration with enumeratum
+  @Benchmark
+  def readUPickle(): Array[EnumeratumSuit] = read[Array[EnumeratumSuit]](jsonBytes)
+*/
+/* FIXME: AVSystem GenCodec hasn't integration with enumeratum
+  @Benchmark
+  def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+*/
+  @Benchmark
+  def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)
+/* FIXME: Jackson-module-scala hasn't integration with enumeratum
+  @Benchmark
+  def writeJacksonScala(): Array[Byte] = jacksonMapper.writeValueAsBytes(obj)
+*/
+  @Benchmark
+  def writeJsoniterScala(): Array[Byte] = writeToArray(obj)
+
+  @Benchmark
+  def writeJsoniterScalaPrealloc(): Int = writeToPreallocatedArray(obj, preallocatedBuf, preallocatedOff)
+
+  @Benchmark
+  def writePlayJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+/* FIXME: the latest version of UPickle hasn't integration with enumeratum
+  @Benchmark
+  def writeUPickle(): Array[Byte] = write(obj).getBytes(UTF_8)
+*/
+}

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/JsoniterCodecs.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/JsoniterCodecs.scala
@@ -32,6 +32,7 @@ object JsoniterCodecs {
   implicit val durationArrayCodec: JsonValueCodec[Array[Duration]] = make(CodecMakerConfig())
   implicit val enumArrayCodec: JsonValueCodec[Array[SuitEnum]] = make(CodecMakerConfig())
   implicit val enumADTArrayCodec: JsonValueCodec[Array[SuitADT]] = make(CodecMakerConfig(discriminatorFieldName = None))
+  implicit val enumeratumADTArrayCodec: JsonValueCodec[Array[EnumeratumSuit]] = make(CodecMakerConfig(discriminatorFieldName = None))
   implicit val floatArrayCodec: JsonValueCodec[Array[Float]] = make(CodecMakerConfig())
   implicit val instantArrayCodec: JsonValueCodec[Array[Instant]] = make(CodecMakerConfig())
   implicit val intArrayCodec: JsonValueCodec[Array[Int]] = make(CodecMakerConfig())

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/ArrayOfEnumADTsBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/ArrayOfEnumADTsBenchmarkSpec.scala
@@ -5,7 +5,7 @@ class ArrayOfEnumADTsBenchmarkSpec extends BenchmarkSpecBase {
     setup()
   }
   
-  "ArrayOfEnumsBenchmark" should {
+  "ArrayOfEnumADTsBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
       benchmark.readCirce() shouldBe benchmark.obj

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/ArrayOfEnumeratumADTsBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/ArrayOfEnumeratumADTsBenchmarkSpec.scala
@@ -1,0 +1,33 @@
+package com.github.plokhotnyuk.jsoniter_scala.macros
+
+class ArrayOfEnumeratumADTsBenchmarkSpec extends BenchmarkSpecBase {
+  private val benchmark = new ArrayOfEnumeratumADTsBenchmark {
+    setup()
+  }
+  
+  "ArrayOfEnumeratumADTsBenchmark" should {
+    "deserialize properly" in {
+      //FIXME: AVSystem GenCodec hasn't integration with enumeratum
+      //benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
+      benchmark.readCirce() shouldBe benchmark.obj
+      //FIXME: Jackson-module-scala hasn't integration with enumeratum
+      //benchmark.readJacksonScala() shouldBe benchmark.obj
+      benchmark.readJsoniterScala() shouldBe benchmark.obj
+      benchmark.readPlayJson() shouldBe benchmark.obj
+      //FIXME: the latest version of UPickle hasn't integration with enumeratum
+      //benchmark.readUPickle() shouldBe benchmark.obj
+    }
+    "serialize properly" in {
+      //FIXME: AVSystem GenCodec hasn't integration with enumeratum
+      //toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
+      //FIXME: Jackson-module-scala hasn't integration with enumeratum
+      //toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString
+      toString(benchmark.writeJsoniterScala()) shouldBe benchmark.jsonString
+      toString(benchmark.preallocatedBuf, benchmark.preallocatedOff, benchmark.writeJsoniterScalaPrealloc()) shouldBe benchmark.jsonString
+      toString(benchmark.writePlayJson()) shouldBe benchmark.jsonString
+      //FIXME: the latest version of UPickle hasn't integration with enumeratum
+      //toString(benchmark.writeUPickle()) shouldBe benchmark.jsonString
+    }
+  }
+}


### PR DESCRIPTION
Results on my notebook:
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                                  (size)   Mode  Cnt        Score       Error  Units
[info] ArrayOfEnumeratumADTsBenchmark.readCirce                      128  thrpt    5    70160.024 ±  2600.274  ops/s
[info] ArrayOfEnumeratumADTsBenchmark.readJsoniterScala              128  thrpt    5   386560.693 ± 24150.781  ops/s
[info] ArrayOfEnumeratumADTsBenchmark.readPlayJson                   128  thrpt    5    71450.235 ±  4748.745  ops/s
[info] ArrayOfEnumeratumADTsBenchmark.writeCirce                     128  thrpt    5    31986.244 ±   323.127  ops/s
[info] ArrayOfEnumeratumADTsBenchmark.writeJsoniterScala             128  thrpt    5  1964112.081 ± 61708.733  ops/s
[info] ArrayOfEnumeratumADTsBenchmark.writeJsoniterScalaPrealloc     128  thrpt    5  2125000.430 ± 10822.709  ops/s
[info] ArrayOfEnumeratumADTsBenchmark.writePlayJson                  128  thrpt    5   212672.311 ±  6918.046  ops/s
```