### PR TITLE
sjson-new benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,6 +129,7 @@ lazy val `jsoniter-scala-benchmark` = project
     resolvers += "Rally Health" at "https://dl.bintray.com/rallyhealth/maven",
     crossScalaVersions := Seq("2.13.1", "2.12.11"),
     libraryDependencies ++= Seq(
+      "com.eed3si9n" %% "sjson-new-scalajson" % "0.8.3",
       "com.rallyhealth" %% "weepickle-v1" % "1.0.1",
       "io.bullet" %% "borer-derivation" % "1.5.0",
       "pl.iterators" %% "kebs-spray-json" % "1.7.1",
@@ -143,7 +144,7 @@ lazy val `jsoniter-scala-benchmark` = project
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.11.0.rc1",
       "io.circe" %% "circe-generic-extras" % "0.13.0",
       "io.circe" %% "circe-generic" % "0.13.0",
-      "io.circe" %% "circe-parser" % "0.13.0",
+      "io.circe" %% "circe-parser" % "0.13.0" exclude("org.typelevel", s"jawn-parser_${scalaBinaryVersion.value}"),
       "com.typesafe.play" %% "play-json" % "2.8.1",
       "org.julienrf" %% "play-json-derived-codecs" % "7.0.0",
       "ai.x" %% "play-json-extensions" % "0.42.0",

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTReading.scala
@@ -47,4 +47,11 @@ class ADTReading extends ADTBenchmark {
 
   @Benchmark
   def weePickle(): ADTBase = FromJson(jsonBytes).transform(ToScala[ADTBase])
+
+  @Benchmark
+  def sjson(): ADTBase = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[ADTBase](Parser.parseFromByteArray(jsonBytes).get)
+  } 
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTWriting.scala
@@ -50,4 +50,11 @@ class ADTWriting extends ADTBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansReading.scala
@@ -51,4 +51,11 @@ class ArrayBufferOfBooleansReading extends ArrayBufferOfBooleansBenchmark {
 
   @Benchmark
   def weePickle(): mutable.ArrayBuffer[Boolean] = FromJson(jsonBytes).transform(ToScala[mutable.ArrayBuffer[Boolean]])
+
+  @Benchmark
+  def sjson(): mutable.ArrayBuffer[Boolean] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[mutable.ArrayBuffer[Boolean]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansWriting.scala
@@ -50,4 +50,11 @@ class ArrayBufferOfBooleansWriting extends ArrayBufferOfBooleansBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsReading.scala
@@ -51,4 +51,10 @@ class ArrayOfBigDecimalsReading extends ArrayOfBigDecimalsBenchmark {
   @Benchmark
   def weePickle(): Array[BigDecimal] = FromJson(jsonBytes).transform(ToScala[Array[BigDecimal]])
 */
+  @Benchmark
+  def sjson(): Array[BigDecimal] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[BigDecimal]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsWriting.scala
@@ -51,4 +51,10 @@ class ArrayOfBigDecimalsWriting extends ArrayOfBigDecimalsBenchmark {
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
 */
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsReading.scala
@@ -49,4 +49,11 @@ class ArrayOfBigIntsReading extends ArrayOfBigIntsBenchmark {
 
   @Benchmark
   def weePickle(): Array[BigInt] = FromJson(jsonBytes).transform(ToScala[Array[BigInt]])
+
+  @Benchmark
+  def sjson(): Array[BigInt] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[BigInt]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsWriting.scala
@@ -53,4 +53,10 @@ class ArrayOfBigIntsWriting extends ArrayOfBigIntsBenchmark {
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
 */
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReading.scala
@@ -50,4 +50,11 @@ class ArrayOfBooleansReading extends ArrayOfBooleansBenchmark {
 
   @Benchmark
   def weePickle(): Array[Boolean] = FromJson(jsonBytes).transform(ToScala[Array[Boolean]])
+
+  @Benchmark
+  def sjson(): Array[Boolean] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[Boolean]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansWriting.scala
@@ -54,4 +54,11 @@ class ArrayOfBooleansWriting extends ArrayOfBooleansBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReading.scala
@@ -50,4 +50,11 @@ class ArrayOfBytesReading extends ArrayOfBytesBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromJson(jsonBytes).transform(ToScala[Array[Byte]])
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[Byte]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesWriting.scala
@@ -54,4 +54,11 @@ class ArrayOfBytesWriting extends ArrayOfBytesBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj)(WeePickleFromTos.fromNonBinaryByteArray).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsReading.scala
@@ -48,4 +48,11 @@ class ArrayOfCharsReading extends ArrayOfCharsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Char] = FromJson(jsonBytes).transform(ToScala[Array[Char]])
+
+  @Benchmark
+  def sjson(): Array[Char] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[Char]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsWriting.scala
@@ -52,4 +52,11 @@ class ArrayOfCharsWriting extends ArrayOfCharsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReading.scala
@@ -50,4 +50,11 @@ class ArrayOfDoublesReading extends ArrayOfDoublesBenchmark {
 
   @Benchmark
   def weePickle(): Array[Double] = FromJson(jsonBytes).transform(ToScala[Array[Double]])
+
+  @Benchmark
+  def sjson(): Array[Double] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[Double]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesWriting.scala
@@ -53,4 +53,11 @@ class ArrayOfDoublesWriting extends ArrayOfDoublesBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsReading.scala
@@ -36,4 +36,11 @@ class ArrayOfDurationsReading extends ArrayOfDurationsBenchmark {
 
   @Benchmark
   def uPickle(): Array[Duration] = read[Array[Duration]](jsonBytes)
+
+  @Benchmark
+  def sjson(): Array[Duration] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[Duration]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsWriting.scala
@@ -39,4 +39,11 @@ class ArrayOfDurationsWriting extends ArrayOfDurationsBenchmark {
 
   @Benchmark
   def uPickle(): Array[Byte] = write(obj).getBytes(UTF_8)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsReading.scala
@@ -51,4 +51,11 @@ class ArrayOfEnumADTsReading extends ArrayOfEnumADTsBenchmark {
 
   @Benchmark
   def weePickle(): Array[SuitADT] = FromJson(jsonBytes).transform(ToScala[Array[SuitADT]])
+
+  @Benchmark
+  def sjson(): Array[SuitADT] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[SuitADT]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsWriting.scala
@@ -54,4 +54,11 @@ class ArrayOfEnumADTsWriting extends ArrayOfEnumADTsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsReading.scala
@@ -48,4 +48,11 @@ class ArrayOfEnumsReading extends ArrayOfEnumsBenchmark {
 
   @Benchmark
   def weePickle(): Array[SuitEnum] = FromJson(jsonBytes).transform(ToScala[Array[SuitEnum]])
+
+  @Benchmark
+  def sjson(): Array[SuitEnum] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[SuitEnum]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsWriting.scala
@@ -50,4 +50,11 @@ class ArrayOfEnumsWriting extends ArrayOfEnumsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReading.scala
@@ -53,4 +53,10 @@ class ArrayOfFloatsReading extends ArrayOfFloatsBenchmark {
   @Benchmark
   def weePickle(): Array[Float] = FromJson(jsonBytes).transform(ToScala[Array[Float]])
 */
+  @Benchmark
+  def sjson(): Array[Float] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[Float]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsWriting.scala
@@ -56,4 +56,11 @@ class ArrayOfFloatsWriting extends ArrayOfFloatsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReading.scala
@@ -41,4 +41,11 @@ class ArrayOfInstantsReading extends ArrayOfInstantsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Instant] = FromJson(jsonBytes).transform(ToScala[Array[Instant]])
+
+  @Benchmark
+  def sjson(): Array[Instant] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[Instant]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsWriting.scala
@@ -44,4 +44,11 @@ class ArrayOfInstantsWriting extends ArrayOfInstantsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReading.scala
@@ -50,4 +50,11 @@ class ArrayOfIntsReading extends ArrayOfIntsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Int] = FromJson(jsonBytes).transform(ToScala[Array[Int]])
+
+  @Benchmark
+  def sjson(): Array[Int] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[Int]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsWriting.scala
@@ -54,4 +54,11 @@ class ArrayOfIntsWriting extends ArrayOfIntsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsReading.scala
@@ -54,4 +54,11 @@ class ArrayOfJavaEnumsReading extends ArrayOfJavaEnumsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Suit] = FromJson(jsonBytes).transform(ToScala[Array[Suit]])
+
+  @Benchmark
+  def sjson(): Array[Suit] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[Suit]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReading.scala
@@ -50,4 +50,11 @@ class ArrayOfLongsReading extends ArrayOfLongsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Long] = FromJson(jsonBytes).transform(ToScala[Array[Long]])
+
+  @Benchmark
+  def sjson(): Array[Long] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[Long]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsWriting.scala
@@ -54,4 +54,11 @@ class ArrayOfLongsWriting extends ArrayOfLongsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReading.scala
@@ -50,4 +50,11 @@ class ArrayOfShortsReading extends ArrayOfShortsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Short] = FromJson(jsonBytes).transform(ToScala[Array[Short]])
+
+  @Benchmark
+  def sjson(): Array[Short] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[Short]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsWriting.scala
@@ -54,4 +54,11 @@ class ArrayOfShortsWriting extends ArrayOfShortsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReading.scala
@@ -49,4 +49,11 @@ class ArrayOfUUIDsReading extends ArrayOfUUIDsBenchmark {
 
   @Benchmark
   def weePickle(): Array[UUID] = FromJson(jsonBytes).transform(ToScala[Array[UUID]])
+
+  @Benchmark
+  def sjson(): Array[UUID] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Array[UUID]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsWriting.scala
@@ -52,4 +52,11 @@ class ArrayOfUUIDsWriting extends ArrayOfUUIDsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalReading.scala
@@ -48,4 +48,11 @@ class BigDecimalReading extends BigDecimalBenchmark {
 
   @Benchmark
   def weePickle(): BigDecimal = FromJson(jsonBytes).transform(ToScala[BigDecimal])
+
+  @Benchmark
+  def sjson(): BigDecimal = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[BigDecimal](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalWriting.scala
@@ -50,4 +50,10 @@ class BigDecimalWriting extends BigDecimalBenchmark {
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
 */
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntReading.scala
@@ -47,4 +47,11 @@ class BigIntReading extends BigIntBenchmark {
 
   @Benchmark
   def weePickle(): BigInt = FromJson(jsonBytes).transform(ToScala[BigInt])
+
+  @Benchmark
+  def sjson(): BigInt = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[BigInt](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntWriting.scala
@@ -51,4 +51,11 @@ class BigIntWriting extends BigIntBenchmark {
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
 */
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BitSetReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BitSetReading.scala
@@ -33,4 +33,11 @@ class BitSetReading extends BitSetBenchmark {
 
   @Benchmark
   def playJson(): BitSet = Json.parse(jsonBytes).as[BitSet](bitSetFormat)
+
+  @Benchmark
+  def sjson(): BitSet = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[BitSet](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BitSetWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BitSetWriting.scala
@@ -35,4 +35,11 @@ class BitSetWriting extends BitSetBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReading.scala
@@ -48,4 +48,11 @@ class GeoJSONReading extends GeoJSONBenchmark {
 
   @Benchmark
   def weePickle(): GeoJSON = FromJson(jsonBytes).transform(ToScala[GeoJSON])
+
+  @Benchmark
+  def sjson(): GeoJSON = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[GeoJSON](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWriting.scala
@@ -50,4 +50,11 @@ class GeoJSONWriting extends GeoJSONBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIReading.scala
@@ -36,4 +36,11 @@ class GitHubActionsAPIReading extends GitHubActionsAPIBenchmark {
 
   @Benchmark
   def weePickle(): GitHubActionsAPI.Response = FromJson(jsonBytes).transform(ToScala[GitHubActionsAPI.Response])
+
+  @Benchmark
+  def sjson(): GitHubActionsAPI.Response = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[GitHubActionsAPI.Response](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIWriting.scala
@@ -36,4 +36,11 @@ class GitHubActionsAPIWriting extends GitHubActionsAPIBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansReading.scala
@@ -35,4 +35,11 @@ class IntMapOfBooleansReading extends IntMapOfBooleansBenchmark {
 
   @Benchmark
   def playJson(): IntMap[Boolean] = Json.parse(jsonBytes).as[IntMap[Boolean]]
+
+  @Benchmark
+  def sjson(): IntMap[Boolean] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[IntMap[Boolean]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansWriting.scala
@@ -35,4 +35,11 @@ class IntMapOfBooleansWriting extends IntMapOfBooleansBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReading.scala
@@ -50,4 +50,11 @@ class IntReading extends IntBenchmark {
 
   @Benchmark
   def weePickle(): Int = FromJson(jsonBytes).transform(ToScala[Int])
+
+  @Benchmark
+  def sjson(): Int = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Int](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntWriting.scala
@@ -52,4 +52,11 @@ class IntWriting extends IntBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReading.scala
@@ -46,4 +46,11 @@ class ListOfBooleansReading extends ListOfBooleansBenchmark {
 
   @Benchmark
   def weePickle(): List[Boolean] = FromJson(jsonBytes).transform(ToScala[List[Boolean]])
+
+  @Benchmark
+  def sjson(): List[Boolean] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[List[Boolean]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansWriting.scala
@@ -50,4 +50,11 @@ class ListOfBooleansWriting extends ListOfBooleansBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansReading.scala
@@ -43,4 +43,10 @@ class MapOfIntsToBooleansReading extends MapOfIntsToBooleansBenchmark {
   @Benchmark
   def uPickle(): Map[Int, Boolean] = read[Map[Int, Boolean]](jsonBytes)
 */
+  @Benchmark
+  def sjson(): Map[Int, Boolean] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Map[Int, Boolean]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansWriting.scala
@@ -45,4 +45,11 @@ class MapOfIntsToBooleansWriting extends MapOfIntsToBooleansBenchmark {
   @Benchmark
   def uPickle(): Array[Byte] = write(obj).getBytes(UTF_8)
 */
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MissingRequiredFieldsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MissingRequiredFieldsReading.scala
@@ -123,4 +123,15 @@ class MissingRequiredFieldsReading extends CommonParams {
     } catch {
       case ex: com.rallyhealth.weepickle.v1.core.TransformException => ex.getMessage
     }
+
+  @Benchmark
+  def sjson(): String = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    try {
+      Converter.fromJsonUnsafe[MissingRequiredFields](Parser.parseFromByteArray(jsonBytes).get).toString // toString() should not be called
+    } catch {
+      case ex: sjsonnew.DeserializationException => ex.getMessage
+    }
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableBitSetReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableBitSetReading.scala
@@ -33,4 +33,11 @@ class MutableBitSetReading extends MutableBitSetBenchmark {
 
   @Benchmark
   def playJson(): mutable.BitSet = Json.parse(jsonBytes).as[mutable.BitSet]
+
+  @Benchmark
+  def sjson(): mutable.BitSet = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[mutable.BitSet](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableBitSetWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableBitSetWriting.scala
@@ -35,4 +35,11 @@ class MutableBitSetWriting extends MutableBitSetBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansReading.scala
@@ -35,4 +35,11 @@ class MutableLongMapOfBooleansReading extends MutableLongMapOfBooleansBenchmark 
 
   @Benchmark
   def playJson(): mutable.LongMap[Boolean] = Json.parse(jsonBytes).as[mutable.LongMap[Boolean]]
+
+  @Benchmark
+  def sjson(): mutable.LongMap[Boolean] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[mutable.LongMap[Boolean]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansWriting.scala
@@ -35,4 +35,11 @@ class MutableLongMapOfBooleansWriting extends MutableLongMapOfBooleansBenchmark 
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansReading.scala
@@ -34,4 +34,11 @@ class MutableMapOfIntsToBooleansReading extends MutableMapOfIntsToBooleansBenchm
 
   @Benchmark
   def playJson(): mutable.Map[Int, Boolean] = Json.parse(jsonBytes).as[mutable.Map[Int, Boolean]]
+
+  @Benchmark
+  def sjson(): mutable.Map[Int, Boolean] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[mutable.Map[Int, Boolean]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansWriting.scala
@@ -34,4 +34,11 @@ class MutableMapOfIntsToBooleansWriting extends MutableMapOfIntsToBooleansBenchm
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsReading.scala
@@ -43,4 +43,11 @@ class MutableSetOfIntsReading extends MutableSetOfIntsBenchmark {
 
   @Benchmark
   def weePickle(): mutable.Set[Int] = FromJson(jsonBytes).transform(ToScala[mutable.Set[Int]])
+
+  @Benchmark
+  def sjson(): mutable.Set[Int] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[mutable.Set[Int]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsWriting.scala
@@ -45,4 +45,11 @@ class MutableSetOfIntsWriting extends MutableSetOfIntsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReading.scala
@@ -51,4 +51,11 @@ class NestedStructsReading extends NestedStructsBenchmark {
 
   @Benchmark
   def weePickle(): NestedStructs = FromJson(jsonBytes).transform(ToScala[NestedStructs])
+
+  @Benchmark
+  def sjson(): NestedStructs = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[NestedStructs](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsWriting.scala
@@ -53,4 +53,11 @@ class NestedStructsWriting extends NestedStructsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReading.scala
@@ -51,4 +51,11 @@ class PrimitivesReading extends PrimitivesBenchmark {
 
   @Benchmark
   def weePickle(): Primitives = FromJson(jsonBytes).transform(ToScala[Primitives])
+
+  @Benchmark
+  def sjson(): Primitives = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Primitives](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesWriting.scala
@@ -54,4 +54,11 @@ class PrimitivesWriting extends PrimitivesBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SJsonEncodersDecoders.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SJsonEncodersDecoders.scala
@@ -1,0 +1,415 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import java.nio.ByteBuffer
+import java.time.{Duration, Instant}
+import java.util.Base64
+
+import com.github.plokhotnyuk.jsoniter_scala.benchmark.BitMask.toBitMask
+import com.github.plokhotnyuk.jsoniter_scala.benchmark.GeoJSON.SimpleGeometry
+import org.typelevel.jawn.SupportParser
+import sjsonnew._
+
+import scala.collection.immutable.{BitSet, IndexedSeq, IntMap}
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.util.Try
+
+object SJsonEncodersDecoders extends BasicJsonProtocol {
+//  val printer: Printer = Printer.noSpaces.copy(dropNullValues = true, reuseWriters = true, predictSize = true)
+//  val prettyPrinter: Printer = Printer.spaces2.copy(dropNullValues = true, reuseWriters = true, predictSize = true)
+//  val escapingPrinter: Printer = printer.copy(escapeNonAscii = true)
+//  implicit val config: Configuration = Configuration.default.withDefaults.withDiscriminator("type")
+  implicit val adtSjsonFormat: JsonFormat[ADTBase] = new JsonFormat[ADTBase]() {
+    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): ADTBase = jsOpt match {
+      case Some(js) =>
+        unbuilder.beginObject(js)
+        val tpe = unbuilder.readField[String]("type")
+        val result = tpe match {
+          case "X" =>
+            val a = unbuilder.readField[Int]("a")
+            X(a)
+          case "Y" =>
+            val b = unbuilder.readField[String]("b")
+            Y(b)
+          case "Z" =>
+            val l = unbuilder.readField[ADTBase]("l")
+            val r = unbuilder.readField[ADTBase]("r")
+            Z(l, r)
+          case t => 
+            deserializationError(s"Unexpected type $tpe")
+        }
+        unbuilder.endObject()
+        result
+      case None =>
+        deserializationError("Expected JsObject but found None")
+    }
+  
+    override def write[J](obj: ADTBase, builder: Builder[J]): Unit = {
+      builder.beginObject()
+      obj match {
+        case X(a) =>
+          builder.addField("type", "X")
+          builder.addField("a", a)
+        case Y(b) =>
+          builder.addField("type", "Y")
+          builder.addField("b", b)
+        case Z(l, r) =>
+          builder.addField("type", "Z")
+          builder.addField("l", l)
+          builder.addField("r", r)
+      }
+      builder.endObject()
+    }
+  }
+
+  implicit val durationSjsonFormat: JsonFormat[Duration] = projectFormat((d: Duration) => d.toString, Duration.parse)
+  implicit val instantSjsonFormat: JsonFormat[Instant] = projectFormat((d: Instant) => d.toString, Instant.parse)
+  
+  implicit val arrayBufferSjsonFormat: RootJsonFormat[ArrayBuffer[Boolean]] = viaSeq[mutable.ArrayBuffer[Boolean], Boolean](s => mutable.ArrayBuffer(s :_*))
+//  implicit val anyValsC3c: Codec[AnyVals] = {
+//    implicit def valueClassEncoder[A <: AnyVal : UnwrappedEncoder]: Encoder[A] = implicitly
+//
+//    implicit def valueClassDecoder[A <: AnyVal : UnwrappedDecoder]: Decoder[A] = implicitly
+//
+//    deriveConfiguredCodec[AnyVals]
+//  }
+//  val (base64D5r: Decoder[Array[Byte]], base64E5r: Encoder[Array[Byte]]) =
+//    (Decoder.decodeString.map[Array[Byte]](Base64.getDecoder.decode),
+//      Encoder.encodeString.contramap[Array[Byte]](Base64.getEncoder.encodeToString))
+//  implicit val bidRequestC3c: Codec[OpenRTB.BidRequest] = {
+//
+//    deriveConfiguredCodec[OpenRTB.BidRequest]
+//  }
+//  implicit val bigIntE5r: Encoder[BigInt] = encodeJsonNumber
+//    .contramap(x => JsonNumber.fromDecimalStringUnsafe(new java.math.BigDecimal(x.bigInteger).toPlainString))
+  implicit val bitSetSjsonFormat: JsonFormat[BitSet] = projectFormat((b: BitSet) => b.toArray[Int], (arr: Array[Int]) => BitSet.fromBitMaskNoCopy(toBitMask(arr, Int.MaxValue /* WARNING: It is unsafe an option for open systems */)))
+//  implicit val (bitSetD5r: Decoder[BitSet], bitSetE5r: Encoder[BitSet]) =
+//    (Decoder.decodeArray[Int].map(arr => BitSet.fromBitMaskNoCopy(toBitMask(arr, Int.MaxValue /* WARNING: It is unsafe an option for open systems */))),
+//      Encoder.encodeSet[Int].contramapArray((m: BitSet) => m))
+implicit val mutableBitSetSjsonFormat: JsonFormat[mutable.BitSet] = projectFormat((b: mutable.BitSet) => b.toArray[Int], (arr: Array[Int]) => mutable.BitSet.fromBitMaskNoCopy(toBitMask(arr, Int.MaxValue /* WARNING: It is unsafe an option for open systems */)))
+//  implicit val (mutableBitSetD5r: Decoder[mutable.BitSet], mutableBitSetE5r: Encoder[mutable.BitSet]) =
+//    (Decoder.decodeArray[Int].map(arr => mutable.BitSet.fromBitMaskNoCopy(toBitMask(arr, Int.MaxValue /* WARNING: It is unsafe an option for open systems */))),
+//      Encoder.encodeSeq[Int].contramapArray((m: mutable.BitSet) => m.toVector))
+//  implicit val distanceMatrixC3c: Codec[GoogleMapsAPI.DistanceMatrix] = {
+//
+//    deriveConfiguredCodec[GoogleMapsAPI.DistanceMatrix]
+//  }
+//  implicit val gitHubActionsAPIC3c: Codec[GitHubActionsAPI.Response] = {
+//    implicit val c1: Codec[GitHubActionsAPI.Artifact] =
+//    Codec.forProduct9("id", "node_id", "name", "size_in_bytes", "url", "archive_download_url",
+//      "expired", "created_at", "expires_at") {
+//      (id: Long, node_id: String, name: String, size_in_bytes: Long, url: String, archive_download_url: String,
+//      expired: String, created_at: Instant, expired_at: Instant) =>
+//        GitHubActionsAPI.Artifact(id, node_id, name, size_in_bytes, url, archive_download_url,
+//          expired.toBoolean, created_at, expired_at)
+//    } { a =>
+//      (a.id, a.node_id, a.name, a.size_in_bytes, a.url, a.archive_download_url,
+//      a.expired.toString, a.created_at, a.expires_at)
+//    }
+//    deriveConfiguredCodec[GitHubActionsAPI.Response]
+//  }
+//  implicit val extractFieldsC3c: Codec[ExtractFields] = deriveConfiguredCodec[ExtractFields]
+//  implicit val geoJSONC3c: Codec[GeoJSON.GeoJSON] = {
+//    implicit val c1: Codec[GeoJSON.SimpleGeometry] = deriveConfiguredCodec[GeoJSON.SimpleGeometry]
+//    implicit val c2: Codec[GeoJSON.Geometry] = deriveConfiguredCodec[GeoJSON.Geometry]
+//    implicit val c3: Codec[GeoJSON.SimpleGeoJSON] = deriveConfiguredCodec[GeoJSON.SimpleGeoJSON]
+//    deriveConfiguredCodec[GeoJSON.GeoJSON]
+//  }
+implicit val gitHubActionsAPISjsonFormat: JsonFormat[GitHubActionsAPI.Response] = {
+  implicit val jf1: RootJsonFormat[GitHubActionsAPI.Artifact] = new RootJsonFormat[GitHubActionsAPI.Artifact] {
+    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): GitHubActionsAPI.Artifact = jsOpt match {
+      case Some(js) =>
+        unbuilder.beginObject(js)
+        val a = GitHubActionsAPI.Artifact(
+          unbuilder.readField[Long]("id"),
+          unbuilder.readField[String]("node_id"),
+          unbuilder.readField[String]("name"),
+          unbuilder.readField[Long]("size_in_bytes"),
+          unbuilder.readField[String]("url"),
+          unbuilder.readField[String]("archive_download_url"),
+          unbuilder.readField[String]("expired").toBoolean,
+          unbuilder.readField[Instant]("created_at"),
+          unbuilder.readField[Instant]("expires_at")
+        )
+        unbuilder.endObject()
+        a
+      case None =>
+        deserializationError("Expected JsObject but found None")
+        
+    }
+
+    override def write[J](obj: GitHubActionsAPI.Artifact, builder: Builder[J]): Unit = {
+      builder.beginObject()
+      builder.addField("id", obj.id)
+      builder.addField("node_id", obj.node_id)
+      builder.addField("name", obj.name)
+      builder.addField("size_in_bytes", obj.size_in_bytes)
+      builder.addField("url", obj.url)
+      builder.addField("archive_download_url", obj.archive_download_url)
+      builder.addField("expired", obj.expired.toString)
+      builder.addField("created_at", obj.created_at.toString)
+      builder.addField("expires_at", obj.expires_at.toString)
+      builder.endObject()
+    }
+  }
+  isolistFormat(LList.iso(
+    { p: GitHubActionsAPI.Response => ("total_count", p.total_count) :*: ("artifacts", p.artifacts) :*: LNil },
+    { in: Int :*: Seq[GitHubActionsAPI.Artifact] :*: LNil => GitHubActionsAPI.Response(in.head, in.tail.head) }
+  ))
+}
+  def readADT[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): String = jsOpt match {
+    case Some(js) =>
+      unbuilder.beginPreObject(js)
+      val tpe = unbuilder.lookupField("type") match {
+        case Some(value) => unbuilder.readString(value)
+        case None => deserializationError("Field not found: type")
+      }
+      unbuilder.endPreObject()
+      tpe
+    case None => deserializationError("Expected JsObject but found None")
+  }
+  def writeADT[J, T <: Product](obj: T, builder: Builder[J]): T = {
+    builder.beginPreObject()
+    builder.addField("type", obj.productPrefix)
+    builder.endPreObject()
+    obj
+  }
+  implicit val geoJSONSjsonFormat: RootJsonFormat[GeoJSON.GeoJSON] = {
+    implicit lazy val jf1: JsonFormat[GeoJSON.Point] = isolistFormat(LList.iso(
+      { p: GeoJSON.Point => ("coordinates", p.coordinates) :*: LNil },
+      { in: (Double, Double) :*: LNil => GeoJSON.Point(in.head) }
+    ))
+    implicit lazy val jf2: JsonFormat[GeoJSON.MultiPoint] = isolistFormat(LList.iso(
+      { p: GeoJSON.MultiPoint => ("coordinates", p.coordinates) :*: LNil },
+      { in: IndexedSeq[(Double, Double)] :*: LNil => GeoJSON.MultiPoint(in.head) }
+    ))
+    implicit lazy val jf3: JsonFormat[GeoJSON.LineString] = isolistFormat(LList.iso(
+      { p: GeoJSON.LineString => ("coordinates", p.coordinates) :*: LNil },
+      { in: IndexedSeq[(Double, Double)] :*: LNil => GeoJSON.LineString(in.head) }
+    ))
+    implicit lazy val jf4: JsonFormat[GeoJSON.MultiLineString] = isolistFormat(LList.iso(
+      { p: GeoJSON.MultiLineString => ("coordinates", p.coordinates) :*: LNil },
+      { in: IndexedSeq[IndexedSeq[(Double, Double)]] :*: LNil => GeoJSON.MultiLineString(in.head) }
+    ))
+    implicit lazy val jf5: JsonFormat[GeoJSON.Polygon] = new RootJsonFormat[GeoJSON.Polygon] {
+      override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): GeoJSON.Polygon = jsOpt match {
+        case Some(js) =>
+          unbuilder.beginObject(js)
+          val f = GeoJSON.Polygon(
+            unbuilder.readField[IndexedSeq[IndexedSeq[(Double, Double)]]]("coordinates")
+          )
+          unbuilder.endObject()
+          f
+        case None => deserializationError("Expected JsObject but found None")
+      }
+      override def write[J](obj: GeoJSON.Polygon, builder: Builder[J]): Unit = {
+        builder.beginObject()
+        builder.addField("coordinates", obj.coordinates)
+        builder.endObject()
+      }
+    }
+    implicit lazy val jf6: JsonFormat[GeoJSON.MultiPolygon] = isolistFormat(LList.iso(
+      { p: GeoJSON.MultiPolygon => ("coordinates", p.coordinates) :*: LNil },
+      { in: IndexedSeq[IndexedSeq[IndexedSeq[(Double, Double)]]] :*: LNil => GeoJSON.MultiPolygon(in.head) }
+    ))
+    implicit lazy val jf7: RootJsonFormat[GeoJSON.SimpleGeometry] = new RootJsonFormat[GeoJSON.SimpleGeometry] {
+      override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): GeoJSON.SimpleGeometry = readADT(jsOpt, unbuilder) match {
+        case "Point" => jsonReader[GeoJSON.Point].read(jsOpt, unbuilder)
+        case "MultiPoint" => jsonReader[GeoJSON.MultiPoint].read(jsOpt, unbuilder)
+        case "LineString" => jsonReader[GeoJSON.LineString].read(jsOpt, unbuilder)
+        case "MultiLineString" => jsonReader[GeoJSON.MultiLineString].read(jsOpt, unbuilder)
+        case "Polygon" => jsonReader[GeoJSON.Polygon].read(jsOpt, unbuilder)
+        case "MultiPolygon" => jsonReader[GeoJSON.MultiPolygon].read(jsOpt, unbuilder)
+      }
+
+      override def write[J](obj: GeoJSON.SimpleGeometry, builder: Builder[J]): Unit = writeADT(obj, builder) match {
+        case x: GeoJSON.Point => jsonWriter[GeoJSON.Point].write(x, builder)
+        case x: GeoJSON.MultiPoint => jsonWriter[GeoJSON.MultiPoint].write(x, builder)
+        case x: GeoJSON.LineString => jsonWriter[GeoJSON.LineString].write(x, builder)
+        case x: GeoJSON.MultiLineString => jsonWriter[GeoJSON.MultiLineString].write(x, builder)
+        case x: GeoJSON.Polygon => jsonWriter[GeoJSON.Polygon].write(x, builder)
+        case x: GeoJSON.MultiPolygon => jsonWriter[GeoJSON.MultiPolygon].write(x, builder)
+      }
+      
+      
+    }
+    implicit lazy val jf8: JsonFormat[GeoJSON.GeometryCollection] = isolistFormat(LList.iso(
+      { p: GeoJSON.GeometryCollection => ("geometries", p.geometries) :*: LNil },
+      { in: IndexedSeq[GeoJSON.SimpleGeometry] :*: LNil => GeoJSON.GeometryCollection(in.head) }
+    ))
+    implicit lazy val jf9: RootJsonFormat[GeoJSON.Geometry] = new RootJsonFormat[GeoJSON.Geometry] {
+      override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): GeoJSON.Geometry = readADT(jsOpt, unbuilder) match {
+        case "Point" => jsonReader[GeoJSON.Point].read(jsOpt, unbuilder)
+        case "MultiPoint" => jsonReader[GeoJSON.MultiPoint].read(jsOpt, unbuilder)
+        case "LineString" => jsonReader[GeoJSON.LineString].read(jsOpt, unbuilder)
+        case "MultiLineString" => jsonReader[GeoJSON.MultiLineString].read(jsOpt, unbuilder)
+        case "Polygon" => jsonReader[GeoJSON.Polygon].read(jsOpt, unbuilder)
+        case "MultiPolygon" => jsonReader[GeoJSON.MultiPolygon].read(jsOpt, unbuilder)
+        case "GeometryCollection" => jsonReader[GeoJSON.GeometryCollection].read(jsOpt, unbuilder)
+      }
+
+      override def write[J](obj: GeoJSON.Geometry, builder: Builder[J]): Unit = writeADT(obj, builder) match {
+        case x: GeoJSON.Point => jsonWriter[GeoJSON.Point].write(x, builder)
+        case x: GeoJSON.MultiPoint => jsonWriter[GeoJSON.MultiPoint].write(x, builder)
+        case x: GeoJSON.LineString => jsonWriter[GeoJSON.LineString].write(x, builder)
+        case x: GeoJSON.MultiLineString => jsonWriter[GeoJSON.MultiLineString].write(x, builder)
+        case x: GeoJSON.Polygon => jsonWriter[GeoJSON.Polygon].write(x, builder)
+        case x: GeoJSON.MultiPolygon => jsonWriter[GeoJSON.MultiPolygon].write(x, builder)
+        case x: GeoJSON.GeometryCollection => jsonWriter[GeoJSON.GeometryCollection].write(x, builder)
+      }
+    }
+    implicit lazy val jf10: JsonFormat[GeoJSON.Feature] = new RootJsonFormat[GeoJSON.Feature] {
+      override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): GeoJSON.Feature = jsOpt match {
+        case Some(js) =>
+          unbuilder.beginObject(js)
+          val f = GeoJSON.Feature(
+            unbuilder.readField[Map[String, String]]("properties"),
+            unbuilder.readField[GeoJSON.Geometry]("geometry"),
+            unbuilder.readField[Option[(Double, Double, Double, Double)]]("bbox")
+          )
+          unbuilder.endObject()
+          f
+        case None => deserializationError("Expected JsObject but found None")
+      }
+      override def write[J](obj: GeoJSON.Feature, builder: Builder[J]): Unit = {
+        builder.beginObject()
+        builder.addField("properties", obj.properties)
+        builder.addField("geometry", obj.geometry)
+        builder.addField("bbox", obj.bbox)
+        builder.endObject()
+      }
+    }
+    implicit lazy val jf12: RootJsonFormat[GeoJSON.SimpleGeoJSON] = new RootJsonFormat[GeoJSON.SimpleGeoJSON] {
+      override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): GeoJSON.SimpleGeoJSON = readADT(jsOpt, unbuilder) match {
+        case "Feature" => jsonReader[GeoJSON.Feature].read(jsOpt, unbuilder)
+      }
+
+      override def write[J](obj: GeoJSON.SimpleGeoJSON, builder: Builder[J]): Unit = writeADT(obj, builder) match {
+        case x: GeoJSON.Feature => jsonWriter[GeoJSON.Feature].write(x, builder)
+      }
+    }
+    implicit lazy val jf13: RootJsonFormat[GeoJSON.FeatureCollection] = new RootJsonFormat[GeoJSON.FeatureCollection] {
+      override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): GeoJSON.FeatureCollection = jsOpt match {
+        case Some(js) => 
+          unbuilder.beginObject(js)
+          val f = GeoJSON.FeatureCollection(
+            unbuilder.readField[IndexedSeq[GeoJSON.SimpleGeoJSON]]("features"),
+            unbuilder.readField[Option[(Double, Double, Double, Double)]]("bbox")
+          )
+          unbuilder.endObject()
+          f
+        case None => deserializationError("Expected JsObject but found None")
+      }
+      override def write[J](obj: GeoJSON.FeatureCollection, builder: Builder[J]): Unit = {
+        builder.beginObject()
+        builder.addField("features", obj.features)
+        builder.addField("bbox", obj.bbox)
+        builder.endObject()
+      }
+    } 
+    implicit lazy val jf14: RootJsonFormat[GeoJSON.GeoJSON] = new RootJsonFormat[GeoJSON.GeoJSON] {
+      override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): GeoJSON.GeoJSON = readADT(jsOpt, unbuilder) match {
+        case "Feature" => jsonReader[GeoJSON.Feature].read(jsOpt, unbuilder)
+        case "FeatureCollection" => jsonReader[GeoJSON.FeatureCollection].read(jsOpt, unbuilder)
+      }
+
+      override def write[J](obj: GeoJSON.GeoJSON, builder: Builder[J]): Unit = writeADT(obj, builder) match {
+        case x: GeoJSON.Feature => jsonWriter[GeoJSON.Feature].write(x, builder)
+        case y: GeoJSON.FeatureCollection => jsonWriter[GeoJSON.FeatureCollection].write(y, builder)
+      }
+    }
+    jf14
+  }
+  implicit val intMapSjsonFormat: JsonFormat[IntMap[Boolean]] = projectFormat[IntMap[Boolean], Map[Int,Boolean]](identity, IntMap.from)
+//  implicit val (intMapD5r: Decoder[IntMap[Boolean]], intMapE5r: Encoder[IntMap[Boolean]]) =
+//    (Decoder.decodeMap[Int, Boolean].map(_.foldLeft(IntMap.empty[Boolean])((m, p) => m.updated(p._1, p._2))),
+//      Encoder.encodeMap[Int, Boolean].contramapObject((m: IntMap[Boolean]) => m))
+  /** Supplies the JsonFormat for mutable.Maps. */
+  implicit def mutableMapFormat[K: JsonKeyFormat, V: JsonFormat]: RootJsonFormat[mutable.Map[K, V]] = new RootJsonFormat[mutable.Map[K, V]] {
+    lazy val keyFormat = implicitly[JsonKeyFormat[K]]
+    lazy val valueFormat = implicitly[JsonFormat[V]]
+    def write[J](m: mutable.Map[K, V], builder: Builder[J]): Unit =
+    {
+      builder.beginObject()
+      m foreach {
+        case (k, v) =>
+          builder.writeString(keyFormat.write(k))
+          valueFormat.write(v, builder)
+      }
+      builder.endObject()
+    }
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): mutable.Map[K, V] =
+      jsOpt match {
+        case Some(js) =>
+          val size = unbuilder.beginObject(js)
+          val mapBuilder = mutable.Map.newBuilder[K, V]
+          mapBuilder.sizeHint(size)
+          (1 to size).toList map { _ =>
+            val (k, v) = unbuilder.nextFieldOpt
+            mapBuilder.addOne(
+              keyFormat.read(k) -> valueFormat.read(v, unbuilder)
+            )
+          }
+          unbuilder.endObject
+          mapBuilder.result()
+        case None => mutable.Map()
+      }
+  }
+  /** Supplies the JsonFormat for mutable.Sets. */
+  implicit def mutableSetFormat[T :JsonFormat]: RootJsonFormat[mutable.Set[T]]               = viaSeq[mutable.Set[T], T](seq => mutable.Set(seq :_*))
+  implicit val longMapSjsonFormat: JsonFormat[mutable.LongMap[Boolean]] = projectFormat[mutable.LongMap[Boolean], Map[Long,Boolean]](_.toMap, mutable.LongMap.from)
+//  implicit val (longMapD5r: Decoder[mutable.LongMap[Boolean]], longMapE5r: Encoder[mutable.LongMap[Boolean]]) =
+//    (Decoder.decodeMap[Long, Boolean].map(_.foldLeft(new mutable.LongMap[Boolean])((m, p) => m += (p._1, p._2))),
+//      Encoder.encodeMapLike[Long, Boolean, mutable.Map].contramapObject((m: mutable.LongMap[Boolean]) => m))
+  implicit lazy val MissingRequiredFieldsSjsonFormat: JsonFormat[MissingRequiredFields] = isolistFormat(LList.iso(
+    { p: MissingRequiredFields => ("s", p.s) :*: ("i", p.i) :*: LNil },
+    { in: String :*: Int :*: LNil => MissingRequiredFields(in.head, in.tail.head) }
+  ))
+//  implicit val missingRequiredFieldsC3c: Codec[MissingRequiredFields] = deriveConfiguredCodec[MissingRequiredFields]
+//  implicit lazy val NestedStructsSjsonFormat: JsonFormat[NestedStructs] = lazyFormat(isolistFormat(LList.iso(
+//    { p: NestedStructs => ("n", p.n) :*: LNil },
+//    { in: Option[NestedStructs] :*: LNil => NestedStructs(in.head) }
+//  )))
+  implicit lazy val NestedStructsSjsonFormat: JsonFormat[NestedStructs] = new RootJsonFormat[NestedStructs] {
+  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): NestedStructs = jsOpt match {
+    case Some(js) =>
+      unbuilder.beginObject(js)
+      val n = NestedStructs(unbuilder.readField[Option[NestedStructs]]("n"))
+      unbuilder.endObject()
+      n
+    case None =>
+      deserializationError("Expected JsObject but found None")
+  }
+  override def write[J](obj: NestedStructs, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("n", obj.n)
+    builder.endObject()
+  }
+}
+//  implicit val nestedStructsC3c: Codec[NestedStructs] = deriveConfiguredCodec[NestedStructs]
+  implicit val enumADTSjsonFormat: JsonFormat[SuitADT] = projectFormat((s: SuitADT) => s.toString, {
+    val suite = Map(
+      "Hearts" -> Hearts,
+      "Spades" -> Spades,
+      "Diamonds" -> Diamonds,
+      "Clubs" -> Clubs)
+    s: String => suite(s)
+  })
+//  implicit val (suitEnumDecoder: Decoder[SuitEnum.Value], suitEnumEncoder: Encoder[SuitEnum.Value]) =
+//    (decodeEnumeration(SuitEnum), encodeEnumeration(SuitEnum))
+  implicit val suitEnumSjsonFormat: JsonFormat[SuitEnum.Value] = projectFormat((s: SuitEnum.Value) => s.toString, SuitEnum.withName)
+  implicit val suitJavaEnumSjsonFormat: JsonFormat[Suit] = projectFormat((s: Suit) => s.toString, Suit.valueOf)
+  implicit lazy val PrimitivesSjsonFormat: JsonFormat[Primitives] = isolistFormat(LList.iso(
+    { p: Primitives => ("b", p.b) :*: ("s", p.s) :*: ("i", p.i) :*: ("l", p.l) :*: ("bl", p.bl) :*: ("ch", p.ch) :*: ("dbl", p.dbl) :*: ("f", p.f) :*: LNil },
+    { in: Byte :*: Short :*: Int :*: Long :*: Boolean :*: Char :*: Double :*: Float :*: LNil => Primitives(in.head, in.tail.head, in.tail.tail.head, in.tail.tail.tail.head, in.tail.tail.tail.tail.head, in.tail.tail.tail.tail.tail.head, in.tail.tail.tail.tail.tail.tail.head, in.tail.tail.tail.tail.tail.tail.tail.head) }
+  ))
+//  implicit val primitivesC3c: Codec[Primitives] = deriveConfiguredCodec[Primitives]
+//  implicit val tweetC3c: Codec[TwitterAPI.Tweet] = {
+//
+//    deriveConfiguredCodec[TwitterAPI.Tweet]
+//  }
+  
+  implicit class Jawn1SupportParser[J](private val Parser: SupportParser[J]) extends AnyVal {
+    def parseFromByteArray(byteArray: Array[Byte]) = Parser.parseFromByteBuffer(ByteBuffer.wrap(byteArray))
+  }
+}

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReading.scala
@@ -48,4 +48,11 @@ class SetOfIntsReading extends SetOfIntsBenchmark {
 
   @Benchmark
   def weePickle(): Set[Int] = FromJson(jsonBytes).transform(ToScala[Set[Int]])
+
+  @Benchmark
+  def sjson(): Set[Int] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Set[Int]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsWriting.scala
@@ -50,4 +50,11 @@ class SetOfIntsWriting extends SetOfIntsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReading.scala
@@ -49,4 +49,11 @@ class StringOfAsciiCharsReading extends StringOfAsciiCharsBenchmark {
 
   @Benchmark
   def weePickle(): String = FromJson(jsonBytes).transform(ToScala[String])
+
+  @Benchmark
+  def sjson(): String = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[String](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsWriting.scala
@@ -57,4 +57,11 @@ class StringOfAsciiCharsWriting extends StringOfAsciiCharsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReading.scala
@@ -48,4 +48,11 @@ class StringOfEscapedCharsReading extends StringOfEscapedCharsBenchmark {
 
   @Benchmark
   def weePickle(): String = FromJson(jsonBytes).transform(ToScala[String])
+
+  @Benchmark
+  def sjson(): String = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[String](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsWriting.scala
@@ -41,4 +41,11 @@ class StringOfEscapedCharsWriting extends StringOfEscapedCharsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToEscapedNonAsciiJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReading.scala
@@ -49,4 +49,11 @@ class StringOfNonAsciiCharsReading extends StringOfNonAsciiCharsBenchmark {
 
   @Benchmark
   def weePickle(): String = FromJson(jsonBytes).transform(ToScala[String])
+
+  @Benchmark
+  def sjson(): String = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[String](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsWriting.scala
@@ -57,4 +57,11 @@ class StringOfNonAsciiCharsWriting extends StringOfNonAsciiCharsBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReading.scala
@@ -46,4 +46,11 @@ class VectorOfBooleansReading extends VectorOfBooleansBenchmark {
 
   @Benchmark
   def weePickle(): Vector[Boolean] = FromJson(jsonBytes).transform(ToScala[Vector[Boolean]])
+
+  @Benchmark
+  def sjson(): Vector[Boolean] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    Converter.fromJsonUnsafe[Vector[Boolean]](Parser.parseFromByteArray(jsonBytes).get)
+  }
 }

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansWriting.scala
@@ -50,4 +50,11 @@ class VectorOfBooleansWriting extends VectorOfBooleansBenchmark {
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)
+
+  @Benchmark
+  def sjson(): Array[Byte] = {
+    import sjsonnew.support.scalajson.unsafe._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.SJsonEncodersDecoders._
+    CompactPrinter(Converter.toJsonUnsafe(obj)).getBytes(UTF_8)
+  }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTReadingSpec.scala
@@ -14,6 +14,8 @@ class ADTReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansReadingSpec.scala
@@ -17,6 +17,7 @@ class ArrayBufferOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsReadingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfBigIntsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReadingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReadingSpec.scala
@@ -19,6 +19,7 @@ class ArrayOfBytesReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsReadingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReadingSpec.scala
@@ -19,6 +19,7 @@ class ArrayOfDoublesReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsReadingSpec.scala
@@ -17,6 +17,7 @@ class ArrayOfEnumADTsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsReadingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfEnumsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReadingSpec.scala
@@ -35,6 +35,7 @@ class ArrayOfFloatsReadingSpec extends BenchmarkSpecBase {
       benchmark.uPickle() shouldBe benchmark.obj
       //FIXME: weePickle parses 1.199999988079071 as 1.2f instead of 1.1999999f
       //benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReadingSpec.scala
@@ -15,6 +15,7 @@ class ArrayOfInstantsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReadingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfIntsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsReadingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfJavaEnumsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReadingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfLongsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReadingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfShortsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReadingSpec.scala
@@ -17,6 +17,7 @@ class ArrayOfUUIDsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntReadingSpec.scala
@@ -18,6 +18,7 @@ class BigIntReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReadingSpec.scala
@@ -14,6 +14,7 @@ class GeoJSONReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIReadingSpec.scala
@@ -11,6 +11,7 @@ class GitHubActionsAPIReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReadingSpec.scala
@@ -16,6 +16,7 @@ class IntReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReadingSpec.scala
@@ -17,6 +17,7 @@ class ListOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsReadingSpec.scala
@@ -16,6 +16,7 @@ class MutableSetOfIntsReadingSpec extends BenchmarkSpecBase {
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReadingSpec.scala
@@ -18,6 +18,7 @@ class NestedStructsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReadingSpec.scala
@@ -16,6 +16,7 @@ class PrimitivesReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReadingSpec.scala
@@ -17,6 +17,7 @@ class SetOfIntsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReadingSpec.scala
@@ -18,6 +18,7 @@ class StringOfAsciiCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReadingSpec.scala
@@ -18,6 +18,7 @@ class StringOfEscapedCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReadingSpec.scala
@@ -18,6 +18,7 @@ class StringOfNonAsciiCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }

--- a/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReadingSpec.scala
@@ -17,6 +17,7 @@ class VectorOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
+      benchmark.sjson() shouldBe benchmark.obj
     }
   }
 }


### PR DESCRIPTION
#### Why benchmark sjson-new?

sjson-new is used in sbt, so I wanted to compare its performance with other JSON libraries

#### Current status:
Not all benchmarks were implemented, because sjson-new requires a lot of boilerplate do defines `Formats`. 
Besides I was blocked with incompatibilities with jawn 1.0 that circe uses...

That said the sjson benchmarks run, but the circe ones dont. However this work might be useful in the future if compatibilities are fixed...