### PR TITLE
UUID.fromString improvements

### DIFF
--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsBenchmark.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsBenchmark.scala
@@ -9,6 +9,8 @@ abstract class ArrayOfUUIDsBenchmark extends CommonParams {
   @Param(Array("1", "10", "100", "1000", "10000", "100000", "1000000"))
   var size: Int = 1000
   var obj: Array[UUID] = _
+  var strings: Array[String] = _
+  var res: Array[UUID] = _
   var jsonString: String = _
   var jsonBytes: Array[Byte] = _
   var preallocatedBuf: Array[Byte] = _
@@ -16,6 +18,8 @@ abstract class ArrayOfUUIDsBenchmark extends CommonParams {
   @Setup
   def setup(): Unit = {
     obj = (1 to size).map(i => new UUID(i * 6971258582664805397L, i * 6971258582664805397L)).toArray
+    strings = obj.map(_.toString)
+    res = new Array[UUID](size)
     jsonString = obj.mkString("[\"", "\",\"", "\"]")
     jsonBytes = jsonString.getBytes(UTF_8)
     preallocatedBuf = new Array[Byte](jsonBytes.length + 100/*to avoid possible out of bounds error*/)

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReading.scala
@@ -49,4 +49,101 @@ class ArrayOfUUIDsReading extends ArrayOfUUIDsBenchmark {
 
   @Benchmark
   def weePickle(): Array[UUID] = FromJson(jsonBytes).transform(ToScala[Array[UUID]])
+
+  @Benchmark
+  def javaCopy(): Array[UUID] = {
+    val len = res.length
+    var i = 0
+    while (i < len) {
+      res(i) = obj(i)
+      i += 1
+    }
+    res
+  }
+
+  @Benchmark
+  def javaOrig(): Array[UUID] = {
+    val len = res.length
+    var i = 0
+    while (i < len) {
+      res(i) = UUID.fromString(strings(i))
+      i += 1
+    }
+    res
+  }
+
+  @Benchmark
+  def javaFast(): Array[UUID] = {
+    val len = res.length
+    var i = 0
+    while (i < len) {
+      res(i) = fromString(strings(i))
+      i += 1
+    }
+    res
+  }
+
+  def fromString(name: String): UUID = {
+    val ns = nibbles
+    var msb, lsb = 0L
+    if (name.length == 36 && {
+      val ch1: Long = name.charAt(8)
+      val ch2: Long = name.charAt(13)
+      val ch3: Long = name.charAt(18)
+      val ch4: Long = name.charAt(23)
+      (ch1 << 48 | ch2 << 32 | ch3 << 16 | ch4) == 0x2D002D002D002DL
+    } && {
+      val msb1 = parse4Nibbles(name, ns, 0)
+      val msb2 = parse4Nibbles(name, ns, 4)
+      val msb3 = parse4Nibbles(name, ns, 9)
+      val msb4 = parse4Nibbles(name, ns, 14)
+      msb = msb1 << 48 | msb2 << 32 | msb3 << 16 | msb4
+      (msb1 | msb2 | msb3 | msb4) >= 0
+    } && {
+      val lsb1 = parse4Nibbles(name, ns, 19)
+      val lsb2 = parse4Nibbles(name, ns, 24)
+      val lsb3 = parse4Nibbles(name, ns, 28)
+      val lsb4 = parse4Nibbles(name, ns, 32)
+      lsb = lsb1 << 48 | lsb2 << 32 | lsb3 << 16 | lsb4
+      (lsb1 | lsb2 | lsb3 | lsb4) >= 0
+    }) new UUID(msb, lsb)
+    else UUID.fromString(name)
+  }
+
+  private[this] def parse4Nibbles(name: String, ns: Array[Byte], pos: Int): Long = {
+    val ch1 = name.charAt(pos)
+    val ch2 = name.charAt(pos + 1)
+    val ch3 = name.charAt(pos + 2)
+    val ch4 = name.charAt(pos + 3)
+    if ((ch1 | ch2 | ch3 | ch4) > 0xFF) -1
+    else ns(ch1) << 12 | ns(ch2) << 8 | ns(ch3) << 4 | ns(ch4)
+  }
+
+  private final val nibbles: Array[Byte] = {
+    val ns = new Array[Byte](256)
+    java.util.Arrays.fill(ns, -1: Byte)
+    ns('0') = 0
+    ns('1') = 1
+    ns('2') = 2
+    ns('3') = 3
+    ns('4') = 4
+    ns('5') = 5
+    ns('6') = 6
+    ns('7') = 7
+    ns('8') = 8
+    ns('9') = 9
+    ns('A') = 10
+    ns('B') = 11
+    ns('C') = 12
+    ns('D') = 13
+    ns('E') = 14
+    ns('F') = 15
+    ns('a') = 10
+    ns('b') = 11
+    ns('c') = 12
+    ns('d') = 13
+    ns('e') = 14
+    ns('f') = 15
+    ns
+  }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReadingSpec.scala
@@ -13,6 +13,9 @@ class ArrayOfUUIDsReadingSpec extends BenchmarkSpecBase {
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
+      benchmark.javaCopy() shouldBe benchmark.obj
+      benchmark.javaOrig() shouldBe benchmark.obj
+      benchmark.javaFast() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj


### PR DESCRIPTION
Bellow are results of benchmarks on Core i7 7700HQ.

## JDK 15
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                           (size)   Mode  Cnt        Score     Error  Units
[info] ArrayOfUUIDsReading.javaCopy                          1000  thrpt    5  1566340.140 ± 502.992  ops/s
[info] ArrayOfUUIDsReading.javaCopy:CPI                      1000  thrpt             0.255             #/op
[info] ArrayOfUUIDsReading.javaCopy:L1-dcache-load-misses    1000  thrpt             1.225             #/op
[info] ArrayOfUUIDsReading.javaCopy:L1-dcache-loads          1000  thrpt          1018.986             #/op
[info] ArrayOfUUIDsReading.javaCopy:L1-dcache-stores         1000  thrpt          1991.333             #/op
[info] ArrayOfUUIDsReading.javaCopy:L1-icache-load-misses    1000  thrpt             0.125             #/op
[info] ArrayOfUUIDsReading.javaCopy:LLC-load-misses          1000  thrpt             0.077             #/op
[info] ArrayOfUUIDsReading.javaCopy:LLC-loads                1000  thrpt             0.133             #/op
[info] ArrayOfUUIDsReading.javaCopy:LLC-store-misses         1000  thrpt             0.001             #/op
[info] ArrayOfUUIDsReading.javaCopy:LLC-stores               1000  thrpt             0.009             #/op
[info] ArrayOfUUIDsReading.javaCopy:branch-misses            1000  thrpt             1.173             #/op
[info] ArrayOfUUIDsReading.javaCopy:branches                 1000  thrpt           272.213             #/op
[info] ArrayOfUUIDsReading.javaCopy:cycles                   1000  thrpt          2168.260             #/op
[info] ArrayOfUUIDsReading.javaCopy:dTLB-load-misses         1000  thrpt             0.006             #/op
[info] ArrayOfUUIDsReading.javaCopy:dTLB-loads               1000  thrpt          1016.183             #/op
[info] ArrayOfUUIDsReading.javaCopy:dTLB-store-misses        1000  thrpt             0.001             #/op
[info] ArrayOfUUIDsReading.javaCopy:dTLB-stores              1000  thrpt          1987.329             #/op
[info] ArrayOfUUIDsReading.javaCopy:iTLB-load-misses         1000  thrpt             0.001             #/op
[info] ArrayOfUUIDsReading.javaCopy:iTLB-loads               1000  thrpt             0.006             #/op
[info] ArrayOfUUIDsReading.javaCopy:instructions             1000  thrpt          8498.627             #/op
[info] ArrayOfUUIDsReading.javaFast                          1000  thrpt    5    25947.447 ±  96.424  ops/s
[info] ArrayOfUUIDsReading.javaFast:CPI                      1000  thrpt             0.290             #/op
[info] ArrayOfUUIDsReading.javaFast:L1-dcache-load-misses    1000  thrpt          1900.055             #/op
[info] ArrayOfUUIDsReading.javaFast:L1-dcache-loads          1000  thrpt         99377.902             #/op
[info] ArrayOfUUIDsReading.javaFast:L1-dcache-stores         1000  thrpt         23182.381             #/op
[info] ArrayOfUUIDsReading.javaFast:L1-icache-load-misses    1000  thrpt            35.205             #/op
[info] ArrayOfUUIDsReading.javaFast:LLC-load-misses          1000  thrpt            14.328             #/op
[info] ArrayOfUUIDsReading.javaFast:LLC-loads                1000  thrpt            27.819             #/op
[info] ArrayOfUUIDsReading.javaFast:LLC-store-misses         1000  thrpt            17.921             #/op
[info] ArrayOfUUIDsReading.javaFast:LLC-stores               1000  thrpt            55.201             #/op
[info] ArrayOfUUIDsReading.javaFast:branch-misses            1000  thrpt             4.053             #/op
[info] ArrayOfUUIDsReading.javaFast:branches                 1000  thrpt         90352.742             #/op
[info] ArrayOfUUIDsReading.javaFast:cycles                   1000  thrpt        131195.580             #/op
[info] ArrayOfUUIDsReading.javaFast:dTLB-load-misses         1000  thrpt             7.910             #/op
[info] ArrayOfUUIDsReading.javaFast:dTLB-loads               1000  thrpt         99799.245             #/op
[info] ArrayOfUUIDsReading.javaFast:dTLB-store-misses        1000  thrpt             0.047             #/op
[info] ArrayOfUUIDsReading.javaFast:dTLB-stores              1000  thrpt         23367.313             #/op
[info] ArrayOfUUIDsReading.javaFast:iTLB-load-misses         1000  thrpt             0.099             #/op
[info] ArrayOfUUIDsReading.javaFast:iTLB-loads               1000  thrpt             0.254             #/op
[info] ArrayOfUUIDsReading.javaFast:instructions             1000  thrpt        452592.770             #/op
[info] ArrayOfUUIDsReading.javaOrig                          1000  thrpt    5     9324.637 ±  76.135  ops/s
[info] ArrayOfUUIDsReading.javaOrig:CPI                      1000  thrpt             0.288             #/op
[info] ArrayOfUUIDsReading.javaOrig:L1-dcache-load-misses    1000  thrpt          2025.178             #/op
[info] ArrayOfUUIDsReading.javaOrig:L1-dcache-loads          1000  thrpt        241176.340             #/op
[info] ArrayOfUUIDsReading.javaOrig:L1-dcache-stores         1000  thrpt         61482.397             #/op
[info] ArrayOfUUIDsReading.javaOrig:L1-icache-load-misses    1000  thrpt            79.012             #/op
[info] ArrayOfUUIDsReading.javaOrig:LLC-load-misses          1000  thrpt            20.031             #/op
[info] ArrayOfUUIDsReading.javaOrig:LLC-loads                1000  thrpt            55.923             #/op
[info] ArrayOfUUIDsReading.javaOrig:LLC-store-misses         1000  thrpt            31.936             #/op
[info] ArrayOfUUIDsReading.javaOrig:LLC-stores               1000  thrpt            89.111             #/op
[info] ArrayOfUUIDsReading.javaOrig:branch-misses            1000  thrpt            10.249             #/op
[info] ArrayOfUUIDsReading.javaOrig:branches                 1000  thrpt        249536.874             #/op
[info] ArrayOfUUIDsReading.javaOrig:cycles                   1000  thrpt        364721.205             #/op
[info] ArrayOfUUIDsReading.javaOrig:dTLB-load-misses         1000  thrpt             9.378             #/op
[info] ArrayOfUUIDsReading.javaOrig:dTLB-loads               1000  thrpt        240166.748             #/op
[info] ArrayOfUUIDsReading.javaOrig:dTLB-store-misses        1000  thrpt             0.112             #/op
[info] ArrayOfUUIDsReading.javaOrig:dTLB-stores              1000  thrpt         62141.889             #/op
[info] ArrayOfUUIDsReading.javaOrig:iTLB-load-misses         1000  thrpt             0.883             #/op
[info] ArrayOfUUIDsReading.javaOrig:iTLB-loads               1000  thrpt             1.925             #/op
[info] ArrayOfUUIDsReading.javaOrig:instructions             1000  thrpt       1265057.458             #/op
```
## GraalVM CE 20.1-dev Java 11 with -Dgraal.UseBranchesWithin32ByteBoundary=true
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                           (size)   Mode  Cnt        Score     Error  Units
[info] ArrayOfUUIDsReading.javaCopy                          1000  thrpt    5  1338953.694 ± 345.888  ops/s
[info] ArrayOfUUIDsReading.javaCopy:CPI                      1000  thrpt             0.213             #/op
[info] ArrayOfUUIDsReading.javaCopy:L1-dcache-load-misses    1000  thrpt             0.739             #/op
[info] ArrayOfUUIDsReading.javaCopy:L1-dcache-loads          1000  thrpt          1029.316             #/op
[info] ArrayOfUUIDsReading.javaCopy:L1-dcache-stores         1000  thrpt          2015.946             #/op
[info] ArrayOfUUIDsReading.javaCopy:L1-icache-load-misses    1000  thrpt             0.064             #/op
[info] ArrayOfUUIDsReading.javaCopy:LLC-load-misses          1000  thrpt             0.116             #/op
[info] ArrayOfUUIDsReading.javaCopy:LLC-loads                1000  thrpt             0.159             #/op
[info] ArrayOfUUIDsReading.javaCopy:LLC-store-misses         1000  thrpt             0.005             #/op
[info] ArrayOfUUIDsReading.javaCopy:LLC-stores               1000  thrpt             0.072             #/op
[info] ArrayOfUUIDsReading.javaCopy:branch-misses            1000  thrpt             1.155             #/op
[info] ArrayOfUUIDsReading.javaCopy:branches                 1000  thrpt          2997.273             #/op
[info] ArrayOfUUIDsReading.javaCopy:cycles                   1000  thrpt          2564.171             #/op
[info] ArrayOfUUIDsReading.javaCopy:dTLB-load-misses         1000  thrpt             0.002             #/op
[info] ArrayOfUUIDsReading.javaCopy:dTLB-loads               1000  thrpt          1031.945             #/op
[info] ArrayOfUUIDsReading.javaCopy:dTLB-store-misses        1000  thrpt            ≈ 10⁻⁴             #/op
[info] ArrayOfUUIDsReading.javaCopy:dTLB-stores              1000  thrpt          2004.193             #/op
[info] ArrayOfUUIDsReading.javaCopy:iTLB-load-misses         1000  thrpt            ≈ 10⁻⁴             #/op
[info] ArrayOfUUIDsReading.javaCopy:instructions             1000  thrpt         12032.364             #/op
[info] ArrayOfUUIDsReading.javaFast                          1000  thrpt    5    34158.198 ± 345.920  ops/s
[info] ArrayOfUUIDsReading.javaFast:CPI                      1000  thrpt             0.237             #/op
[info] ArrayOfUUIDsReading.javaFast:L1-dcache-load-misses    1000  thrpt          1899.787             #/op
[info] ArrayOfUUIDsReading.javaFast:L1-dcache-loads          1000  thrpt        119133.840             #/op
[info] ArrayOfUUIDsReading.javaFast:L1-dcache-stores         1000  thrpt         46048.208             #/op
[info] ArrayOfUUIDsReading.javaFast:L1-icache-load-misses    1000  thrpt             9.170             #/op
[info] ArrayOfUUIDsReading.javaFast:LLC-load-misses          1000  thrpt            11.883             #/op
[info] ArrayOfUUIDsReading.javaFast:LLC-loads                1000  thrpt            22.172             #/op
[info] ArrayOfUUIDsReading.javaFast:LLC-store-misses         1000  thrpt            28.462             #/op
[info] ArrayOfUUIDsReading.javaFast:LLC-stores               1000  thrpt            71.982             #/op
[info] ArrayOfUUIDsReading.javaFast:branch-misses            1000  thrpt             5.314             #/op
[info] ArrayOfUUIDsReading.javaFast:branches                 1000  thrpt         44432.540             #/op
[info] ArrayOfUUIDsReading.javaFast:cycles                   1000  thrpt        100548.367             #/op
[info] ArrayOfUUIDsReading.javaFast:dTLB-load-misses         1000  thrpt             8.236             #/op
[info] ArrayOfUUIDsReading.javaFast:dTLB-loads               1000  thrpt        118949.122             #/op
[info] ArrayOfUUIDsReading.javaFast:dTLB-store-misses        1000  thrpt             0.064             #/op
[info] ArrayOfUUIDsReading.javaFast:dTLB-stores              1000  thrpt         46239.626             #/op
[info] ArrayOfUUIDsReading.javaFast:iTLB-load-misses         1000  thrpt             0.212             #/op
[info] ArrayOfUUIDsReading.javaFast:iTLB-loads               1000  thrpt             0.546             #/op
[info] ArrayOfUUIDsReading.javaFast:instructions             1000  thrpt        423657.440             #/op
[info] ArrayOfUUIDsReading.javaOrig                          1000  thrpt    5    12801.416 ± 430.552  ops/s
[info] ArrayOfUUIDsReading.javaOrig:CPI                      1000  thrpt             0.228             #/op
[info] ArrayOfUUIDsReading.javaOrig:L1-dcache-load-misses    1000  thrpt          1989.368             #/op
[info] ArrayOfUUIDsReading.javaOrig:L1-dcache-loads          1000  thrpt        135610.330             #/op
[info] ArrayOfUUIDsReading.javaOrig:L1-dcache-stores         1000  thrpt         43292.899             #/op
[info] ArrayOfUUIDsReading.javaOrig:L1-icache-load-misses    1000  thrpt            52.342             #/op
[info] ArrayOfUUIDsReading.javaOrig:LLC-load-misses          1000  thrpt            13.719             #/op
[info] ArrayOfUUIDsReading.javaOrig:LLC-loads                1000  thrpt            23.901             #/op
[info] ArrayOfUUIDsReading.javaOrig:LLC-store-misses         1000  thrpt            16.356             #/op
[info] ArrayOfUUIDsReading.javaOrig:LLC-stores               1000  thrpt            55.335             #/op
[info] ArrayOfUUIDsReading.javaOrig:branch-misses            1000  thrpt            20.082             #/op
[info] ArrayOfUUIDsReading.javaOrig:branches                 1000  thrpt        279228.754             #/op
[info] ArrayOfUUIDsReading.javaOrig:cycles                   1000  thrpt        268660.568             #/op
[info] ArrayOfUUIDsReading.javaOrig:dTLB-load-misses         1000  thrpt             8.241             #/op
[info] ArrayOfUUIDsReading.javaOrig:dTLB-loads               1000  thrpt        135119.651             #/op
[info] ArrayOfUUIDsReading.javaOrig:dTLB-store-misses        1000  thrpt             0.309             #/op
[info] ArrayOfUUIDsReading.javaOrig:dTLB-stores              1000  thrpt         43326.363             #/op
[info] ArrayOfUUIDsReading.javaOrig:iTLB-load-misses         1000  thrpt             0.415             #/op
[info] ArrayOfUUIDsReading.javaOrig:iTLB-loads               1000  thrpt             1.514             #/op
[info] ArrayOfUUIDsReading.javaOrig:instructions             1000  thrpt       1180127.443             #/op
```