### PR TITLE
More efficient serialization of medium `BigInt` values

### DIFF
--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1994,8 +1994,8 @@ object JsonWriter {
   private final val f32Pow5Split = new Array[Int](94)
   private final val f64Pow5InvSplit = new Array[Int](1164)
   private final val f64Pow5Split = new Array[Int](1304)
-  private final val tenPow18: BigInteger = BigInteger.valueOf(1000000000000000000L)
-  private final val tenPows: Stream[BigInteger] = tenPow18 #:: tenPows.map(p => p.multiply(p))
+  private final val tenPows: Stream[BigInteger] =
+    BigInteger.valueOf(1000000000000000000L) #:: tenPows.map(p => p.multiply(p))
 
   {
     var pow5 = BigInteger.ONE

--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -817,7 +817,7 @@ final class JsonWriter private[jsoniter_scala](
     if (x.bitLength < 64) writeLong(x.longValue)
     else {
       val n = 31 - java.lang.Integer.numberOfLeadingZeros(Math.max((x.bitLength * 71828554L >>> 32).toInt - 1, 1))
-      val qr = x.divideAndRemainder(tenPows(n))
+      val qr = x.divideAndRemainder(tenPow18Squares(n))
       writeBigInteger(qr(0))
       writeBigIntegerReminder(qr(1), n - 1)
     }
@@ -825,7 +825,7 @@ final class JsonWriter private[jsoniter_scala](
   private[this] def writeBigIntegerReminder(x: BigInteger, n: Int): Unit =
     if (n < 0) count = write18Digits(Math.abs(x.longValue), ensureBufCapacity(18), buf, digits)
     else {
-      val qr = x.divideAndRemainder(tenPows(n))
+      val qr = x.divideAndRemainder(tenPow18Squares(n))
       writeBigIntegerReminder(qr(0), n - 1)
       writeBigIntegerReminder(qr(1), n - 1)
     }
@@ -1994,8 +1994,8 @@ object JsonWriter {
   private final val f32Pow5Split = new Array[Int](94)
   private final val f64Pow5InvSplit = new Array[Int](1164)
   private final val f64Pow5Split = new Array[Int](1304)
-  private final val tenPows: Stream[BigInteger] =
-    BigInteger.valueOf(1000000000000000000L) #:: tenPows.map(p => p.multiply(p))
+  private final val tenPow18Squares: Stream[BigInteger] =
+    BigInteger.valueOf(1000000000000000000L) #:: tenPow18Squares.map(p => p.multiply(p))
 
   {
     var pow5 = BigInteger.ONE


### PR DESCRIPTION
Before
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                    (size)   Mode  Cnt         Score         Error  Units
[info] BigIntBenchmark.writeJsoniterScalaPrealloc        1  thrpt    5  77182242.654 ± 3347569.080  ops/s
[info] BigIntBenchmark.writeJsoniterScalaPrealloc       10  thrpt    5  43829690.204 ± 1499866.371  ops/s
[info] BigIntBenchmark.writeJsoniterScalaPrealloc      100  thrpt    5    674855.569 ±   76136.902  ops/s
[info] BigIntBenchmark.writeJsoniterScalaPrealloc     1000  thrpt    5     32500.883 ±    2878.903  ops/s
[info] BigIntBenchmark.writeJsoniterScalaPrealloc    10000  thrpt    5      1386.491 ±     164.643  ops/s
[info] BigIntBenchmark.writeJsoniterScalaPrealloc   100000  thrpt    5        52.739 ±       4.910  ops/s
[info] BigIntBenchmark.writeJsoniterScalaPrealloc  1000000  thrpt    5         1.837 ±       0.034  ops/s
```
After:
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                    (size)   Mode  Cnt         Score         Error  Units
[info] BigIntBenchmark.writeJsoniterScalaPrealloc        1  thrpt    5  75998515.968 ± 1206437.673  ops/s
[info] BigIntBenchmark.writeJsoniterScalaPrealloc       10  thrpt    5  42449136.581 ± 2978413.342  ops/s
[info] BigIntBenchmark.writeJsoniterScalaPrealloc      100  thrpt    5   1111569.073 ±    7954.778  ops/s
[info] BigIntBenchmark.writeJsoniterScalaPrealloc     1000  thrpt    5     42658.565 ±     219.385  ops/s
[info] BigIntBenchmark.writeJsoniterScalaPrealloc    10000  thrpt    5      1504.612 ±      89.547  ops/s
[info] BigIntBenchmark.writeJsoniterScalaPrealloc   100000  thrpt    5        57.714 ±       0.535  ops/s
[info] BigIntBenchmark.writeJsoniterScalaPrealloc  1000000  thrpt    5         1.886 ±       0.062  ops/s
```
