### PR TITLE
Parse and serialize circe AST using jsoniter-scala

### DIFF
--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReading.scala
@@ -12,6 +12,8 @@ import com.github.plokhotnyuk.jsoniter_scala.benchmark.PlayJsonFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.SprayFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.UPickleReaderWriters._
 import com.github.plokhotnyuk.jsoniter_scala.core._
+import io.circe.CirceJsoniter._
+import io.circe.Decoder
 import io.circe.parser._
 import org.openjdk.jmh.annotations.Benchmark
 import play.api.libs.json.Json
@@ -23,6 +25,12 @@ class GeoJSONReading extends GeoJSONBenchmark {
 
   @Benchmark
   def circe(): GeoJSON = decode[GeoJSON](new String(jsonBytes, UTF_8)).fold(throw _, identity)
+
+  @Benchmark
+  def circeJsoniter(): GeoJSON = {
+    val json = readFromArray[io.circe.Json](jsonBytes)
+    Decoder.apply[GeoJSON].decodeJson(json).fold(throw _, identity)
+  }
 
   @Benchmark
   def jacksonScala(): GeoJSON = jacksonMapper.readValue[GeoJSON](jsonBytes)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWriting.scala
@@ -11,6 +11,7 @@ import com.github.plokhotnyuk.jsoniter_scala.benchmark.PlayJsonFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.SprayFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.UPickleReaderWriters._
 import com.github.plokhotnyuk.jsoniter_scala.core._
+import io.circe.CirceJsoniter._
 import io.circe.syntax._
 import org.openjdk.jmh.annotations.Benchmark
 import play.api.libs.json.Json
@@ -22,6 +23,9 @@ class GeoJSONWriting extends GeoJSONBenchmark {
 
   @Benchmark
   def circe(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)
+
+  @Benchmark
+  def circeJsoniter(): Array[Byte] = writeToArray(obj.asJson)
 
   @Benchmark
   def jacksonScala(): Array[Byte] = jacksonMapper.writeValueAsBytes(obj)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrinting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrinting.scala
@@ -11,6 +11,7 @@ import com.github.plokhotnyuk.jsoniter_scala.benchmark.PlayJsonFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.SprayFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.UPickleReaderWriters._
 import com.github.plokhotnyuk.jsoniter_scala.core._
+import io.circe.CirceJsoniter._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.openjdk.jmh.annotations.Benchmark
@@ -23,6 +24,10 @@ class GoogleMapsAPIPrettyPrinting extends GoogleMapsAPIBenchmark {
 
   @Benchmark
   def circe(): Array[Byte] = prettyPrinter.pretty(obj.asJson).getBytes(UTF_8)
+
+  @Benchmark
+  def circeJsoniter(): Array[Byte] = writeToArray(obj.asJson, prettyConfig)
+
   /* FIXME: DSL-JSON doesn't support pretty printing
     @Benchmark
     def prettyPrintDslJsonScala(): Array[Byte] = dslJsonEncode(obj)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReading.scala
@@ -13,6 +13,8 @@ import com.github.plokhotnyuk.jsoniter_scala.benchmark.PlayJsonFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.SprayFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.UPickleReaderWriters._
 import com.github.plokhotnyuk.jsoniter_scala.core._
+import io.circe.Decoder
+import io.circe.CirceJsoniter._
 import io.circe.generic.auto._
 import io.circe.parser._
 import org.openjdk.jmh.annotations.Benchmark
@@ -28,6 +30,12 @@ class GoogleMapsAPIReading extends GoogleMapsAPIBenchmark {
 
   @Benchmark
   def circe(): DistanceMatrix = decode[DistanceMatrix](new String(jsonBytes1, UTF_8)).fold(throw _, identity)
+
+  @Benchmark
+  def circeJsoniter(): DistanceMatrix = {
+    val json = readFromArray[io.circe.Json](jsonBytes1)
+    Decoder.apply[DistanceMatrix].decodeJson(json).fold(throw _, identity)
+  }
 
   @Benchmark
   def dslJsonScala(): DistanceMatrix = dslJsonDecode[DistanceMatrix](jsonBytes1)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWriting.scala
@@ -13,6 +13,7 @@ import com.github.plokhotnyuk.jsoniter_scala.benchmark.PlayJsonFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.SprayFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.UPickleReaderWriters._
 import com.github.plokhotnyuk.jsoniter_scala.core._
+import io.circe.CirceJsoniter._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.openjdk.jmh.annotations.Benchmark
@@ -28,6 +29,9 @@ class GoogleMapsAPIWriting extends GoogleMapsAPIBenchmark {
 
   @Benchmark
   def circe(): Array[Byte] = printer.pretty(obj.asJson).getBytes(UTF_8)
+
+  @Benchmark
+  def circeJsoniter(): Array[Byte] = writeToArray(obj.asJson)
 
   @Benchmark
   def dslJsonScala(): Array[Byte] = dslJsonEncode(obj)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIReading.scala
@@ -12,6 +12,8 @@ import com.github.plokhotnyuk.jsoniter_scala.benchmark.TwitterAPI._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.SprayFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.UPickleReaderWriters._
 import com.github.plokhotnyuk.jsoniter_scala.core._
+import io.circe.CirceJsoniter._
+import io.circe.Decoder
 import io.circe.generic.auto._
 import io.circe.parser._
 import org.openjdk.jmh.annotations.Benchmark
@@ -26,6 +28,12 @@ class TwitterAPIReading extends TwitterAPIBenchmark {
 
   @Benchmark
   def circe(): Seq[Tweet] = decode[Seq[Tweet]](new String(jsonBytes, UTF_8)).fold(throw _, identity)
+
+  @Benchmark
+  def circeJsoniter(): Seq[Tweet] = {
+    val json = readFromArray[io.circe.Json](jsonBytes)
+    Decoder.apply[Seq[Tweet]].decodeJson(json).fold(throw _, identity)
+  }
 
   @Benchmark
   def dslJsonScala(): Seq[Tweet] = dslJsonDecode[Seq[Tweet]](jsonBytes)

--- a/jsoniter-scala-benchmark/src/main/scala/io/circe/CirceJsoniter.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/io/circe/CirceJsoniter.scala
@@ -1,0 +1,83 @@
+package io.circe
+
+import java.util
+
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import io.circe.Json._
+
+object CirceJsoniter {
+  implicit val codec: JsonValueCodec[Json] = new JsonValueCodec[Json] {
+    override def decodeValue(in: JsonReader, default: Json): Json = {
+      var b = in.nextToken()
+      if (b == 'n') in.readNullOrError(default, "expected `null` value")
+      else if (b == '"') {
+        in.rollbackToken()
+        new JString(in.readString(null))
+      } else if (b == 'f' || b == 't') {
+        in.rollbackToken()
+        if (in.readBoolean()) Json.True
+        else Json.False
+      } else if ((b >= '0' && b <= '9') || b == '-') {
+        new JNumber({
+          in.rollbackToken()
+          in.setMark() // TODO: add in.readNumberAsString() to Core API of jsoniter-scala
+          try {
+            do b = in.nextByte()
+            while (b >= '0' && b <= '9')
+          } catch { case _: JsonReaderException => /* ignore end of input error */} finally in.rollbackToMark()
+          if (b == '.' || b == 'e' || b == 'E') new JsonDouble(in.readDouble())
+          else new JsonLong(in.readLong())
+        })
+      } else if (b == '[') {
+        new JArray(if (in.isNextToken(']')) Vector.empty
+        else {
+          in.rollbackToken()
+          var x = new Array[Json](4)
+          var i = 0
+          do {
+            if (i == x.length) x = java.util.Arrays.copyOf(x, i << 1)
+            x(i) = decodeValue(in, default)
+            i += 1
+          } while (in.isNextToken(','))
+          (if (in.isCurrentToken(']'))
+            if (i == x.length) x
+            else java.util.Arrays.copyOf(x, i)
+          else in.arrayEndOrCommaError()).to[Vector]
+        })
+      } else if (b == '{') {
+        new JObject(if (in.isNextToken('}')) JsonObject.empty
+        else {
+          val x = new util.LinkedHashMap[String, Json]
+          in.rollbackToken()
+          do x.put(in.readKeyAsString(), decodeValue(in, default))
+          while (in.isNextToken(','))
+          if (!in.isCurrentToken('}')) in.objectEndOrCommaError()
+          JsonObject.fromLinkedHashMap(x)
+        })
+      } else in.decodeError("expected JSON value")
+    }
+
+    override def encodeValue(x: Json, out: JsonWriter): Unit = x match {
+      case JNull => out.writeNull()
+      case JString(s) => out.writeVal(s)
+      case JBoolean(b) => out.writeVal(b)
+      case JNumber(n) => n match {
+        case JsonLong(l) => out.writeVal(l)
+        case _ => out.writeVal(n.toDouble)
+      }
+      case JArray(a) =>
+        out.writeArrayStart()
+        a.foreach(v => encodeValue(v, out))
+        out.writeArrayEnd()
+      case JObject(o) =>
+        out.writeObjectStart()
+        o.toIterable.foreach { case (k, v) =>
+          out.writeKey(k)
+          encodeValue(v, out)
+        }
+        out.writeObjectEnd()
+    }
+
+    override def nullValue: Json = Json.Null
+  }
+}

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReadingSpec.scala
@@ -7,6 +7,7 @@ class GeoJSONReadingSpec extends BenchmarkSpecBase {
     "read properly" in {
       benchmark.avSystemGenCodec() shouldBe benchmark.obj
       benchmark.circe() shouldBe benchmark.obj
+      benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWritingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWritingSpec.scala
@@ -7,6 +7,7 @@ class GeoJSONWritingSpec extends BenchmarkSpecBase {
     "write properly" in {
       toString(benchmark.avSystemGenCodec()) shouldBe GeoJSON.jsonString1
       toString(benchmark.circe()) shouldBe GeoJSON.jsonString2
+      toString(benchmark.circeJsoniter()) shouldBe GeoJSON.jsonString2
       toString(benchmark.jacksonScala()) shouldBe GeoJSON.jsonString1
       toString(benchmark.jsoniterScala()) shouldBe GeoJSON.jsonString1
       toString(benchmark.preallocatedBuf, 0, benchmark.jsoniterScalaPrealloc()) shouldBe GeoJSON.jsonString1

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrintingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrintingSpec.scala
@@ -7,6 +7,7 @@ class GoogleMapsAPIPrettyPrintingSpec extends BenchmarkSpecBase {
     "pretty print properly" in {
       toString(benchmark.avSystemGenCodec()) shouldBe GoogleMapsAPI.jsonString2
       toString(benchmark.circe()) shouldBe GoogleMapsAPI.jsonString1
+      toString(benchmark.circeJsoniter()) shouldBe GoogleMapsAPI.jsonString2
       //FIXME: DSL-JSON doesn't support pretty printing
       //toString(benchmark.dslJsonScala()) shouldBe GoogleMapsAPI.jsonString1
       toString(benchmark.jacksonScala()) shouldBe GoogleMapsAPI.jsonString1

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReadingSpec.scala
@@ -8,6 +8,7 @@ class GoogleMapsAPIReadingSpec extends BenchmarkSpecBase {
       benchmark.avSystemGenCodec() shouldBe benchmark.obj
       benchmark.borerJson() shouldBe benchmark.obj
       benchmark.circe() shouldBe benchmark.obj
+      benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWritingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWritingSpec.scala
@@ -8,6 +8,7 @@ class GoogleMapsAPIWritingSpec extends BenchmarkSpecBase {
       toString(benchmark.avSystemGenCodec()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.borerJson()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.circe()) shouldBe GoogleMapsAPI.compactJsonString
+      toString(benchmark.circeJsoniter()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.dslJsonScala()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.jacksonScala()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.jsoniterScala()) shouldBe GoogleMapsAPI.compactJsonString

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIReadingSpec.scala
@@ -7,6 +7,7 @@ class TwitterAPIReadingSpec extends BenchmarkSpecBase {
     "read properly" in {
       benchmark.avSystemGenCodec() shouldBe benchmark.obj
       benchmark.circe() shouldBe benchmark.obj
+      benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj

--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
@@ -489,6 +489,8 @@ final class JsonReader private[jsoniter_scala](
     else if (isCurrentToken('n', head)) parseNullOrTokenError(default, b, head)
     else tokenOrNullError(b)
 
+  def nextByte(): Byte = nextByte(head)
+
   def nextToken(): Byte = nextToken(head)
 
   def isNextToken(b: Byte): Boolean = isNextToken(b, head)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.46.5-SNAPSHOT"
+version in ThisBuild := "0.47.0-SNAPSHOT"


### PR DESCRIPTION
Results of benchmarks:
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                   Mode  Cnt      Score      Error  Units
[info] GeoJSONReading.circe                       thrpt    5   6434.510 ±  387.368  ops/s
[info] GeoJSONReading.circeJsoniter               thrpt    5   6503.791 ±  244.144  ops/s
[info] GeoJSONReading.jsoniterScala               thrpt    5  38970.101 ±  319.176  ops/s
[info] GeoJSONWriting.circe                       thrpt    5   4044.570 ±  356.425  ops/s
[info] GeoJSONWriting.circeJsoniter               thrpt    5   6216.887 ±  468.054  ops/s
[info] GeoJSONWriting.jsoniterScala               thrpt    5  13440.258 ±  108.046  ops/s
[info] GoogleMapsAPIPrettyPrinting.circe          thrpt    5   7556.502 ±  949.123  ops/s
[info] GoogleMapsAPIPrettyPrinting.circeJsoniter  thrpt    5   8787.719 ±  137.656  ops/s
[info] GoogleMapsAPIPrettyPrinting.jsoniterScala  thrpt    5  48592.752 ± 2897.298  ops/s
[info] GoogleMapsAPIReading.circe                 thrpt    5   8258.472 ±  416.014  ops/s
[info] GoogleMapsAPIReading.circeJsoniter         thrpt    5   9435.155 ±  371.863  ops/s
[info] GoogleMapsAPIReading.jsoniterScala         thrpt    5  31316.494 ±  439.374  ops/s
[info] GoogleMapsAPIWriting.circe                 thrpt    5   8031.358 ±  178.514  ops/s
[info] GoogleMapsAPIWriting.circeJsoniter         thrpt    5   9392.853 ± 1066.635  ops/s
[info] GoogleMapsAPIWriting.jsoniterScala         thrpt    5  91760.728 ± 3033.358  ops/s
[info] TwitterAPIReading.circe                    thrpt    5  12922.692 ±  170.774  ops/s
[info] TwitterAPIReading.circeJsoniter            thrpt    5  17641.198 ±  383.072  ops/s
[info] TwitterAPIReading.jsoniterScala            thrpt    5  41987.413 ± 2753.776  ops/s
```

