### PR TITLE
Linked list benchmarks

### DIFF
--- a/jsoniter-scala-benchmark/src/main/java/com/github/plokhotnyuk/jsoniter_scala/benchmark/LinkedListBenchmark.java
+++ b/jsoniter-scala-benchmark/src/main/java/com/github/plokhotnyuk/jsoniter_scala/benchmark/LinkedListBenchmark.java
@@ -1,0 +1,54 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark;
+
+import org.openjdk.jmh.annotations.*;
+import scala.collection.immutable.List;
+import scala.collection.mutable.ListBuffer;
+
+import java.util.LinkedList;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgs = {
+        "-server",
+        "-Xms2g",
+        "-Xmx2g",
+        "-XX:NewSize=1g",
+        "-XX:MaxNewSize=1g",
+        "-XX:InitialCodeCacheSize=512m",
+        "-XX:ReservedCodeCacheSize=512m",
+        "-XX:+UseParallelGC",
+        "-XX:-UseBiasedLocking",
+        "-XX:+AlwaysPreTouch"
+})
+@BenchmarkMode({Mode.Throughput})
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class LinkedListBenchmark {
+    @Param({"1", "10", "100"})
+    int size;
+
+    @Benchmark
+    public LinkedList<Boolean> javaListOfBooleans() {
+        LinkedList<Boolean> list = new LinkedList<>();
+        int l = size;
+        int i = 0;
+        while (i < l) {
+            list.add((i & 1) == 0);
+            i++;
+        }
+        return list;
+    }
+
+    @Benchmark
+    public List<Boolean> scalaListOfBooleans() {
+        ListBuffer<Boolean> listBuffer = new ListBuffer<>();
+        int l = size;
+        int i = 0;
+        while (i < l) {
+            listBuffer.$plus$eq((i & 1) == 0);
+            i++;
+        }
+        return listBuffer.toList();
+    }
+}

--- a/jsoniter-scala-core/src/main/scala-2.11/scala/collection/immutable/Unsafe.scala
+++ b/jsoniter-scala-core/src/main/scala-2.11/scala/collection/immutable/Unsafe.scala
@@ -1,0 +1,9 @@
+package scala.collection.immutable
+
+object Unsafe {
+  final def append[T](last: ::[T], x: T): ::[T] = {
+    val next = new ::(x, Nil)
+    last.tl = next
+    next
+  }
+}

--- a/jsoniter-scala-core/src/main/scala-2.12/scala/collection/immutable/Unsafe.scala
+++ b/jsoniter-scala-core/src/main/scala-2.12/scala/collection/immutable/Unsafe.scala
@@ -1,0 +1,9 @@
+package scala.collection.immutable
+
+object Unsafe {
+  final def append[T](last: ::[T], x: T): ::[T] = {
+    val next = new ::(x, Nil)
+    last.tl = next
+    next
+  }
+}

--- a/jsoniter-scala-core/src/main/scala-2.13/scala/collection/immutable/Unsafe.scala
+++ b/jsoniter-scala-core/src/main/scala-2.13/scala/collection/immutable/Unsafe.scala
@@ -1,0 +1,9 @@
+package scala.collection.immutable
+
+object Unsafe {
+  final def append[T](last: ::[T], x: T): ::[T] = {
+    val next = new ::(x, Nil)
+    last.next = next
+    next
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.51.6-SNAPSHOT"
+version in ThisBuild := "0.52.0-SNAPSHOT"


### PR DESCRIPTION
# OpenJDK 11.0.3 + Scala 2.12.8:
```
$ sbt -java-home /usr/lib/jvm/jdk-11 -no-colors 'jsoniter-scala-benchmark/jmh:run LinkedListBenchmark'
...
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                (size)   Mode  Cnt          Score         Error  Units
[info] LinkedListBenchmark.javaListOfBooleans        1  thrpt    5  115677866.323 ± 1856046.532  ops/s
[info] LinkedListBenchmark.javaListOfBooleans       10  thrpt    5   21302289.382 ±   77986.499  ops/s
[info] LinkedListBenchmark.javaListOfBooleans      100  thrpt    5    2352426.493 ±   12423.118  ops/s
[info] LinkedListBenchmark.scalaListOfBooleans       1  thrpt    5  216106541.578 ± 4254001.448  ops/s
[info] LinkedListBenchmark.scalaListOfBooleans      10  thrpt    5   23955163.923 ±  136549.036  ops/s
[info] LinkedListBenchmark.scalaListOfBooleans     100  thrpt    5    1956150.213 ±    3476.563  ops/s
```
# GraalVM CE 19.1 + Scala 2.12.8:
```
$ sbt -java-home /usr/lib/jvm/graalvm-ce-19 -no-colors ++2.12.8 'jsoniter-scala-benchmark/jmh:run LinkedListBenchmark'
...
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                (size)   Mode  Cnt          Score         Error  Units
[info] LinkedListBenchmark.javaListOfBooleans        1  thrpt    5  136454985.860 ±  300236.640  ops/s
[info] LinkedListBenchmark.javaListOfBooleans       10  thrpt    5   28053108.765 ±   73090.306  ops/s
[info] LinkedListBenchmark.javaListOfBooleans      100  thrpt    5    3131982.762 ±   43925.480  ops/s
[info] LinkedListBenchmark.scalaListOfBooleans       1  thrpt    5  238747879.718 ±  256970.391  ops/s
[info] LinkedListBenchmark.scalaListOfBooleans      10  thrpt    5   30402232.209 ± 1980022.072  ops/s
[info] LinkedListBenchmark.scalaListOfBooleans     100  thrpt    5    2946315.602 ±   19555.809  ops/s
```
# OpenJDK 11.0.3 + Scala 2.13.0:
```
$ sbt -java-home /usr/lib/jvm/jdk-11 -no-colors ++2.13.0 'jsoniter-scala-benchmark/jmh:run LinkedListBenchmark'
...
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                (size)   Mode  Cnt          Score         Error  Units
[info] LinkedListBenchmark.javaListOfBooleans        1  thrpt    5  116032687.834 ±  680710.285  ops/s
[info] LinkedListBenchmark.javaListOfBooleans       10  thrpt    5   21333418.826 ±   38952.347  ops/s
[info] LinkedListBenchmark.javaListOfBooleans      100  thrpt    5    2352184.921 ±   10654.879  ops/s
[info] LinkedListBenchmark.scalaListOfBooleans       1  thrpt    5  141021551.692 ± 1217908.450  ops/s
[info] LinkedListBenchmark.scalaListOfBooleans      10  thrpt    5   17378635.708 ±   47899.970  ops/s
[info] LinkedListBenchmark.scalaListOfBooleans     100  thrpt    5    1739740.096 ±    3339.678  ops/s
```
# GraalVM CE 19.1 + Scala 2.13.0:
```
$ sbt -java-home /usr/lib/jvm/graalvm-ce-19 -no-colors ++2.13.0 'jsoniter-scala-benchmark/jmh:run LinkedListBenchmark'
...
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                (size)   Mode  Cnt          Score        Error  Units
[info] LinkedListBenchmark.javaListOfBooleans        1  thrpt    5  136713513.364 ± 273265.310  ops/s
[info] LinkedListBenchmark.javaListOfBooleans       10  thrpt    5   27998249.564 ± 387952.646  ops/s
[info] LinkedListBenchmark.javaListOfBooleans      100  thrpt    5    3140353.751 ±  24782.666  ops/s
[info] LinkedListBenchmark.scalaListOfBooleans       1  thrpt    5   37943758.097 ± 971974.562  ops/s
[info] LinkedListBenchmark.scalaListOfBooleans      10  thrpt    5    6054572.419 ±  14871.766  ops/s
[info] LinkedListBenchmark.scalaListOfBooleans     100  thrpt    5     697626.100 ±   4105.390  ops/s
```
