### PR TITLE
Evaluate lookup tables in compile time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,6 +100,7 @@ lazy val `jsoniter-scala-core` = project
   .settings(
     crossScalaVersions := Seq("2.13.0", "2.12.8", "2.11.12"),
     libraryDependencies ++= Seq(
+      "com.github.plokhotnyuk.expression-evaluator" %% "expression-evaluator" % "0.1.0" % Provided,
       "org.scalacheck" %% "scalacheck" % "1.14.0" % Test,
       "org.scalatest" %% "scalatest" % "3.0.8" % Test
     )

--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
@@ -2794,7 +2794,7 @@ object JsonReader {
     ns('f') = 15
     ns
   }
-  private final val zoneOffsets: Array[ZoneOffset] = {
+  private final lazy val zoneOffsets: Array[ZoneOffset] = {
     val zos = new Array[ZoneOffset](145)
     var i = 0
     while (i < 145) {
@@ -2803,7 +2803,7 @@ object JsonReader {
     }
     zos
   }
-  private final val zoneIds: java.util.HashMap[String, ZoneId] = {
+  private final lazy val zoneIds: java.util.HashMap[String, ZoneId] = {
     val zs = new java.util.HashMap[String, ZoneId](1024)
     val azs = ZoneId.getAvailableZoneIds.iterator()
     while (azs.hasNext) {

--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
@@ -2829,9 +2829,9 @@ object JsonReader {
   private final val hexDigits: Array[Char] =
     Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f')
   private final val dumpBorder: Array[Char] =
-    "\n+----------+-------------------------------------------------+------------------+".toCharArray
+    eval("\n+----------+-------------------------------------------------+------------------+".toCharArray)
   private final val dumpHeader: Array[Char] =
-    "\n|          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f | 0123456789abcdef |".toCharArray
+    eval("\n|          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f | 0123456789abcdef |".toCharArray)
   final val bigDecimalMathContext: MathContext = MathContext.DECIMAL128
   final val bigDecimalDigitsLimit: Int = 308
   final val bigDecimalScaleLimit: Int = 6178

--- a/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -2176,51 +2176,51 @@ object JsonWriter {
     ds
   }
   private final val f32Pow5InvSplit: Array[Long] = eval {
-    val fs = new Array[Long](31)
+    val ss = new Array[Long](31)
     var pow5 = BigInt(1)
     var i = 0
     while (i < 31) {
-      fs(i) = ((BigInt(1) << (pow5.bitLength + 58)) / pow5).longValue + 1
+      ss(i) = ((BigInt(1) << (pow5.bitLength + 58)) / pow5).longValue + 1
       pow5 *= 5
       i += 1
     }
-    fs
+    ss
   }
   private final val f32Pow5Split: Array[Long] = eval {
-    val fs = new Array[Long](47)
+    val ss = new Array[Long](47)
     var pow5 = BigInt(1)
     var i = 0
     while (i < 47) {
-      fs(i) = (pow5 >> (pow5.bitLength - 61)).longValue
+      ss(i) = (pow5 >> (pow5.bitLength - 61)).longValue
       pow5 *= 5
       i += 1
     }
-    fs
+    ss
   }
   private final val f64Pow5InvSplit: Array[Long] = eval {
-    val fs = new Array[Long](582)
+    val ss = new Array[Long](582)
     var pow5 = BigInt(1)
     var i = 0
     while (i < 582) {
       val inv = ((BigInt(1) << (pow5.bitLength + 121)) / pow5) + 1
-      fs(i) = inv.longValue & 0x3FFFFFFFFFFFFFFFL
-      fs(i + 1) = (inv >> 62).longValue & 0x3FFFFFFFFFFFFFFFL
+      ss(i) = inv.longValue & 0x3FFFFFFFFFFFFFFFL
+      ss(i + 1) = (inv >> 62).longValue & 0x3FFFFFFFFFFFFFFFL
       pow5 *= 5
       i += 2
     }
-    fs
+    ss
   }
   private final val f64Pow5Split: Array[Long] = eval {
-    val fs = new Array[Long](652)
+    val ss = new Array[Long](652)
     var pow5 = BigInt(1)
     var i = 0
     while (i < 652) {
-      fs(i) = (pow5 >> (pow5.bitLength - 121)).longValue & 0x3FFFFFFFFFFFFFFFL
-      fs(i + 1) = (pow5 >> (pow5.bitLength - 59)).longValue & 0x3FFFFFFFFFFFFFFFL
+      ss(i) = (pow5 >> (pow5.bitLength - 121)).longValue & 0x3FFFFFFFFFFFFFFFL
+      ss(i + 1) = (pow5 >> (pow5.bitLength - 59)).longValue & 0x3FFFFFFFFFFFFFFFL
       pow5 *= 5
       i += 2
     }
-    fs
+    ss
   }
   private final val tenPow18Squares: Stream[BigInteger] =
     BigInteger.valueOf(1000000000000000000L) #:: tenPow18Squares.map(p => p.multiply(p))


### PR DESCRIPTION
It allows to speed up startup of parser and serializer. Parsing of timezone still affected by delay due initialization of cached values for them.

Bellow is timing of starting jsoniter-scala-example using JDK 8 and native image compiled by GraalVM CE 19 accordingly.

Before:
```
s$ time java -jar target/scala-2.12/jsoniter-scala-examples-assembly-0.1.0-SNAPSHOT.jar
User(John,List(Device(1,HTC One X)))
{"name":"John","devices":[{"id":2,"model":"iPhone X"}]}

real	0m0,376s
user	0m0,814s
sys	0m0,044s

$ time ./jsoniter-scala-examples-assembly-0.1.0-SNAPSHOT
User(John,List(Device(1,HTC One X)))
{"name":"John","devices":[{"id":2,"model":"iPhone X"}]}

real	0m0,013s
user	0m0,014s
sys	0m0,000s
```

After:
```
$ time java -jar target/scala-2.12/jsoniter-scala-examples-assembly-0.1.0-SNAPSHOT.jar
User(John,List(Device(1,HTC One X)))
{"name":"John","devices":[{"id":2,"model":"iPhone X"}]}

real	0m0,323s
user	0m0,391s
sys	0m0,027s

$ time ./jsoniter-scala-examples-assembly-0.1.0-SNAPSHOT
User(John,List(Device(1,HTC One X)))
{"name":"John","devices":[{"id":2,"model":"iPhone X"}]}

real	0m0,001s
user	0m0,001s
sys	0m0,000s
```