### PR TITLE
Update ToString benchmarks for the Schubfach algorithm

### DIFF
--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/DoubleToString.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/DoubleToString.scala
@@ -1,0 +1,49 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import org.openjdk.jmh.annotations.Benchmark
+
+class DoubleToString extends CommonParams {
+  private[this] val stringify: Double => String = {
+    import com.github.plokhotnyuk.jsoniter_scala.core._
+
+    new ThreadLocal[Array[Byte]] with JsonValueCodec[Double] with (Double => String) {
+      def apply(x: Double): String = if (java.lang.Double.isFinite(x)) {
+        val buf = get
+        val len = writeToSubArray(x, buf, 0, 32)(this)
+        new String(buf, 0, 0, len)
+      } else java.lang.Double.toString(x)
+
+      override def decodeValue(in: JsonReader, default: Double): Double = in.readDouble()
+
+      override def encodeValue(x: Double, out: JsonWriter): Unit = out.writeVal(x)
+
+      override def initialValue(): Array[Byte] = new Array[Byte](32)
+
+      override val nullValue: Double = 0.0
+    }
+  }
+
+  @Benchmark
+  def longMantissaBase(): String = java.lang.Double.toString(123456.7890123456)
+
+  @Benchmark
+  def longMantissaJsoniterScala(): String = stringify(123456.7890123456)
+
+  @Benchmark
+  def longWholeNumberBase(): String = java.lang.Double.toString(1234567890123456.0)
+
+  @Benchmark
+  def longWholeNumberJsoniterScala(): String = stringify(1234567890123456.0)
+
+  @Benchmark
+  def shortMantissaBase(): String = java.lang.Double.toString(1.2)
+
+  @Benchmark
+  def shortMantissaJsoniterScala(): String = stringify(1.2)
+
+  @Benchmark
+  def shortWholeNumberBase(): String = java.lang.Double.toString(12.0)
+
+  @Benchmark
+  def shortWholeNumberJsoniterScala(): String = stringify(12.0)
+}

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/FloatToString.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/FloatToString.scala
@@ -1,0 +1,49 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import org.openjdk.jmh.annotations.Benchmark
+
+class FloatToString extends CommonParams {
+  private[this] val stringify: Float => String = {
+    import com.github.plokhotnyuk.jsoniter_scala.core._
+
+    new ThreadLocal[Array[Byte]] with JsonValueCodec[Float] with (Float => String) {
+      def apply(x: Float): String = if (java.lang.Float.isFinite(x)) {
+        val buf = get
+        val len = writeToSubArray(x, buf, 0, 32)(this)
+        new String(buf, 0, 0, len)
+      } else java.lang.Float.toString(x)
+
+      override def decodeValue(in: JsonReader, default: Float): Float = in.readFloat()
+
+      override def encodeValue(x: Float, out: JsonWriter): Unit = out.writeVal(x)
+
+      override def initialValue(): Array[Byte] = new Array[Byte](32)
+
+      override val nullValue: Float = 0.0f
+    }
+  }
+
+  @Benchmark
+  def longMantissaBase(): String = java.lang.Float.toString(123.45678f)
+
+  @Benchmark
+  def longMantissaJsoniterScala(): String = stringify(123.45678f)
+
+  @Benchmark
+  def longWholeNumberBase(): String = java.lang.Float.toString(12345678.0f)
+
+  @Benchmark
+  def longWholeNumberJsoniterScala(): String = stringify(12345678.0f)
+
+  @Benchmark
+  def shortMantissaBase(): String = java.lang.Float.toString(1.2f)
+
+  @Benchmark
+  def shortMantissaJsoniterScala(): String = stringify(1.2f)
+
+  @Benchmark
+  def shortWholeNumberBase(): String = java.lang.Float.toString(12.0f)
+
+  @Benchmark
+  def shortWholeNumberJsoniterScala(): String = stringify(12.0f)
+}

--- a/jsoniter-scala-core/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1921,8 +1921,8 @@ final class JsonWriter private[jsoniter_scala](
         buf(dotPos) = '.'
         lastPos
       } else if (exp < len - 1) {
-        val beforeDotPos = pos + exp
         val lastPos = writeSignificantFractionDigits(dv, 0, pos + len, pos, buf, ds)
+        val beforeDotPos = pos + exp
         while (pos <= beforeDotPos) {
           buf(pos) = buf(pos + 1)
           pos += 1
@@ -2049,8 +2049,8 @@ final class JsonWriter private[jsoniter_scala](
         buf(dotPos) = '.'
         lastPos
       } else if (exp < len - 1) {
-        val beforeDotPos = pos + exp
         val lastPos = writeSignificantFractionDigits(dv, pos + len, pos, buf, ds)
+        val beforeDotPos = pos + exp
         while (pos <= beforeDotPos) {
           buf(pos) = buf(pos + 1)
           pos += 1
@@ -2059,7 +2059,7 @@ final class JsonWriter private[jsoniter_scala](
         lastPos
       } else {
         pos += len
-        writeSmallPositiveLongStartingFromLastPosition(dv, pos - 1, buf, ds)
+        writePositiveIntStartingFromLastPosition(dv.toInt, pos - 1, buf, ds)
         buf(pos) = '.'
         buf(pos + 1) = '0'
         pos + 2
@@ -2118,25 +2118,25 @@ final class JsonWriter private[jsoniter_scala](
     if (pos > posLim) {
       val qp = q0 * 1374389535L
       val q1 = (qp >> 37).toInt // divide a positive int by 100
-      writeSignificantFractionDigits(q1, {
-        if (((qp & 0x1fc0000000L) | lastPos) == 0) lastPos // trailing zeros
-        else {
-          val d = ds(q0 - q1 * 100)
-          buf(pos - 1) = d.toByte
-          buf(pos) = (d >> 8).toByte
-          if (lastPos != 0) lastPos
-          else (12345 - d >>> 31) + pos
-        }
+      if (((qp & 0x1fc0000000L) | lastPos) == 0) writeSignificantFractionDigits(q1, lastPos, pos - 2, posLim, buf, ds)
+      else writeSignificantFractionDigits2(q1, {
+        val d = ds(q0 - q1 * 100)
+        buf(pos - 1) = d.toByte
+        buf(pos) = (d >> 8).toByte
+        if (lastPos != 0) lastPos
+        else (12345 - d >>> 31) + pos // 12345 == ('0' << 8) | '9'
       }, pos - 2, posLim, buf, ds)
     } else lastPos
 
-  private[this] def writeSmallPositiveLongStartingFromLastPosition(q0: Long, pos: Int, buf: Array[Byte], ds: Array[Short]): Unit =
-    if (q0.toInt == q0) writePositiveIntStartingFromLastPosition(q0.toInt, pos, buf, ds)
-    else {
-      val q1 = q0 / 100000000 // FIXME: Use Math.multiplyHigh(q0, 193428131138340668L) >>> 20 after dropping JDK 8 support
-      writePositiveIntStartingFromLastPosition(q1.toInt, pos - 8, buf, ds)
-      write8Digits((q0 - q1 * 100000000).toInt, pos - 7, buf, ds)
-    }
+  @tailrec
+  private[this] def writeSignificantFractionDigits2(q0: Int, lastPos: Int, pos: Int, posLim: Int, buf: Array[Byte], ds: Array[Short]): Int =
+    if (pos > posLim) {
+      val q1 = (q0 * 1374389535L >> 37).toInt // divide a positive int by 100
+      val d = ds(q0 - q1 * 100)
+      buf(pos - 1) = d.toByte
+      buf(pos) = (d >> 8).toByte
+      writeSignificantFractionDigits2(q1, lastPos, pos - 2, posLim, buf, ds)
+    } else lastPos
 
   @tailrec
   private[this] def writePositiveIntStartingFromLastPosition(q0: Int, pos: Int, buf: Array[Byte], ds: Array[Short]): Unit =

--- a/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1241,7 +1241,7 @@ final class JsonWriter private[jsoniter_scala](
         pos =
           if (hours.toInt == hours) writePositiveInt(hours.toInt, pos, buf, ds)
           else {
-            val q1 = hours / 100000000 // FIXME: Use Math.multiplyHigh(hours, 193428131138340668L) >>> 20 after dropping JDK 8 support
+            val q1 = Math.multiplyHigh(hours, 193428131138340668L) >>> 20
             val r1 = (hours - q1 * 100000000).toInt
             write8Digits(r1, writePositiveInt(q1.toInt, pos, buf, ds), buf, ds)
           }
@@ -1675,7 +1675,7 @@ final class JsonWriter private[jsoniter_scala](
   }
 
   private[this] def write18Digits(q0: Long, pos: Int, buf: Array[Byte], ds: Array[Short]): Int = {
-    val q1 = q0 / 100000000 // FIXME: Use Math.multiplyHigh(q0, 193428131138340668L) >>> 20 after dropping JDK 8 support
+    val q1 = Math.multiplyHigh(q0, 193428131138340668L) >>> 20
     val r1 = (q0 - q1 * 100000000).toInt
     val q2 = (q1 >> 8) * 1441151881 >> 49 // divide small positive long by 100000000
     val r2 = (q1 - q2 * 100000000).toInt
@@ -1743,7 +1743,7 @@ final class JsonWriter private[jsoniter_scala](
       }
     if (q0.toInt == q0) writePositiveInt(q0.toInt, pos, buf, ds)
     else {
-      val q1 = q0 / 100000000 // FIXME: Use Math.multiplyHigh(q0, 193428131138340668L) >>> 20 after dropping JDK 8 support
+      val q1 = Math.multiplyHigh(q0, 193428131138340668L) >>> 20
       val r1 = (q0 - q1 * 100000000).toInt
       if (q1.toInt == q1) write8Digits(r1, writePositiveInt(q1.toInt, pos, buf, ds), buf, ds)
       else {
@@ -1880,8 +1880,8 @@ final class JsonWriter private[jsoniter_scala](
   }
 
   private[this] def rop(g: Long, cp: Int): Int = {
-    val x1 = ((g & 0xFFFFFFFFL) * cp >>> 32) + (g >>> 32) * cp // FIXME: Use Math.multiplyHigh after dropping JDK 8 support
-    (x1 >>> 31).toInt | (x1.toInt & 0x7FFFFFFF) + 0x7FFFFFFF >>> 31
+    val x1 = Math.multiplyHigh(g, cp.toLong << 32)
+    (x1 >>> 31).toInt | ((x1.toInt & 0x7FFFFFFF) + 0x7FFFFFFF >>> 31)
   }
 
   // Based on the amazing work of Raffaello Giulietti
@@ -1929,7 +1929,7 @@ final class JsonWriter private[jsoniter_scala](
         val vbrd = outm1 - rop(g1, g0, cb + 2 << h)
         val s = vb >> 2
         if (s < 100 || {
-          dv = s / 10 // FIXME: Use Math.multiplyHigh(s, 1844674407370955168L) instead after dropping JDK 8 support
+          dv = Math.multiplyHigh(s, 1844674407370955168L) // Divide positive long by 10
           val sp10 = dv * 10
           val sp40 = sp10 << 2
           val upin = (vbls - sp40).toInt
@@ -2008,21 +2008,11 @@ final class JsonWriter private[jsoniter_scala](
   }
 
   private[this] def rop(g1: Long, g0: Long, cp: Long): Long = {
-    val x1 = /*Math.*/multiplyHigh(g0, cp) // FIXME: Use Math.multiplyHigh after dropping JDK 8 support
+    val x1 = Math.multiplyHigh(g0, cp)
     val y0 = g1 * cp
-    val y1 = /*Math.*/multiplyHigh(g1, cp) // FIXME: Use Math.multiplyHigh after dropping JDK 8 support
+    val y1 = Math.multiplyHigh(g1, cp)
     val z = (y0 >>> 1) + x1
     (z >>> 63) + y1 | (z & 0x7FFFFFFFFFFFFFFFL) + 0x7FFFFFFFFFFFFFFFL >>> 63
-  }
-
-  private[this] def multiplyHigh(x: Long, y: Long): Long = {
-    val x2 = x & 0xFFFFFFFFL
-    val y2 = y & 0xFFFFFFFFL
-    val b = x2 * y2
-    val x1 = x >>> 32
-    val y1 = y >>> 32
-    val a = x1 * y1
-    (((b >>> 32) + (x1 + x2) * (y1 + y2) - b - a) >>> 32) + a
   }
 
   private[this] def offset(q0: Long): Int = {
@@ -2045,7 +2035,7 @@ final class JsonWriter private[jsoniter_scala](
   private[this] def writeSignificantFractionDigits(q0: Long, pos: Int, posLim: Int, buf: Array[Byte], ds: Array[Short]): Int =
     if (q0.toInt == q0) writeSignificantFractionDigits(q0.toInt, 0, pos, posLim, buf, ds)
     else {
-      val q1 = q0 / 100000000 // FIXME: Use Math.multiplyHigh(q0, 193428131138340668L) >>> 20 after dropping JDK 8 support
+      val q1 = Math.multiplyHigh(q0, 193428131138340668L) >>> 20
       writeSignificantFractionDigits(q1.toInt, {
         val r1 = (q0 - q1 * 100000000).toInt
         if (r1 == 0) 0

--- a/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1861,8 +1861,8 @@ final class JsonWriter private[jsoniter_scala](
         buf(dotPos) = '.'
         lastPos
       } else if (exp < len - 1) {
-        val beforeDotPos = pos + exp
         val lastPos = writeSignificantFractionDigits(dv, 0, pos + len, pos, buf, ds)
+        val beforeDotPos = pos + exp
         while (pos <= beforeDotPos) {
           buf(pos) = buf(pos + 1)
           pos += 1
@@ -1989,8 +1989,8 @@ final class JsonWriter private[jsoniter_scala](
         buf(dotPos) = '.'
         lastPos
       } else if (exp < len - 1) {
-        val beforeDotPos = pos + exp
         val lastPos = writeSignificantFractionDigits(dv, pos + len, pos, buf, ds)
+        val beforeDotPos = pos + exp
         while (pos <= beforeDotPos) {
           buf(pos) = buf(pos + 1)
           pos += 1
@@ -1999,7 +1999,7 @@ final class JsonWriter private[jsoniter_scala](
         lastPos
       } else {
         pos += len
-        writeSmallPositiveLongStartingFromLastPosition(dv, pos - 1, buf, ds)
+        writePositiveIntStartingFromLastPosition(dv.toInt, pos - 1, buf, ds)
         buf(pos) = '.'
         buf(pos + 1) = '0'
         pos + 2
@@ -2058,25 +2058,25 @@ final class JsonWriter private[jsoniter_scala](
     if (pos > posLim) {
       val qp = q0 * 1374389535L
       val q1 = (qp >> 37).toInt // divide a positive int by 100
-      writeSignificantFractionDigits(q1, {
-        if (((qp & 0x1fc0000000L) | lastPos) == 0) lastPos // trailing zeros
-        else {
-          val d = ds(q0 - q1 * 100)
-          buf(pos - 1) = d.toByte
-          buf(pos) = (d >> 8).toByte
-          if (lastPos != 0) lastPos
-          else (12345 - d >>> 31) + pos
-        }
+      if (((qp & 0x1fc0000000L) | lastPos) == 0) writeSignificantFractionDigits(q1, lastPos, pos - 2, posLim, buf, ds)
+      else writeSignificantFractionDigits2(q1, {
+        val d = ds(q0 - q1 * 100)
+        buf(pos - 1) = d.toByte
+        buf(pos) = (d >> 8).toByte
+        if (lastPos != 0) lastPos
+        else (12345 - d >>> 31) + pos // 12345 == ('0' << 8) | '9'
       }, pos - 2, posLim, buf, ds)
     } else lastPos
 
-  private[this] def writeSmallPositiveLongStartingFromLastPosition(q0: Long, pos: Int, buf: Array[Byte], ds: Array[Short]): Unit =
-    if (q0.toInt == q0) writePositiveIntStartingFromLastPosition(q0.toInt, pos, buf, ds)
-    else {
-      val q1 = q0 / 100000000 // FIXME: Use Math.multiplyHigh(q0, 193428131138340668L) >>> 20 after dropping JDK 8 support
-      writePositiveIntStartingFromLastPosition(q1.toInt, pos - 8, buf, ds)
-      write8Digits((q0 - q1 * 100000000).toInt, pos - 7, buf, ds)
-    }
+  @tailrec
+  private[this] def writeSignificantFractionDigits2(q0: Int, lastPos: Int, pos: Int, posLim: Int, buf: Array[Byte], ds: Array[Short]): Int =
+    if (pos > posLim) {
+      val q1 = (q0 * 1374389535L >> 37).toInt // divide a positive int by 100
+      val d = ds(q0 - q1 * 100)
+      buf(pos - 1) = d.toByte
+      buf(pos) = (d >> 8).toByte
+      writeSignificantFractionDigits2(q1, lastPos, pos - 2, posLim, buf, ds)
+    } else lastPos
 
   @tailrec
   private[this] def writePositiveIntStartingFromLastPosition(q0: Int, pos: Int, buf: Array[Byte], ds: Array[Short]): Unit =


### PR DESCRIPTION
## Original (Base) vs jsoniter-scala implementation of the Schubfach algorithm on JDK 15-internal, OpenJDK 64-Bit Server VM, 15-internal+0-adhoc.andriy.jdk, with [this](http://cr.openjdk.java.net/~bpb/4511638/webrev.04/) patch

```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                      Mode  Cnt         Score        Error  Units
[info] DoubleToString.longMantissaBase               thrpt   15  17491420.470 ± 460439.272  ops/s
[info] DoubleToString.longMantissaJsoniterScala      thrpt   15  16234218.979 ± 240598.499  ops/s
[info] DoubleToString.longWholeNumberBase            thrpt   15  23069985.469 ± 799836.583  ops/s
[info] DoubleToString.longWholeNumberJsoniterScala   thrpt   15  20964431.705 ± 613601.854  ops/s
[info] DoubleToString.shortMantissaBase              thrpt   15  19820426.774 ± 156886.633  ops/s
[info] DoubleToString.shortMantissaJsoniterScala     thrpt   15  21801118.068 ± 197316.108  ops/s
[info] DoubleToString.shortWholeNumberBase           thrpt   15  27191292.298 ± 183591.618  ops/s
[info] DoubleToString.shortWholeNumberJsoniterScala  thrpt   15  41542373.772 ± 983941.337  ops/s
[info] FloatToString.longMantissaBase                thrpt   15  22464008.614 ± 272645.475  ops/s
[info] FloatToString.longMantissaJsoniterScala       thrpt   15  21697338.190 ±  79414.728  ops/s
[info] FloatToString.longWholeNumberBase             thrpt   15  23451256.855 ±  81278.167  ops/s
[info] FloatToString.longWholeNumberJsoniterScala    thrpt   15  29390531.011 ± 567405.820  ops/s
[info] FloatToString.shortMantissaBase               thrpt   15  21227729.613 ± 130969.332  ops/s
[info] FloatToString.shortMantissaJsoniterScala      thrpt   15  23169344.472 ± 203043.900  ops/s
[info] FloatToString.shortWholeNumberBase            thrpt   15  25770016.873 ± 138407.616  ops/s
[info] FloatToString.shortWholeNumberJsoniterScala   thrpt   15  42341248.838 ± 346237.723  ops/s
```
The command to reproduce:
```
sbt -java-home /home/andriy/Projects/com/github/plokhotnyuk/jdk/build/linux-x86_64-server-release/images/jdk 'jsoniter-scala-benchmarkJVM/jmh:run -p size=128 -f 3 ToString'
```