### PR TITLE
More efficient parsing of BigInt values

### DIFF
--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
@@ -1367,22 +1367,71 @@ final class JsonReader private[jsoniter_scala](
     }
   }
 
-  private[this] def toBigInt(isNeg: Boolean, pos: Int): BigInt = {
-    val startPos = this.mark
-    var numPos =
-      if (isNeg) startPos + 1
-      else startPos
-    if (pos < 19 + numPos) { // 19 == Long.MaxValue.toString.length
+  private[this] def toBigInt(isNeg: Boolean, limit: Int): BigInt = {
+    var pos = this.mark
+    if (isNeg) pos += 1
+    if (limit - pos < 19) { // 19 == Long.MaxValue.toString.length
       var x = 0L
-      while (numPos < pos) {
-        x = x * 10 + (buf(numPos) - '0')
-        numPos += 1
+      while (pos < limit) {
+        x = x * 10 + (buf(pos) - '0')
+        pos += 1
       }
       new BigInt(BigInteger.valueOf {
         if (isNeg) -x
         else x
       })
-    } else new BigInt(new java.math.BigInteger(new String(buf, 0, startPos, pos - startPos), 10))
+    } else toBigInt(isNeg, limit, pos)
+  }
+
+  private[this] def toBigInt(isNeg: Boolean, limit: Int, p: Int): BigInt = {
+    var pos = p
+    val numDigits = limit - pos
+    val numWords = ((numDigits * 445861642L) >>> 32).toInt + 1 // == numDigits * log(10) / log (1L << 32) + 1
+    if (numWords > 67108863) numberError() // == BigInteger.MAX_MAG_LENGTH - 1
+    val magnitude = new Array[Int](numWords)
+    val blockNum = ((numDigits * 954437177L) >> 33).toInt // divide positive int by 9
+    val firstBlockPos = pos + numDigits - 9 * blockNum
+    var x = 0L
+    while (pos < firstBlockPos) {
+      x = x * 10 + (buf(pos) - '0')
+      pos += 1
+    }
+    magnitude(numWords - 1) = x.toInt
+    while (pos < limit) {
+      x =
+        buf(pos) * 100000000L +
+          buf(pos + 1) * 10000000L +
+          buf(pos + 2) * 1000000 +
+          buf(pos + 3) * 100000 +
+          buf(pos + 4) * 10000 +
+          buf(pos + 5) * 1000 +
+          buf(pos + 6) * 100 +
+          buf(pos + 7) * 10 +
+          buf(pos + 8) - 5333333328L // == '0' * 111111111L
+      var i = numWords - 1
+      while (i >= 0) {
+        val p = (magnitude(i) & 0xFFFFFFFFL) * 1000000000 + x
+        magnitude(i) = p.toInt
+        x = p >>> 32
+        i -= 1
+      }
+      pos += 9
+    }
+    val mag = new Array[Byte](numWords << 2)
+    var i = 0
+    while (i < numWords) {
+      val w = magnitude(i)
+      val j = i << 2
+      mag(j) = ((w >> 24) & 0xFF).toByte
+      mag(j + 1) = ((w >> 16) & 0xFF).toByte
+      mag(j + 2) = ((w >> 8) & 0xFF).toByte
+      mag(j + 3) = (w & 0xFF).toByte
+      i += 1
+    }
+    val signum =
+      if (isNeg) -1
+      else 1
+    new BigInt(new java.math.BigInteger(signum, mag))
   }
 
   private[this] def parseBigDecimal(isToken: Boolean, default: BigDecimal, mc: MathContext, scaleLimit: Int,
@@ -1460,9 +1509,9 @@ final class JsonReader private[jsoniter_scala](
     }
   }
 
-  private[this] def toBigDecimal(pos: Int, mc: MathContext): BigDecimal = {
-    val startPos = this.mark
-    new BigDecimal(new java.math.BigDecimal(new String(buf, 0, startPos, pos - startPos), mc), mc)
+  private[this] def toBigDecimal(limit: Int, mc: MathContext): BigDecimal = {
+    val pos = this.mark
+    new BigDecimal(new java.math.BigDecimal(new String(buf, 0, pos, limit - pos), mc), mc)
   }
 
   private[this] def readNullOrNumberError[@sp A](default: A, pos: Int): A =


### PR DESCRIPTION
Before:
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                           (size)   Mode  Cnt         Score         Error  Units
[info] BigIntBenchmark.readJsoniterScala       10  thrpt    5  28609840.548 ± 1689063.362  ops/s
[info] BigIntBenchmark.readJsoniterScala      100  thrpt    5   1413079.020 ±    8176.779  ops/s
[info] BigIntBenchmark.readJsoniterScala     1000  thrpt    5     57806.661 ±    2977.655  ops/s
[info] BigIntBenchmark.readJsoniterScala    10000  thrpt    5       751.482 ±       1.143  ops/s
[info] BigIntBenchmark.readJsoniterScala   100000  thrpt    5         7.515 ±       0.645  ops/s
[info] BigIntBenchmark.readJsoniterScala  1000000  thrpt    5         0.075 ±       0.009  ops/s
```
After:
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                           (size)   Mode  Cnt         Score        Error  Units
[info] BigIntBenchmark.readJsoniterScala       10  thrpt    5  29684957.083 ± 918541.294  ops/s
[info] BigIntBenchmark.readJsoniterScala      100  thrpt    5   3258604.858 ± 281143.988  ops/s
[info] BigIntBenchmark.readJsoniterScala     1000  thrpt    5    121549.540 ±    946.224  ops/s
[info] BigIntBenchmark.readJsoniterScala    10000  thrpt    5      1420.101 ±      5.044  ops/s
[info] BigIntBenchmark.readJsoniterScala   100000  thrpt    5        14.582 ±      0.030  ops/s
[info] BigIntBenchmark.readJsoniterScala  1000000  thrpt    5         0.144 ±      0.004  ops/s
```