### PR TITLE
Declare Map.Builder as val, not var (to avoid warning)

### DIFF
--- a/jsoniter-scala-macros/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
+++ b/jsoniter-scala-macros/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
@@ -1223,7 +1223,7 @@ object JsonCodecMaker {
         } else if (tpe <:< typeOf[collection.Map[_, _]]) withDecoderFor(methodKey, default) {
           val tpe1 = typeArg1(tpe)
           val tpe2 = typeArg2(tpe)
-          val newBuilder = q"var x = ${collectionCompanion(tpe)}.newBuilder[$tpe1, $tpe2]"
+          val newBuilder = q"val x = ${collectionCompanion(tpe)}.newBuilder[$tpe1, $tpe2]"
           val readVal2 = genReadVal(tpe2 :: types, nullValue(tpe2 :: types), isStringified)
           if (cfg.mapAsArray) {
             val readVal1 = genReadVal(tpe1 :: types, nullValue(tpe1 :: types), isStringified)


### PR DESCRIPTION
after upgrading from 2.1.2 to 2.1.4 macro generated code started to produce  the following warning

`Error:(16, 39) local var x in method d2 is never updated: consider using immutable val`

i think that was introduced in https://github.com/plokhotnyuk/jsoniter-scala/commit/1ac15f68a18cdc5599e12d1062721a2248050a7a