### PR TITLE
Comparison of current Java vs. Ryū vs. Schubfach

### DIFF
--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/DoubleToString.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/DoubleToString.scala
@@ -1,0 +1,49 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import org.openjdk.jmh.annotations.Benchmark
+
+class DoubleToString extends CommonParams {
+  private[this] val stringify: Double => String = {
+    import com.github.plokhotnyuk.jsoniter_scala.core._
+
+    new ThreadLocal[Array[Byte]] with JsonValueCodec[Double] with (Double => String) {
+      def apply(x: Double): String = if (java.lang.Double.isFinite(x)) {
+        val buf = get
+        val len = writeToSubArray(x, buf, 0, 32)(this)
+        new String(buf, 0, 0, len)
+      } else java.lang.Double.toString(x)
+
+      override def decodeValue(in: JsonReader, default: Double): Double = in.readDouble()
+
+      override def encodeValue(x: Double, out: JsonWriter): Unit = out.writeVal(x)
+
+      override def initialValue(): Array[Byte] = new Array[Byte](32)
+
+      override val nullValue: Double = 0.0
+    }
+  }
+
+  @Benchmark
+  def longMantissaBase(): String = java.lang.Double.toString(123456.7890123456)
+
+  @Benchmark
+  def longMantissaRyu(): String = stringify(123456.7890123456)
+
+  @Benchmark
+  def longWholeNumberBase(): String = java.lang.Double.toString(1234567890123456.0)
+
+  @Benchmark
+  def longWholeNumberRyu(): String = stringify(1234567890123456.0)
+
+  @Benchmark
+  def shortMantissaBase(): String = java.lang.Double.toString(1.2)
+
+  @Benchmark
+  def shortMantissaRyu(): String = stringify(1.2)
+
+  @Benchmark
+  def shortWholeNumberBase(): String = java.lang.Double.toString(12.0)
+
+  @Benchmark
+  def shortWholeNumberRyu(): String = stringify(12.0)
+}

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/FloatToString.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/FloatToString.scala
@@ -1,0 +1,49 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import org.openjdk.jmh.annotations.Benchmark
+
+class FloatToString extends CommonParams {
+  private[this] val stringify: Float => String = {
+    import com.github.plokhotnyuk.jsoniter_scala.core._
+
+    new ThreadLocal[Array[Byte]] with JsonValueCodec[Float] with (Float => String) {
+      def apply(x: Float): String = if (java.lang.Float.isFinite(x)) {
+        val buf = get
+        val len = writeToSubArray(x, buf, 0, 32)(this)
+        new String(buf, 0, 0, len)
+      } else java.lang.Float.toString(x)
+
+      override def decodeValue(in: JsonReader, default: Float): Float = in.readFloat()
+
+      override def encodeValue(x: Float, out: JsonWriter): Unit = out.writeVal(x)
+
+      override def initialValue(): Array[Byte] = new Array[Byte](32)
+
+      override val nullValue: Float = 0.0f
+    }
+  }
+
+  @Benchmark
+  def longMantissaBase(): String = java.lang.Float.toString(123.45678f)
+
+  @Benchmark
+  def longMantissaRyu(): String = stringify(123.45678f)
+
+  @Benchmark
+  def longWholeNumberBase(): String = java.lang.Float.toString(12345678.0f)
+
+  @Benchmark
+  def longWholeNumberRyu(): String = stringify(12345678.0f)
+
+  @Benchmark
+  def shortMantissaBase(): String = java.lang.Float.toString(1.2f)
+
+  @Benchmark
+  def shortMantissaRyu(): String = stringify(1.2f)
+
+  @Benchmark
+  def shortWholeNumberBase(): String = java.lang.Float.toString(12.0f)
+
+  @Benchmark
+  def shortWholeNumberRyu(): String = stringify(12.0f)
+}

--- a/jsoniter-scala-core/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1853,8 +1853,10 @@ final class JsonWriter private[jsoniter_scala](
       } else if (ieeeExponent == 255) illegalNumberError(x)
       var decimalNotation = false
       var dv, exp, len = 0
-      if (e >= -23 && e <= 0 && multiplePowOf2(m, -e)) {
+      if (e >= -23 && e <= 0 && {
         dv = m >> -e
+        dv << -e == m
+      }) {
         len = offset(dv)
         exp += len
         len += 1
@@ -1901,7 +1903,7 @@ final class JsonWriter private[jsoniter_scala](
               dvIsTrailingZeros = true
               if ((mv & 0x7) == 0) dmIsTrailingZeros = mmShift != 1
               else dp -= 1
-            } else if (q < 31) dvIsTrailingZeros = multiplePowOf2(mv, q)
+            } else if (q < 31) dvIsTrailingZeros = mv >> q << q == mv
             f32Pow5Split
           }
         val s = ss(i)
@@ -2025,8 +2027,6 @@ final class JsonWriter private[jsoniter_scala](
     }
   }
 
-  private[this] def multiplePowOf2(q0: Int, q: Int): Boolean = (q0 & ((1 << q) - 1)) == 0
-
   @tailrec
   private[this] def multiplePowOf5(q0: Int, q: Int): Boolean = q match {
     case 0 => true
@@ -2059,8 +2059,10 @@ final class JsonWriter private[jsoniter_scala](
       var decimalNotation = false
       var dv = 0L
       var exp, len = 0
-      if (e >= -52 && e <= 0 && multiplePowOf2(m, -e)) {
+      if (e >= -52 && e <= 0 && {
         dv = m >> -e
+        dv << -e == m
+      }) {
         len = offset(dv)
         exp += len
         len += 1
@@ -2108,7 +2110,7 @@ final class JsonWriter private[jsoniter_scala](
               dvIsTrailingZeros = true
               if ((mv & 0x7) == 0) dmIsTrailingZeros = mmShift != 1
               else dp -= 1
-            } else if (q < 63) dvIsTrailingZeros = multiplePowOf2(mv, q)
+            } else if (q < 63) dvIsTrailingZeros = mv >> q << q == mv
             f64Pow5Split
           }
         i <<= 1
@@ -2245,8 +2247,6 @@ final class JsonWriter private[jsoniter_scala](
       }
     }
   }
-
-  private[this] def multiplePowOf2(q0: Long, q: Int): Boolean = (q0 & ((1L << q) - 1)) == 0
 
   @tailrec
   private[this] def multiplePowOf5(q0: Long, q: Int): Boolean = q match {

--- a/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1793,8 +1793,10 @@ final class JsonWriter private[jsoniter_scala](
       } else if (ieeeExponent == 255) illegalNumberError(x)
       var decimalNotation = false
       var dv, exp, len = 0
-      if (e >= -23 && e <= 0 && multiplePowOf2(m, -e)) {
+      if (e >= -23 && e <= 0 && {
         dv = m >> -e
+        dv << -e == m
+      }) {
         len = offset(dv)
         exp += len
         len += 1
@@ -1841,7 +1843,7 @@ final class JsonWriter private[jsoniter_scala](
               dvIsTrailingZeros = true
               if ((mv & 0x7) == 0) dmIsTrailingZeros = mmShift != 1
               else dp -= 1
-            } else if (q < 31) dvIsTrailingZeros = multiplePowOf2(mv, q)
+            } else if (q < 31) dvIsTrailingZeros = mv >> q << q == mv
             f32Pow5Split
           }
         val s = ss(i)
@@ -1965,8 +1967,6 @@ final class JsonWriter private[jsoniter_scala](
     }
   }
 
-  private[this] def multiplePowOf2(q0: Int, q: Int): Boolean = (q0 & ((1 << q) - 1)) == 0
-
   @tailrec
   private[this] def multiplePowOf5(q0: Int, q: Int): Boolean = q match {
     case 0 => true
@@ -1999,8 +1999,10 @@ final class JsonWriter private[jsoniter_scala](
       var decimalNotation = false
       var dv = 0L
       var exp, len = 0
-      if (e >= -52 && e <= 0 && multiplePowOf2(m, -e)) {
+      if (e >= -52 && e <= 0 && {
         dv = m >> -e
+        dv << -e == m
+      }) {
         len = offset(dv)
         exp += len
         len += 1
@@ -2048,7 +2050,7 @@ final class JsonWriter private[jsoniter_scala](
               dvIsTrailingZeros = true
               if ((mv & 0x7) == 0) dmIsTrailingZeros = mmShift != 1
               else dp -= 1
-            } else if (q < 63) dvIsTrailingZeros = multiplePowOf2(mv, q)
+            } else if (q < 63) dvIsTrailingZeros = mv >> q << q == mv
             f64Pow5Split
           }
         i <<= 1
@@ -2185,8 +2187,6 @@ final class JsonWriter private[jsoniter_scala](
       }
     }
   }
-
-  private[this] def multiplePowOf2(q0: Long, q: Int): Boolean = (q0 & ((1L << q) - 1)) == 0
 
   @tailrec
   private[this] def multiplePowOf5(q0: Long, q: Int): Boolean = q match {


### PR DESCRIPTION
## Ryū vs. current Java (Base) on JDK 15-ea, OpenJDK 64-Bit Server VM, 15-ea+24-1168
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                             Mode  Cnt         Score        Error  Units
[info] DoubleToString.longMantissaBase      thrpt   15   3898741.262 ±  75768.660  ops/s
[info] DoubleToString.longMantissaRyu       thrpt   15  15362834.199 ±  80649.851  ops/s
[info] DoubleToString.longWholeNumberBase   thrpt   15  16814379.488 ± 144662.917  ops/s
[info] DoubleToString.longWholeNumberRyu    thrpt   15  23354315.741 ± 360641.230  ops/s
[info] DoubleToString.shortMantissaBase     thrpt   15  16893375.094 ± 104092.441  ops/s
[info] DoubleToString.shortMantissaRyu      thrpt   15  16323874.060 ± 244468.344  ops/s
[info] DoubleToString.shortWholeNumberBase  thrpt   15  31595400.226 ± 148225.712  ops/s
[info] DoubleToString.shortWholeNumberRyu   thrpt   15  41622284.915 ± 349486.560  ops/s
[info] FloatToString.longMantissaBase       thrpt   15   8916129.475 ± 133570.438  ops/s
[info] FloatToString.longMantissaRyu        thrpt   15  22466620.689 ±  92966.538  ops/s
[info] FloatToString.longWholeNumberBase    thrpt   15  23200132.777 ± 308318.708  ops/s
[info] FloatToString.longWholeNumberRyu     thrpt   15  28666678.302 ± 562628.281  ops/s
[info] FloatToString.shortMantissaBase      thrpt   15  20854530.176 ± 234298.373  ops/s
[info] FloatToString.shortMantissaRyu       thrpt   15  24962751.542 ± 190572.914  ops/s
[info] FloatToString.shortWholeNumberBase   thrpt   15  31610280.223 ± 324878.715  ops/s
[info] FloatToString.shortWholeNumberRyu    thrpt   15  41828568.125 ± 591337.188  ops/s
```

```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                   (size)   Mode  Cnt       Score      Error  Units
[info] ArrayOfFloatsWriting.avSystemGenCodec          128  thrpt    5   71110.759 ±  667.615  ops/s
[info] ArrayOfFloatsWriting.borer                     128  thrpt    5   74395.842 ±  236.580  ops/s
[info] ArrayOfFloatsWriting.circe                     128  thrpt    5   76116.544 ± 3053.763  ops/s
[info] ArrayOfFloatsWriting.dslJsonScala              128  thrpt    5   93400.639 ±  404.054  ops/s
[info] ArrayOfFloatsWriting.jacksonScala              128  thrpt    5   79904.326 ±  455.392  ops/s
[info] ArrayOfFloatsWriting.jsoniterScala             128  thrpt    5  255225.465 ± 8260.645  ops/s
[info] ArrayOfFloatsWriting.jsoniterScalaPrealloc     128  thrpt    5  264756.564 ±  991.767  ops/s
[info] ArrayOfFloatsWriting.uPickle                   128  thrpt    5   62232.441 ±  260.310  ops/s
[info] ArrayOfFloatsWriting.weePickle                 128  thrpt    5   70881.941 ± 2113.837  ops/s
```

```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                    (size)   Mode  Cnt       Score      Error  Units
[info] ArrayOfDoublesWriting.avSystemGenCodec          128  thrpt    5   23700.098 ±  313.727  ops/s
[info] ArrayOfDoublesWriting.borer                     128  thrpt    5   23664.872 ±   79.361  ops/s
[info] ArrayOfDoublesWriting.circe                     128  thrpt    5   24433.572 ±  143.861  ops/s
[info] ArrayOfDoublesWriting.jacksonScala              128  thrpt    5   24513.045 ±   95.477  ops/s
[info] ArrayOfDoublesWriting.jsoniterScala             128  thrpt    5  136259.021 ±  448.082  ops/s
[info] ArrayOfDoublesWriting.jsoniterScalaPrealloc     128  thrpt    5  145601.115 ± 2861.360  ops/s
[info] ArrayOfDoublesWriting.uPickle                   128  thrpt    5   23016.571 ±  230.251  ops/s
[info] ArrayOfDoublesWriting.weePickle                 128  thrpt    5   23469.245 ±  183.072  ops/s
```

```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                              Mode  Cnt      Score     Error  Units
[info] GeoJSONWriting.avSystemGenCodec       thrpt    5   5111.158 ±  43.100  ops/s
[info] GeoJSONWriting.borer                  thrpt    5   5329.040 ±  34.210  ops/s
[info] GeoJSONWriting.circe                  thrpt    5   4307.485 ±  35.185  ops/s
[info] GeoJSONWriting.jacksonScala           thrpt    5   4395.271 ±  32.978  ops/s
[info] GeoJSONWriting.jsoniterScala          thrpt    5  16563.811 ± 135.429  ops/s
[info] GeoJSONWriting.jsoniterScalaPrealloc  thrpt    5  17440.522 ±  21.063  ops/s
[info] GeoJSONWriting.playJson               thrpt    5   1964.989 ±  26.762  ops/s
[info] GeoJSONWriting.sprayJson              thrpt    5   2970.917 ±  26.366  ops/s
[info] GeoJSONWriting.uPickle                thrpt    5   3968.329 ±  18.312  ops/s
[info] GeoJSONWriting.weePickle              thrpt    5   5121.702 ±  29.438  ops/s
```
## Ryū vs. Schubfach (Base) on JDK 15-internal, OpenJDK 64-Bit Server VM, 15-internal+0-adhoc.andriy.jdk, with [this](http://cr.openjdk.java.net/~bpb/4511638/webrev.04/) patch
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                             Mode  Cnt         Score         Error  Units
[info] DoubleToString.longMantissaBase      thrpt   15  17822085.186 ±  175418.511  ops/s
[info] DoubleToString.longMantissaRyu       thrpt   15  15348971.605 ±   75443.501  ops/s
[info] DoubleToString.longWholeNumberBase   thrpt   15  23082567.696 ±  714676.038  ops/s
[info] DoubleToString.longWholeNumberRyu    thrpt   15  23235422.519 ±  468317.968  ops/s
[info] DoubleToString.shortMantissaBase     thrpt   15  19863204.306 ±  102920.554  ops/s
[info] DoubleToString.shortMantissaRyu      thrpt   15  16401975.497 ±   80628.289  ops/s
[info] DoubleToString.shortWholeNumberBase  thrpt   15  26885730.486 ± 1032804.703  ops/s
[info] DoubleToString.shortWholeNumberRyu   thrpt   15  41618462.743 ±  308296.537  ops/s
[info] FloatToString.longMantissaBase       thrpt   15  22713667.299 ±  161471.154  ops/s
[info] FloatToString.longMantissaRyu        thrpt   15  22451876.932 ±  204380.176  ops/s
[info] FloatToString.longWholeNumberBase    thrpt   15  23409187.203 ±  181236.778  ops/s
[info] FloatToString.longWholeNumberRyu     thrpt   15  28757664.214 ±  393971.729  ops/s
[info] FloatToString.shortMantissaBase      thrpt   15  21283744.325 ±  105581.738  ops/s
[info] FloatToString.shortMantissaRyu       thrpt   15  24527084.474 ± 1004331.098  ops/s
[info] FloatToString.shortWholeNumberBase   thrpt   15  25632328.387 ±  286387.514  ops/s
[info] FloatToString.shortWholeNumberRyu    thrpt   15  41466167.061 ±  786103.186  ops/s
```

```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                   (size)   Mode  Cnt       Score       Error  Units
[info] ArrayOfFloatsWriting.avSystemGenCodec          128  thrpt    5   92030.568 ±  8140.723  ops/s
[info] ArrayOfFloatsWriting.borer                     128  thrpt    5  107715.751 ±  2906.360  ops/s
[info] ArrayOfFloatsWriting.circe                     128  thrpt    5   93419.196 ± 12207.080  ops/s
[info] ArrayOfFloatsWriting.dslJsonScala              128  thrpt    5  125542.224 ± 12016.273  ops/s
[info] ArrayOfFloatsWriting.jacksonScala              128  thrpt    5  109739.927 ± 13501.733  ops/s
[info] ArrayOfFloatsWriting.jsoniterScala             128  thrpt    5  247966.341 ± 30919.367  ops/s
[info] ArrayOfFloatsWriting.jsoniterScalaPrealloc     128  thrpt    5  259946.513 ± 16641.742  ops/s
[info] ArrayOfFloatsWriting.uPickle                   128  thrpt    5   76863.081 ±   275.084  ops/s
[info] ArrayOfFloatsWriting.weePickle                 128  thrpt    5   93072.588 ±  1245.157  ops/s
```

```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                    (size)   Mode  Cnt       Score      Error  Units
[info] ArrayOfDoublesWriting.avSystemGenCodec          128  thrpt    5   74748.881 ±  250.523  ops/s
[info] ArrayOfDoublesWriting.borer                     128  thrpt    5   76419.279 ±  481.689  ops/s
[info] ArrayOfDoublesWriting.circe                     128  thrpt    5   73646.844 ±  595.364  ops/s
[info] ArrayOfDoublesWriting.jacksonScala              128  thrpt    5   82152.465 ± 1644.854  ops/s
[info] ArrayOfDoublesWriting.jsoniterScala             128  thrpt    5  137496.360 ±  393.520  ops/s
[info] ArrayOfDoublesWriting.jsoniterScalaPrealloc     128  thrpt    5  139543.970 ±  613.696  ops/s
[info] ArrayOfDoublesWriting.uPickle                   128  thrpt    5   67969.805 ±  728.277  ops/s
[info] ArrayOfDoublesWriting.weePickle                 128  thrpt    5   75186.860 ±  400.975  ops/s
```

```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                              Mode  Cnt      Score     Error  Units
[info] GeoJSONWriting.avSystemGenCodec       thrpt    5  10597.577 ± 267.382  ops/s
[info] GeoJSONWriting.borer                  thrpt    5  10839.756 ± 497.362  ops/s
[info] GeoJSONWriting.circe                  thrpt    5   7253.812 ±  20.146  ops/s
[info] GeoJSONWriting.jacksonScala           thrpt    5   8290.606 ± 280.383  ops/s
[info] GeoJSONWriting.jsoniterScala          thrpt    5  17273.010 ± 151.218  ops/s
[info] GeoJSONWriting.jsoniterScalaPrealloc  thrpt    5  17375.654 ±  59.879  ops/s
[info] GeoJSONWriting.playJson               thrpt    5   2407.529 ±  37.257  ops/s
[info] GeoJSONWriting.sprayJson              thrpt    5   4170.374 ±  24.920  ops/s
[info] GeoJSONWriting.uPickle                thrpt    5   6524.880 ±  33.366  ops/s
[info] GeoJSONWriting.weePickle              thrpt    5   9892.991 ± 350.411  ops/s
```