### PR TITLE
Benchmarks for Jawn AST

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,8 +124,12 @@ lazy val `jsoniter-scala-benchmark` = project
   .settings(
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     resolvers += Resolver.bintrayRepo("reug", "maven"),
+    resolvers += Resolver.sonatypeRepo("releases"),
     crossScalaVersions := Seq("2.13.1", "2.12.10"),
     libraryDependencies ++= Seq(
+      "org.typelevel" %% "jawn-parser" % "1.0.0-RC1",
+      "org.typelevel" %% "jawn-ast" % "1.0.0-RC1",
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.2",
       "io.bullet" %% "borer-derivation" % "1.1.0",
       "pl.iterators" %% "kebs-spray-json" % "1.6.3",
       "io.spray" %%  "spray-json" % "1.3.5",

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReading.scala
@@ -1,5 +1,6 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.UTF_8
 
 import com.avsystem.commons.serialization.json._
@@ -16,6 +17,8 @@ import com.github.plokhotnyuk.jsoniter_scala.benchmark.UPickleReaderWriters._
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import io.circe.parser._
 import org.openjdk.jmh.annotations.{Benchmark, Param, Setup}
+import org.typelevel.jawn.{ByteBufferParser, Parser}
+import org.typelevel.jawn.ast.{JValue, JawnFacade}
 import play.api.libs.json.Json
 import spray.json._
 
@@ -53,6 +56,15 @@ class ExtractFieldsReading extends CommonParams {
 
   @Benchmark
   def jacksonScala(): ExtractFields = jacksonMapper.readValue[ExtractFields](jsonBytes)
+
+  @Benchmark
+  def jawnByteBufferParser(): JValue = new ByteBufferParser(ByteBuffer.wrap(jsonBytes)).parse()(JawnFacade)
+
+  @Benchmark
+  def jawnStringParser(): JValue = Parser.parseUnsafe(new String(jsonBytes, UTF_8))(JawnFacade)
+
+  @Benchmark
+  def jawnJsoniterScala(): JValue = readFromArray[JValue](jsonBytes)
 
   @Benchmark
   def jsoniterScala(): ExtractFields = readFromArray[ExtractFields](jsonBytes)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIBenchmark.scala
@@ -6,6 +6,7 @@ import com.avsystem.commons.serialization.transientDefault
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.TwitterAPI._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.core._
+import org.typelevel.jawn.ast.JValue
 
 import scala.collection.immutable.Seq
 import scala.reflect.io.Streamable
@@ -141,5 +142,6 @@ object TwitterAPI {
 
 abstract class TwitterAPIBenchmark extends CommonParams {
   var obj: Seq[Tweet] = readFromArray[Seq[Tweet]](jsonBytes)
+  var jValue: JValue = readFromArray[JValue](jsonBytes)
   var preallocatedBuf: Array[Byte] = new Array(compactJsonBytes.length + 100/*to avoid possible out of bounds error*/)
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIReading.scala
@@ -1,5 +1,6 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.UTF_8
 
 import com.avsystem.commons.serialization.json._
@@ -16,6 +17,9 @@ import com.github.plokhotnyuk.jsoniter_scala.benchmark.UPickleReaderWriters._
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import io.circe.parser._
 import org.openjdk.jmh.annotations.Benchmark
+import org.typelevel.jawn.{ByteBufferParser, Parser}
+import org.typelevel.jawn.ast.JValue
+import org.typelevel.jawn.ast.JawnFacade
 import play.api.libs.json.Json
 import spray.json._
 
@@ -36,6 +40,15 @@ class TwitterAPIReading extends TwitterAPIBenchmark {
 
   @Benchmark
   def jacksonScala(): Seq[Tweet] = jacksonMapper.readValue[Seq[Tweet]](jsonBytes)
+
+  @Benchmark
+  def jawnByteBufferParser(): JValue = new ByteBufferParser(ByteBuffer.wrap(jsonBytes)).parse()(JawnFacade)
+
+  @Benchmark
+  def jawnStringParser(): JValue = Parser.parseUnsafe(new String(jsonBytes, UTF_8))(JawnFacade)
+
+  @Benchmark
+  def jawnJsoniterScala(): JValue = readFromArray[JValue](jsonBytes)
 
   @Benchmark
   def jsoniterScala(): Seq[Tweet] = readFromArray[Seq[Tweet]](jsonBytes)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIWriting.scala
@@ -12,6 +12,7 @@ import com.github.plokhotnyuk.jsoniter_scala.benchmark.UPickleReaderWriters._
 import com.github.plokhotnyuk.jsoniter_scala.core._
 //import io.circe.syntax._
 import org.openjdk.jmh.annotations.Benchmark
+import org.typelevel.jawn.ast.FastRenderer
 //import spray.json._
 
 class TwitterAPIWriting extends TwitterAPIBenchmark {
@@ -31,6 +32,15 @@ class TwitterAPIWriting extends TwitterAPIBenchmark {
 */
   @Benchmark
   def jacksonScala(): Array[Byte] = jacksonMapper.writeValueAsBytes(obj)
+
+  @Benchmark
+  def jawnCompact(): Array[Byte] = FastRenderer.render(jValue).getBytes(UTF_8)
+
+  @Benchmark
+  def jawnJsoniterScalaCompact(): Array[Byte] = writeToArray(jValue)
+
+  @Benchmark
+  def jawnJsoniterScalaPretty(): Array[Byte] = writeToArray(jValue, WriterConfig.withIndentionStep(2))
 
   @Benchmark
   def jsoniterScala(): Array[Byte] = writeToArray(obj)


### PR DESCRIPTION
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                       Mode  Cnt      Score      Error  Units
[info] TwitterAPIReading.jawnByteBufferParser         thrpt    5  16641.767 ± 1695.585  ops/s
[info] TwitterAPIReading.jawnJsoniterScala            thrpt    5  32285.656 ± 1031.747  ops/s
[info] TwitterAPIReading.jawnStringParser             thrpt    5  19002.116 ± 1222.220  ops/s
[info] TwitterAPIWriting.jawnCompact                  thrpt    5  12356.264 ± 1087.366  ops/s
[info] TwitterAPIWriting.jawnJsoniterScalaCompact     thrpt    5  44700.379 ± 1969.862  ops/s
[info] TwitterAPIWriting.jawnJsoniterScalaPretty      thrpt    5  40087.147 ± 2933.002  ops/s
```