### PR TITLE
Solution for @chetkhatri

### DIFF
--- a/jsoniter-scala-examples/build.sbt
+++ b/jsoniter-scala-examples/build.sbt
@@ -6,9 +6,9 @@ val `jsoniter-scala-examples` = project.in(file("."))
     mainClass in assembly := Some("com.github.plokhotnyuk.jsoniter_scala.examples.Example01"),
     libraryDependencies ++= Seq(
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "latest.integration",
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "latest.integration" % "compile-internal" // or "provided", but it is required only in compile-time
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "latest.integration" % "provided" // or "provided", but it is required only in compile-time
     ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 13)) => Seq("org.graalvm.nativeimage" % "svm" % "20.0.0" % "compile-internal") // or "provided", but it is required only in compile-time
+      case Some((2, 13)) => Seq("org.graalvm.nativeimage" % "svm" % "20.0.0" % "provided") // or "provided", but it is required only in compile-time
       case _ => Seq()
     }),
     assemblyShadeRules in assembly := Seq(

--- a/jsoniter-scala-examples/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/examples/Example01.scala
+++ b/jsoniter-scala-examples/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/examples/Example01.scala
@@ -7,17 +7,15 @@ import com.github.plokhotnyuk.jsoniter_scala.core._
   * Example of basic usage from README.md
   */
 object Example01 {
-  case class Device(id: Int, model: String)
-
-  case class User(name: String, devices: Seq[Device])
-
-  implicit val codec: JsonValueCodec[User] = JsonCodecMaker.make
-
   def main(args: Array[String]): Unit = {
-    val user = readFromArray("""{"name":"John","devices":[{"id":1,"model":"HTC One X"}]}""".getBytes("UTF-8"))
-    val json = writeToArray(User(name = "John", devices = Seq(Device(id = 2, model = "iPhone X"))))
+    case class Category(id: Int, name: String)
 
-    println(user)
-    println(new String(json, "UTF-8"))
+    case class Categories(categories: Seq[Category])
+
+    implicit val codec: JsonValueCodec[Categories] = JsonCodecMaker.make
+
+    val cats = readFromStream(System.in)
+
+    cats.categories.foreach(c => println(c.productIterator.mkString(", ")))
   }
 }


### PR DESCRIPTION
Command to run:
```
$ echo '{"categories": [ { "id": 28, "name": "Sports" }, { "id": 114, "name": "Football" } ]}' | java -jar target/scala-2.11/jsoniter-scala-examples-assembly-0.1.0-SNAPSHOT.jar
```
Expected output:
```
28, Sports
114, Football
```