### PR TITLE
How to improve serialization of float and double values

### DIFF
--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/DoubleToString.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/DoubleToString.scala
@@ -1,0 +1,50 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import org.openjdk.jmh.annotations.Benchmark
+
+class DoubleToString extends CommonParams {
+    private[this] val stringify: Double => String = {
+        import com.github.plokhotnyuk.jsoniter_scala.core._
+
+        new ThreadLocal[Array[Byte]] with JsonValueCodec[Double] with (Double => String) {
+            def apply(x: Double): String =
+                if (java.lang.Double.isFinite(x)) {
+                    val buf = get
+                    val len = writeToSubArray(x, buf, 0, 32)(this)
+                    new String(buf, 0, 0, len)
+                } else java.lang.Double.toString(x)
+
+            override def decodeValue(in: JsonReader, default: Double): Double = in.readDouble()
+
+            override def encodeValue(x: Double, out: JsonWriter): Unit = out.writeVal(x)
+
+            override def initialValue(): Array[Byte] = new Array[Byte](32)
+
+            override val nullValue: Double = 0.0
+        }
+    }
+
+    @Benchmark
+    def longMantissaBase(): String = java.lang.Double.toString(123456.7890123456)
+
+    @Benchmark
+    def longMantissaRyu(): String = stringify(123456.7890123456)
+
+    @Benchmark
+    def longWholeNumberBase(): String = java.lang.Double.toString(1234567890123456.0)
+
+    @Benchmark
+    def longWholeNumberRyu(): String = stringify(1234567890123456.0)
+
+    @Benchmark
+    def shortMantissaBase(): String = java.lang.Double.toString(1.2)
+
+    @Benchmark
+    def shortMantissaRyu(): String = stringify(1.2)
+
+    @Benchmark
+    def shortWholeNumberBase(): String = java.lang.Double.toString(12.0)
+
+    @Benchmark
+    def shortWholeNumberRyu(): String = stringify(12.0)
+}

--- a/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/FloatToString.scala
+++ b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/FloatToString.scala
@@ -1,0 +1,50 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import org.openjdk.jmh.annotations.Benchmark
+
+class FloatToString extends CommonParams {
+    private[this] val stringify: Float => String = {
+        import com.github.plokhotnyuk.jsoniter_scala.core._
+
+        new ThreadLocal[Array[Byte]] with JsonValueCodec[Float] with (Float => String) {
+            def apply(x: Float): String =
+                if (java.lang.Float.isFinite(x)) {
+                    val buf = get
+                    val len = writeToSubArray(x, buf, 0, 32)(this)
+                    new String(buf, 0, 0, len)
+                } else java.lang.Float.toString(x)
+
+            override def decodeValue(in: JsonReader, default: Float): Float = in.readFloat()
+
+            override def encodeValue(x: Float, out: JsonWriter): Unit = out.writeVal(x)
+
+            override def initialValue(): Array[Byte] = new Array[Byte](32)
+
+            override val nullValue: Float = 0.0f
+        }
+    }
+
+    @Benchmark
+    def longMantissaBase(): String = java.lang.Float.toString(123.45678f)
+
+    @Benchmark
+    def longMantissaRyu(): String = stringify(123.45678f)
+
+    @Benchmark
+    def longWholeNumberBase(): String = java.lang.Float.toString(12345678.0f)
+
+    @Benchmark
+    def longWholeNumberRyu(): String = stringify(12345678.0f)
+
+    @Benchmark
+    def shortMantissaBase(): String = java.lang.Float.toString(1.2f)
+
+    @Benchmark
+    def shortMantissaRyu(): String = stringify(1.2f)
+
+    @Benchmark
+    def shortWholeNumberBase(): String = java.lang.Float.toString(12.0f)
+
+    @Benchmark
+    def shortWholeNumberRyu(): String = stringify(12.0f)
+}


### PR DESCRIPTION
Results from my notebook with OpenJDK 15:
```
Benchmark                             Mode  Cnt         Score         Error  Units
DoubleToString.longMantissaBase      thrpt    5   3029140.651 ±    5806.226  ops/s
DoubleToString.longMantissaRyu       thrpt    5  14464040.818 ±   30401.037  ops/s
DoubleToString.longWholeNumberBase   thrpt    5  16901790.743 ±  741542.046  ops/s
DoubleToString.longWholeNumberRyu    thrpt    5  22583261.561 ± 1013234.063  ops/s
DoubleToString.shortMantissaBase     thrpt    5  13431961.226 ±   99752.260  ops/s
DoubleToString.shortMantissaRyu      thrpt    5  14176891.374 ±  307092.374  ops/s
DoubleToString.shortWholeNumberBase  thrpt    5  32248389.311 ±  211137.435  ops/s
DoubleToString.shortWholeNumberRyu   thrpt    5  38869686.702 ±  170191.015  ops/s
FloatToString.longMantissaBase       thrpt    5   8020357.600 ±   28396.935  ops/s
FloatToString.longMantissaRyu        thrpt    5  21429879.060 ±  377754.365  ops/s
FloatToString.longWholeNumberBase    thrpt    5  23464740.907 ±  523547.096  ops/s
FloatToString.longWholeNumberRyu     thrpt    5  27164462.667 ± 3252269.984  ops/s
FloatToString.shortMantissaBase      thrpt    5  19793453.886 ±  150084.467  ops/s
FloatToString.shortMantissaRyu       thrpt    5  23561108.080 ±  136225.344  ops/s
FloatToString.shortWholeNumberBase   thrpt    5  32149629.407 ±  312628.565  ops/s
FloatToString.shortWholeNumberRyu    thrpt    5  40079886.100 ±  408385.023  ops/s
```