### PR TITLE
Add Borer JSON

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,8 @@ lazy val `jsoniter-scala-benchmark` = project
   .settings(noPublishSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
+      "io.bullet" %% "borer-core" % "0.8.0",
+      "io.bullet" %% "borer-derivation" % "0.8.0",
       "pl.iterators" %% "kebs-spray-json" % "1.6.2",
       "io.spray" %%  "spray-json" % "1.3.5",
       "com.avsystem.commons" %% "commons-core" % "1.34.16",

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansBenchmark.scala
@@ -39,6 +39,10 @@ class ArrayBufferOfBooleansBenchmark extends CommonParams {
     JsonStringInput.read[mutable.ArrayBuffer[Boolean]](new String(jsonBytes, UTF_8))
 
   @Benchmark
+  def readBorerJson(): mutable.ArrayBuffer[Boolean] =
+    io.bullet.borer.Json.decode(jsonBytes).to[mutable.ArrayBuffer[Boolean]].value
+
+  @Benchmark
   def readCirce(): mutable.ArrayBuffer[Boolean] =
     decode[mutable.ArrayBuffer[Boolean]](new String(jsonBytes, UTF_8)).fold(throw _, identity)
 
@@ -62,6 +66,9 @@ class ArrayBufferOfBooleansBenchmark extends CommonParams {
 
   @Benchmark
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsBenchmark.scala
@@ -61,6 +61,9 @@ class ArrayOfBigIntsBenchmark extends CommonParams {
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
 
   @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
+
+  @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)
 
   @Benchmark

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansBenchmark.scala
@@ -38,6 +38,9 @@ class ArrayOfBooleansBenchmark extends CommonParams {
   def readAVSystemGenCodec(): Array[Boolean] = JsonStringInput.read[Array[Boolean]](new String(jsonBytes, UTF_8))
 
   @Benchmark
+  def readBorerJson(): Array[Boolean] = io.bullet.borer.Json.decode(jsonBytes).to[Array[Boolean]].value
+
+  @Benchmark
   def readCirce(): Array[Boolean] = decode[Array[Boolean]](new String(jsonBytes, UTF_8)).fold(throw _, identity)
 
   @Benchmark
@@ -63,6 +66,9 @@ class ArrayOfBooleansBenchmark extends CommonParams {
 
   @Benchmark
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesBenchmark.scala
@@ -66,6 +66,9 @@ class ArrayOfDoublesBenchmark extends CommonParams {
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
 
   @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
+
+  @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)
 
 /*FIXME: dsl-json serializes doubles in a plain representation

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsBenchmark.scala
@@ -38,6 +38,9 @@ class ArrayOfIntsBenchmark extends CommonParams {
   def readAVSystemGenCodec(): Array[Int] = JsonStringInput.read[Array[Int]](new String(jsonBytes, UTF_8))
 
   @Benchmark
+  def readBorerJson(): Array[Int] = io.bullet.borer.Json.decode(jsonBytes).to[Array[Int]].value
+
+  @Benchmark
   def readCirce(): Array[Int] = decode[Array[Int]](new String(jsonBytes, UTF_8)).fold(throw _, identity)
 
   @Benchmark
@@ -63,6 +66,9 @@ class ArrayOfIntsBenchmark extends CommonParams {
 
   @Benchmark
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsBenchmark.scala
@@ -65,6 +65,9 @@ class ArrayOfLongsBenchmark extends CommonParams {
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
 
   @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
+
+  @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)
 
   @Benchmark

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsBenchmark.scala
@@ -38,6 +38,9 @@ class ArrayOfShortsBenchmark extends CommonParams {
   def readAVSystemGenCodec(): Array[Short] = JsonStringInput.read[Array[Short]](new String(jsonBytes, UTF_8))
 
   @Benchmark
+  def readBorerJson(): Array[Short] = io.bullet.borer.Json.decode(jsonBytes).to[Array[Short]].value
+
+  @Benchmark
   def readCirce(): Array[Short] = decode[Array[Short]](new String(jsonBytes, UTF_8)).fold(throw _, identity)
 
   @Benchmark
@@ -63,6 +66,9 @@ class ArrayOfShortsBenchmark extends CommonParams {
 
   @Benchmark
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalBenchmark.scala
@@ -43,6 +43,9 @@ class BigDecimalBenchmark extends CommonParams {
   def readAVSystemGenCodec(): BigDecimal = JsonStringInput.read[BigDecimal](new String(jsonBytes, UTF_8), jsonOptions)
 
   @Benchmark
+  def readBorerJson(): BigDecimal = io.bullet.borer.Json.decode(jsonBytes).to[BigDecimal].value
+
+  @Benchmark
   def readCirce(): BigDecimal = decode[BigDecimal](new String(jsonBytes, UTF_8)).fold(throw _, identity)
 
   @Benchmark
@@ -65,6 +68,9 @@ class BigDecimalBenchmark extends CommonParams {
 
   @Benchmark
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntBenchmark.scala
@@ -36,6 +36,9 @@ class BigIntBenchmark extends CommonParams {
   def readAVSystemGenCodec(): BigInt = JsonStringInput.read[BigInt](new String(jsonBytes, UTF_8))
 
   @Benchmark
+  def readBorerJson(): BigInt = io.bullet.borer.Json.decode(jsonBytes).to[BigInt].value
+
+  @Benchmark
   def readCirce(): BigInt = decode[BigInt](new String(jsonBytes, UTF_8)).fold(throw _, identity)
 
   @Benchmark
@@ -58,6 +61,9 @@ class BigIntBenchmark extends CommonParams {
 
   @Benchmark
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BorerJsonEncodersDecoders.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BorerJsonEncodersDecoders.scala
@@ -1,0 +1,13 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import io.bullet.borer.{Codec, Decoder, Encoder}
+import io.bullet.borer.derivation.MapBasedCodecs._
+
+object BorerJsonEncodersDecoders {
+  implicit val Codec(googleMapsAPIEnc: Encoder[DistanceMatrix], googleMapsAPIDec: Decoder[DistanceMatrix]) = {
+    implicit val c1: Codec[Value] = deriveCodec[Value]
+    implicit val c2: Codec[Elements] = deriveCodec[Elements]
+    implicit val c3: Codec[Rows] = deriveCodec[Rows]
+    deriveCodec[DistanceMatrix]
+  }
+}

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIBenchmark.scala
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 import com.avsystem.commons.serialization.json._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
+import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.GoogleMapsAPI._
@@ -31,6 +32,9 @@ class GoogleMapsAPIBenchmark extends CommonParams {
   def readCirce(): DistanceMatrix = decode[DistanceMatrix](new String(jsonBytes1, UTF_8)).fold(throw _, identity)
 
   @Benchmark
+  def readBorerJson(): DistanceMatrix = io.bullet.borer.Json.decode(jsonBytes1).to[DistanceMatrix].value
+
+  @Benchmark
   def readDslJsonScala(): DistanceMatrix = dslJsonDecode[DistanceMatrix](jsonBytes1)
 
   @Benchmark
@@ -50,6 +54,9 @@ class GoogleMapsAPIBenchmark extends CommonParams {
 
   @Benchmark
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntBenchmark.scala
@@ -28,6 +28,9 @@ class IntBenchmark extends CommonParams {
   def readAVSystemGenCodec(): Int = JsonStringInput.read[Int](new String(jsonBytes, UTF_8))
 
   @Benchmark
+  def readBorerJson(): Int = io.bullet.borer.Json.decode(jsonBytes).to[Int].value
+
+  @Benchmark
   def readCirce(): Int = decode[Int](new String(jsonBytes, UTF_8)).fold(throw _, identity)
 
   @Benchmark
@@ -53,6 +56,9 @@ class IntBenchmark extends CommonParams {
 
   @Benchmark
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansBenchmark.scala
@@ -36,6 +36,9 @@ class ListOfBooleansBenchmark extends CommonParams {
   def readAVSystemGenCodec(): List[Boolean] = JsonStringInput.read[List[Boolean]](new String(jsonBytes, UTF_8))
 
   @Benchmark
+  def readBorerJson(): List[Boolean] = io.bullet.borer.Json.decode(jsonBytes).to[List[Boolean]].value
+
+  @Benchmark
   def readCirce(): List[Boolean] = decode[List[Boolean]](new String(jsonBytes, UTF_8)).fold(throw _, identity)
 
   @Benchmark
@@ -58,6 +61,9 @@ class ListOfBooleansBenchmark extends CommonParams {
 
   @Benchmark
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsBenchmark.scala
@@ -36,6 +36,9 @@ class MutableSetOfIntsBenchmark extends CommonParams {
   def readAVSystemGenCodec(): mutable.Set[Int] = JsonStringInput.read[mutable.Set[Int]](new String(jsonBytes, UTF_8))
 
   @Benchmark
+  def readBorerJson(): mutable.Set[Int] = io.bullet.borer.Json.decode(jsonBytes).to[mutable.Set[Int]].value
+
+  @Benchmark
   def readCirce(): mutable.Set[Int] = decode[mutable.Set[Int]](new String(jsonBytes, UTF_8)).fold(throw _, identity)
 
   @Benchmark
@@ -55,6 +58,9 @@ class MutableSetOfIntsBenchmark extends CommonParams {
 
   @Benchmark
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsBenchmark.scala
@@ -38,6 +38,9 @@ class SetOfIntsBenchmark extends CommonParams {
   def readAVSystemGenCodec(): Set[Int] = JsonStringInput.read[Set[Int]](new String(jsonBytes, UTF_8))
 
   @Benchmark
+  def readBorerJson(): Set[Int] = io.bullet.borer.Json.decode(jsonBytes).to[Set[Int]].value
+
+  @Benchmark
   def readCirce(): Set[Int] = decode[Set[Int]](new String(jsonBytes, UTF_8)).fold(throw _, identity)
 
   @Benchmark
@@ -60,6 +63,9 @@ class SetOfIntsBenchmark extends CommonParams {
 
   @Benchmark
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsBenchmark.scala
@@ -53,6 +53,9 @@ class StringOfAsciiCharsBenchmark extends CommonParams {
   def readAVSystemGenCodec(): String = JsonStringInput.read[String](new String(jsonBytes, UTF_8))
 
   @Benchmark
+  def readBorerJson(): String = io.bullet.borer.Json.decode(jsonBytes).to[String].value
+
+  @Benchmark
   def readCirce(): String = decode[String](new String(jsonBytes, UTF_8)).fold(throw _, identity)
 
   @Benchmark
@@ -78,6 +81,9 @@ class StringOfAsciiCharsBenchmark extends CommonParams {
 
   @Benchmark
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsBenchmark.scala
@@ -54,6 +54,9 @@ class StringOfNonAsciiCharsBenchmark extends CommonParams {
   def readAVSystemGenCodec(): String = JsonStringInput.read[String](new String(jsonBytes, UTF_8))
 
   @Benchmark
+  def readBorerJson(): String = io.bullet.borer.Json.decode(jsonBytes).to[String].value
+
+  @Benchmark
   def readCirce(): String = decode[String](new String(jsonBytes, UTF_8)).fold(throw _, identity)
 
   @Benchmark
@@ -79,6 +82,9 @@ class StringOfNonAsciiCharsBenchmark extends CommonParams {
 
   @Benchmark
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansBenchmark.scala
@@ -36,6 +36,9 @@ class VectorOfBooleansBenchmark extends CommonParams {
   def readAVSystemGenCodec(): Vector[Boolean] = JsonStringInput.read[Vector[Boolean]](new String(jsonBytes, UTF_8))
 
   @Benchmark
+  def readBorerJson(): Vector[Boolean] = io.bullet.borer.Json.decode(jsonBytes).to[Vector[Boolean]].value
+
+  @Benchmark
   def readCirce(): Vector[Boolean] = decode[Vector[Boolean]](new String(jsonBytes, UTF_8)).fold(throw _, identity)
 
   @Benchmark
@@ -58,6 +61,9 @@ class VectorOfBooleansBenchmark extends CommonParams {
 
   @Benchmark
   def writeAVSystemGenCodec(): Array[Byte] = JsonStringOutput.write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def writeBorerJson(): Array[Byte] = io.bullet.borer.Json.encode(obj).toByteArray
 
   @Benchmark
   def writeCirce(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansBenchmarkSpec.scala
@@ -8,6 +8,7 @@ class ArrayBufferOfBooleansBenchmarkSpec extends BenchmarkSpecBase {
   "ArrayBufferOfBooleansBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
+      benchmark.readBorerJson() shouldBe benchmark.obj
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
@@ -18,6 +19,7 @@ class ArrayBufferOfBooleansBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsBenchmarkSpec.scala
@@ -19,6 +19,7 @@ class ArrayOfBigIntsBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansBenchmarkSpec.scala
@@ -8,6 +8,7 @@ class ArrayOfBooleansBenchmarkSpec extends BenchmarkSpecBase {
   "ArrayOfBooleansBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
+      benchmark.readBorerJson() shouldBe benchmark.obj
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
@@ -19,6 +20,7 @@ class ArrayOfBooleansBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesBenchmarkSpec.scala
@@ -20,6 +20,7 @@ class ArrayOfDoublesBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       sameOrBetter(toString(benchmark.writeAVSystemGenCodec()), benchmark.jsonString)
+      sameOrBetter(toString(benchmark.writeBorerJson()), benchmark.jsonString)
       sameOrBetter(toString(benchmark.writeCirce()), benchmark.jsonString)
       //FIXME: dsl-json serializes doubles in a plain representation
       //sameOrBetter(toString(benchmark.writeDslJsonScala()), benchmark.jsonString)

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsBenchmarkSpec.scala
@@ -8,6 +8,7 @@ class ArrayOfIntsBenchmarkSpec extends BenchmarkSpecBase {
   "ArrayOfIntsBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
+      benchmark.readBorerJson() shouldBe benchmark.obj
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
@@ -19,6 +20,7 @@ class ArrayOfIntsBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsBenchmarkSpec.scala
@@ -19,6 +19,7 @@ class ArrayOfLongsBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsBenchmarkSpec.scala
@@ -8,6 +8,7 @@ class ArrayOfShortsBenchmarkSpec extends BenchmarkSpecBase {
   "ArrayOfShortsBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
+      benchmark.readBorerJson() shouldBe benchmark.obj
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
@@ -19,6 +20,7 @@ class ArrayOfShortsBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalBenchmarkSpec.scala
@@ -8,6 +8,7 @@ class BigDecimalBenchmarkSpec extends BenchmarkSpecBase {
   "BigDecimalBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.sourceObj
+      benchmark.readBorerJson() shouldBe benchmark.sourceObj
       benchmark.readCirce() shouldBe benchmark.sourceObj
       benchmark.readDslJsonScala() shouldBe benchmark.sourceObj
       benchmark.readJacksonScala() shouldBe benchmark.sourceObj
@@ -19,6 +20,7 @@ class BigDecimalBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntBenchmarkSpec.scala
@@ -8,6 +8,7 @@ class BigIntBenchmarkSpec extends BenchmarkSpecBase {
   "BigIntBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
+      benchmark.readBorerJson() shouldBe benchmark.obj
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
@@ -19,6 +20,7 @@ class BigIntBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIBenchmarkSpec.scala
@@ -6,6 +6,7 @@ class GoogleMapsAPIBenchmarkSpec extends BenchmarkSpecBase {
   "GoogleMapsAPIBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
+      benchmark.readBorerJson() shouldBe benchmark.obj
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
@@ -16,6 +17,7 @@ class GoogleMapsAPIBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe GoogleMapsAPI.compactJsonString
+      toString(benchmark.writeBorerJson()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.writeCirce()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.writeDslJsonScala()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.writeJacksonScala()) shouldBe GoogleMapsAPI.compactJsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntBenchmarkSpec.scala
@@ -6,6 +6,7 @@ class IntBenchmarkSpec extends BenchmarkSpecBase {
   "IntBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
+      benchmark.readBorerJson() shouldBe benchmark.obj
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
@@ -17,6 +18,7 @@ class IntBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansBenchmarkSpec.scala
@@ -8,6 +8,7 @@ class ListOfBooleansBenchmarkSpec extends BenchmarkSpecBase {
   "ListOfBooleansBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
+      benchmark.readBorerJson() shouldBe benchmark.obj
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
@@ -18,6 +19,7 @@ class ListOfBooleansBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsBenchmarkSpec.scala
@@ -8,6 +8,7 @@ class MutableSetOfIntsBenchmarkSpec extends BenchmarkSpecBase {
   "MutableSetOfIntsBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
+      benchmark.readBorerJson() shouldBe benchmark.obj
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
@@ -17,6 +18,7 @@ class MutableSetOfIntsBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsBenchmarkSpec.scala
@@ -13,6 +13,7 @@ class SetOfIntsBenchmarkSpec extends BenchmarkSpecBase {
   "SetOfIntsBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
+      benchmark.readBorerJson() shouldBe benchmark.obj
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
@@ -23,6 +24,7 @@ class SetOfIntsBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsBenchmarkSpec.scala
@@ -8,6 +8,7 @@ class StringOfAsciiCharsBenchmarkSpec extends BenchmarkSpecBase {
   "StringOfAsciiCharsBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
+      benchmark.readBorerJson() shouldBe benchmark.obj
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
@@ -19,6 +20,7 @@ class StringOfAsciiCharsBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsBenchmarkSpec.scala
@@ -8,6 +8,7 @@ class StringOfNonAsciiCharsBenchmarkSpec extends BenchmarkSpecBase {
   "StringOfNonAsciiCharsBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
+      benchmark.readBorerJson() shouldBe benchmark.obj
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
@@ -19,6 +20,7 @@ class StringOfNonAsciiCharsBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansBenchmarkSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansBenchmarkSpec.scala
@@ -8,6 +8,7 @@ class VectorOfBooleansBenchmarkSpec extends BenchmarkSpecBase {
   "VectorOfBooleansBenchmark" should {
     "deserialize properly" in {
       benchmark.readAVSystemGenCodec() shouldBe benchmark.obj
+      benchmark.readBorerJson() shouldBe benchmark.obj
       benchmark.readCirce() shouldBe benchmark.obj
       benchmark.readDslJsonScala() shouldBe benchmark.obj
       benchmark.readJacksonScala() shouldBe benchmark.obj
@@ -18,6 +19,7 @@ class VectorOfBooleansBenchmarkSpec extends BenchmarkSpecBase {
     }
     "serialize properly" in {
       toString(benchmark.writeAVSystemGenCodec()) shouldBe benchmark.jsonString
+      toString(benchmark.writeBorerJson()) shouldBe benchmark.jsonString
       toString(benchmark.writeCirce()) shouldBe benchmark.jsonString
       toString(benchmark.writeDslJsonScala()) shouldBe benchmark.jsonString
       toString(benchmark.writeJacksonScala()) shouldBe benchmark.jsonString


### PR DESCRIPTION
@sirthias I have updated this branch by rebasing it over the latest version of benchmarks and adding more benchmarks for the Borer library (JSON version only).

Feel free to run them with different profilers or, if you interested, I can run them on the same environment and JVMs as for others [here](https://plokhotnyuk.github.io/jsoniter-scala/)