### PR TITLE
More efficient parsing of small `BigDecimal` and `BigInt` numbers

### DIFF
--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
@@ -1,7 +1,7 @@
 package com.github.plokhotnyuk.jsoniter_scala.core
 
 import java.io.InputStream
-import java.math.{BigInteger, MathContext}
+import java.math.MathContext
 import java.nio.ByteBuffer
 import java.time._
 import java.util.UUID
@@ -1488,7 +1488,7 @@ final class JsonReader private[jsoniter_scala](
         x = x * 10 + (buf(pos) - '0')
         pos += 1
       }
-      new java.math.BigDecimal(BigInteger.valueOf {
+      java.math.BigDecimal.valueOf({
         if (isNeg) -x
         else x
       }, scale)
@@ -1529,10 +1529,10 @@ final class JsonReader private[jsoniter_scala](
         buf(pos + 15) * 100 +
         buf(pos + 16) * 10 +
         buf(pos + 17) - 5333333333333333328L // == '0' * 111111111111111111L
-    new java.math.BigDecimal(BigInteger.valueOf {
+    java.math.BigDecimal.valueOf({
       if (isNeg) -x1
       else x1
-    }, scale - 18).add(new java.math.BigDecimal(BigInteger.valueOf {
+    }, scale - 18).add(java.math.BigDecimal.valueOf({
       if (isNeg) -x2
       else x2
     }, scale))

--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
@@ -1364,7 +1364,7 @@ final class JsonReader private[jsoniter_scala](
         if (b == '.' || (b | 0x20) == 'e') numberError(pos)
         var numPos = this.mark
         if (isNeg) numPos += 1
-        new BigInt(toBigDecimal(buf, numPos, pos, isNeg, 0).toBigInteger)
+        new BigInt(toBigDecimal(buf, numPos, pos, isNeg, 0).unscaledValue)
       } finally this.mark = mark
     }
   }


### PR DESCRIPTION
Before:
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                      (size)   Mode  Cnt        Score        Error  Units
[info] ArrayOfBigDecimalsBenchmark.readJsoniterScala     128  thrpt    5    73151.454 ±   7927.367  ops/s
[info] ArrayOfBigIntsBenchmark.readJsoniterScala         128  thrpt    5   101838.911 ±   1388.464  ops/s
```
After:
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                      (size)   Mode  Cnt        Score       Error  Units
[info] ArrayOfBigDecimalsBenchmark.readJsoniterScala     128  thrpt    5    80853.200 ±  4786.837  ops/s
[info] ArrayOfBigIntsBenchmark.readJsoniterScala         128  thrpt    5   132494.519 ±  5219.268  ops/s
```