### PR TITLE
Add ScalaJack benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,9 @@ lazy val `jsoniter-scala-benchmark` = project
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     resolvers += Resolver.bintrayRepo("reug", "maven"),
     crossScalaVersions := Seq("2.13.0", "2.12.10"),
+    useJCenter := true,
     libraryDependencies ++= Seq(
+      "co.blocke" %% "scalajack" % "6.0.4",
       "io.bullet" %% "borer-derivation" % "1.0.0",
       "pl.iterators" %% "kebs-spray-json" % "1.6.3",
       "io.spray" %%  "spray-json" % "1.3.5",

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyRefsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyRefsReading.scala
@@ -10,6 +10,7 @@ import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.PlayJsonFormats._
+import com.github.plokhotnyuk.jsoniter_scala.benchmark.ScalaJackStuff.sj
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.SprayFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.UPickleReaderWriters._
 import com.github.plokhotnyuk.jsoniter_scala.core._
@@ -39,6 +40,9 @@ class AnyRefsReading extends AnyRefsBenchmark {
 
   @Benchmark
   def playJson(): AnyRefs = Json.parse(jsonBytes).as[AnyRefs]
+
+  @Benchmark
+  def scalaJack(): AnyRefs = sj.read[AnyRefs](new String(jsonBytes, UTF_8))
 
   @Benchmark
   def sprayJson(): AnyRefs = JsonParser(jsonBytes).convertTo[AnyRefs]

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyRefsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyRefsWriting.scala
@@ -10,6 +10,7 @@ import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.PlayJsonFormats._
+import com.github.plokhotnyuk.jsoniter_scala.benchmark.ScalaJackStuff.sj
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.SprayFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.UPickleReaderWriters._
 import com.github.plokhotnyuk.jsoniter_scala.core._
@@ -42,6 +43,9 @@ class AnyRefsWriting extends AnyRefsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def scalaJack(): Array[Byte] = sj.render(obj).getBytes(UTF_8)
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReading.scala
@@ -11,6 +11,7 @@ import com.github.plokhotnyuk.jsoniter_scala.benchmark.GoogleMapsAPI._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.PlayJsonFormats._
+import com.github.plokhotnyuk.jsoniter_scala.benchmark.ScalaJackStuff.sj
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.SprayFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.UPickleReaderWriters._
 import com.github.plokhotnyuk.jsoniter_scala.core._
@@ -40,6 +41,9 @@ class GoogleMapsAPIReading extends GoogleMapsAPIBenchmark {
 
   @Benchmark
   def playJson(): DistanceMatrix = Json.parse(jsonBytes1).as[DistanceMatrix]
+
+  @Benchmark
+  def scalaJack(): DistanceMatrix = sj.read[DistanceMatrix](new String(jsonBytes1, UTF_8))
 
   @Benchmark
   def sprayJson(): DistanceMatrix = JsonParser(jsonBytes1).convertTo[DistanceMatrix]

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWriting.scala
@@ -10,6 +10,7 @@ import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.PlayJsonFormats._
+import com.github.plokhotnyuk.jsoniter_scala.benchmark.ScalaJackStuff.sj
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.SprayFormats._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.UPickleReaderWriters._
 import com.github.plokhotnyuk.jsoniter_scala.core._
@@ -42,6 +43,9 @@ class GoogleMapsAPIWriting extends GoogleMapsAPIBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def scalaJack(): Array[Byte] = sj.render(obj).getBytes(UTF_8)
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ScalaJackStuff.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ScalaJackStuff.scala
@@ -1,0 +1,7 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import co.blocke.scalajack._
+
+object ScalaJackStuff {
+  val sj = ScalaJack()
+}

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyRefsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyRefsReadingSpec.scala
@@ -12,6 +12,7 @@ class AnyRefsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.scalaJack() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
     }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyRefsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyRefsWritingSpec.scala
@@ -13,6 +13,7 @@ class AnyRefsWritingSpec extends BenchmarkSpecBase {
       toString(benchmark.jsoniterScala()) shouldBe benchmark.jsonString1
       toString(benchmark.preallocatedBuf, 0, benchmark.jsoniterScalaPrealloc()) shouldBe benchmark.jsonString1
       toString(benchmark.playJson()) shouldBe benchmark.jsonString1
+      toString(benchmark.scalaJack()) shouldBe benchmark.jsonString1
       toString(benchmark.sprayJson()) shouldBe benchmark.jsonString2
       toString(benchmark.uPickle()) shouldBe benchmark.jsonString1
     }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReadingSpec.scala
@@ -12,6 +12,7 @@ class GoogleMapsAPIReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.scalaJack() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
     }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWritingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWritingSpec.scala
@@ -13,6 +13,7 @@ class GoogleMapsAPIWritingSpec extends BenchmarkSpecBase {
       toString(benchmark.jsoniterScala()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.preallocatedBuf, 0, benchmark.jsoniterScalaPrealloc()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.playJson()) shouldBe GoogleMapsAPI.compactJsonString
+      toString(benchmark.scalaJack()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.sprayJson()) shouldBe GoogleMapsAPI.compactJsonString
       toString(benchmark.uPickle()) shouldBe GoogleMapsAPI.compactJsonString
     }


### PR DESCRIPTION
First results of benchmarks shows that ScalaJack is one of the slowest:
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                           Mode  Cnt       Score      Error  Units
...
[info] GoogleMapsAPIReading.avSystemGenCodec              thrpt    5   11754.426 ±   16.341  ops/s
[info] GoogleMapsAPIReading.borerJson                     thrpt    5   17524.356 ±  314.333  ops/s
[info] GoogleMapsAPIReading.circe                         thrpt    5    9062.135 ±   30.583  ops/s
[info] GoogleMapsAPIReading.dslJsonScala                  thrpt    5   12303.772 ±  165.061  ops/s
[info] GoogleMapsAPIReading.jacksonScala                  thrpt    5   14673.624 ±  188.035  ops/s
[info] GoogleMapsAPIReading.jsoniterScala                 thrpt    5   26501.935 ±  120.846  ops/s
[info] GoogleMapsAPIReading.playJson                      thrpt    5    5500.785 ±   41.413  ops/s
[info] GoogleMapsAPIReading.scalaJack                     thrpt    5    6126.029 ±   17.127  ops/s
[info] GoogleMapsAPIReading.sprayJson                     thrpt    5    6944.357 ±   56.419  ops/s
[info] GoogleMapsAPIReading.uPickle                       thrpt    5    7302.484 ±    8.941  ops/s
[info] GoogleMapsAPIWriting.avSystemGenCodec              thrpt    5   21044.658 ±  131.042  ops/s
[info] GoogleMapsAPIWriting.borerJson                     thrpt    5   23483.164 ±  137.192  ops/s
[info] GoogleMapsAPIWriting.circe                         thrpt    5   11080.777 ±   51.672  ops/s
[info] GoogleMapsAPIWriting.dslJsonScala                  thrpt    5   47341.649 ±  997.129  ops/s
[info] GoogleMapsAPIWriting.jacksonScala                  thrpt    5   37341.093 ±   51.400  ops/s
[info] GoogleMapsAPIWriting.jsoniterScala                 thrpt    5   85793.590 ± 1273.181  ops/s
[info] GoogleMapsAPIWriting.jsoniterScalaPrealloc         thrpt    5  100794.516 ±  113.679  ops/s
[info] GoogleMapsAPIWriting.playJson                      thrpt    5    4518.022 ±   15.973  ops/s
[info] GoogleMapsAPIWriting.scalaJack                     thrpt    5    2901.237 ±    4.183  ops/s
[info] GoogleMapsAPIWriting.sprayJson                     thrpt    5   10434.829 ±  122.091  ops/s
[info] GoogleMapsAPIWriting.uPickle                       thrpt    5    4304.022 ±   26.548  ops/s
```