### PR TITLE
How to improve serialization of floats and doubles (JDK 9+ version)

### DIFF
--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/DoubleToString.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/DoubleToString.scala
@@ -1,0 +1,50 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import org.openjdk.jmh.annotations.Benchmark
+
+class DoubleToString extends CommonParams {
+  private[this] val stringify: Double => String = {
+    import com.github.plokhotnyuk.jsoniter_scala.core._
+
+    new ThreadLocal[Array[Byte]] with JsonValueCodec[Double] with (Double => String) {
+      def apply(x: Double): String =
+        if (java.lang.Double.isFinite(x)) {
+          val buf = get
+          val len = writeToSubArray(x, buf, 0, 32)(this)
+          new String(buf, 0, 0, len)
+        } else java.lang.Double.toString(x)
+
+      override def decodeValue(in: JsonReader, default: Double): Double = in.readDouble()
+
+      override def encodeValue(x: Double, out: JsonWriter): Unit = out.writeVal(x)
+
+      override def initialValue(): Array[Byte] = new Array[Byte](32)
+
+      override val nullValue: Double = 0.0
+    }
+  }
+
+  @Benchmark
+  def longMantissaBase(): String = java.lang.Double.toString(123456.7890123456)
+
+  @Benchmark
+  def longMantissaRyu(): String = stringify(123456.7890123456)
+
+  @Benchmark
+  def longWholeNumberBase(): String = java.lang.Double.toString(1234567890123456.0)
+
+  @Benchmark
+  def longWholeNumberRyu(): String = stringify(1234567890123456.0)
+
+  @Benchmark
+  def shortMantissaBase(): String = java.lang.Double.toString(1.2)
+
+  @Benchmark
+  def shortMantissaRyu(): String = stringify(1.2)
+
+  @Benchmark
+  def shortWholeNumberBase(): String = java.lang.Double.toString(12.0)
+
+  @Benchmark
+  def shortWholeNumberRyu(): String = stringify(12.0)
+}

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/FloatToString.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/FloatToString.scala
@@ -1,0 +1,50 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import org.openjdk.jmh.annotations.Benchmark
+
+class FloatToString extends CommonParams {
+  private[this] val stringify: Float => String = {
+    import com.github.plokhotnyuk.jsoniter_scala.core._
+
+    new ThreadLocal[Array[Byte]] with JsonValueCodec[Float] with (Float => String) {
+      def apply(x: Float): String =
+        if (java.lang.Float.isFinite(x)) {
+          val buf = get
+          val len = writeToSubArray(x, buf, 0, 32)(this)
+          new String(buf, 0, 0, len)
+        } else java.lang.Float.toString(x)
+
+      override def decodeValue(in: JsonReader, default: Float): Float = in.readFloat()
+
+      override def encodeValue(x: Float, out: JsonWriter): Unit = out.writeVal(x)
+
+      override def initialValue(): Array[Byte] = new Array[Byte](32)
+
+      override val nullValue: Float = 0.0f
+    }
+  }
+
+  @Benchmark
+  def longMantissaBase(): String = java.lang.Float.toString(123.45678f)
+
+  @Benchmark
+  def longMantissaRyu(): String = stringify(123.45678f)
+
+  @Benchmark
+  def longWholeNumberBase(): String = java.lang.Float.toString(12345678.0f)
+
+  @Benchmark
+  def longWholeNumberRyu(): String = stringify(12345678.0f)
+
+  @Benchmark
+  def shortMantissaBase(): String = java.lang.Float.toString(1.2f)
+
+  @Benchmark
+  def shortMantissaRyu(): String = stringify(1.2f)
+
+  @Benchmark
+  def shortWholeNumberBase(): String = java.lang.Float.toString(12.0f)
+
+  @Benchmark
+  def shortWholeNumberRyu(): String = stringify(12.0f)
+}

--- a/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1796,8 +1796,8 @@ final class JsonWriter private[jsoniter_scala](
         }
         exp = e * 315653 - expCorr >> 20
         val g1 = gs(exp + 324 << 1) + 1
-        val h = (-exp * 108853 >> 15) + e + 1
-        val cb = m << 2
+        val h = (-exp * 108853 >> 15) + e + 33
+        val cb: Long = m << 2
         val outm1 = (m & 0x1) - 1
         val vb = rop(g1, cb << h)
         val vbls = rop(g1, cb - cblShift << h) + outm1
@@ -1874,8 +1874,8 @@ final class JsonWriter private[jsoniter_scala](
     }
   }
 
-  private[this] def rop(g: Long, cp: Int): Int = {
-    val x1 = ((g & 0xFFFFFFFFL) * cp >>> 32) + (g >>> 32) * cp // FIXME: Use Math.multiplyHigh after dropping JDK 8 support
+  private[this] def rop(g: Long, cp: Long): Int = {
+    val x1 = Math.multiplyHigh(g, cp)
     (x1 >>> 31).toInt | -x1.toInt >>> 31
   }
 
@@ -1931,7 +1931,7 @@ final class JsonWriter private[jsoniter_scala](
         val vbrd = outm1 - rop(g1, g0, cb + 2 << h)
         val s = vb >> 2
         if (s < 100 || {
-          dv = s / 10 // FIXME: Use Math.multiplyHigh(s, 1844674407370955168L) instead after dropping JDK 8 support
+          dv = Math.multiplyHigh(s, 1844674407370955168L)
           val sp10 = dv * 10
           val sp40 = sp10 << 2
           val upin = (vbls - sp40).toInt
@@ -2003,20 +2003,10 @@ final class JsonWriter private[jsoniter_scala](
   }
 
   private[this] def rop(g1: Long, g0: Long, cp: Long): Long = {
-    val x1 = /*Math.*/multiplyHigh(g0, cp) // FIXME: Use Math.multiplyHigh after dropping JDK 8 support
+    val x1 = Math.multiplyHigh(g0, cp)
     val z = (g1 * cp >>> 1) + x1
-    val y1 = /*Math.*/multiplyHigh(g1, cp) // FIXME: Use Math.multiplyHigh after dropping JDK 8 support
+    val y1 = Math.multiplyHigh(g1, cp)
     (z >>> 63) + y1 | -(z & 0x7FFFFFFFFFFFFFFFL) >>> 63
-  }
-
-  private[this] def multiplyHigh(x: Long, y: Long): Long = {
-    val x2 = x & 0xFFFFFFFFL
-    val y2 = y & 0xFFFFFFFFL
-    val b = x2 * y2
-    val x1 = x >>> 32
-    val y1 = y >>> 32
-    val a = x1 * y1
-    (((b >>> 32) + (x1 + x2) * (y1 + y2) - b - a) >>> 32) + a
   }
 
   private[this] def offset(q0: Long): Int =
@@ -2037,7 +2027,7 @@ final class JsonWriter private[jsoniter_scala](
   private[this] def writeSignificantFractionDigits(q0: Long, pos: Int, posLim: Int, buf: Array[Byte], ds: Array[Short]): Int =
     if (q0.toInt == q0) writeSignificantFractionDigits(q0.toInt, 0, pos, posLim, buf, ds)
     else {
-      val q1 = q0 / 100000000 // FIXME: Use Math.multiplyHigh(q0, 193428131138340668L) >>> 20 after dropping JDK 8 support
+      val q1 = Math.multiplyHigh(q0, 193428131138340668L) >>> 20
       writeSignificantFractionDigits(q1.toInt, {
         val r1 = (q0 - q1 * 100000000).toInt
         if (r1 == 0) 0


### PR DESCRIPTION
### OpenJDK 15 patched with [the Schubfach way to render doubles](http://cr.openjdk.java.net/~bpb/4511638/webrev.04/openjdk.patch)
```
[info] Benchmark                             Mode  Cnt         Score          Error  Units
[info] DoubleToString.longMantissaBase      thrpt    5  17912069.987 ±   388061.300  ops/s
[info] DoubleToString.longMantissaRyu       thrpt    5  16532753.156 ±  1579086.571  ops/s
[info] DoubleToString.longWholeNumberBase   thrpt    5  23480570.031 ±  1041838.274  ops/s
[info] DoubleToString.longWholeNumberRyu    thrpt    5  20719803.050 ±  2359575.659  ops/s
[info] DoubleToString.shortMantissaBase     thrpt    5  19809620.555 ±   220397.862  ops/s
[info] DoubleToString.shortMantissaRyu      thrpt    5  23024754.093 ±   670952.507  ops/s
[info] DoubleToString.shortWholeNumberBase  thrpt    5  26735198.003 ±  1106354.985  ops/s
[info] DoubleToString.shortWholeNumberRyu   thrpt    5  41906243.436 ±  3538051.656  ops/s
[info] FloatToString.longMantissaBase       thrpt    5  22614369.763 ±   452330.506  ops/s
[info] FloatToString.longMantissaRyu        thrpt    5  22151399.284 ±    86092.623  ops/s
[info] FloatToString.longWholeNumberBase    thrpt    5  23231325.900 ±   180823.912  ops/s
[info] FloatToString.longWholeNumberRyu     thrpt    5  29492066.684 ±  2544898.297  ops/s
[info] FloatToString.shortMantissaBase      thrpt    5  21108039.803 ±    55656.595  ops/s
[info] FloatToString.shortMantissaRyu       thrpt    5  23863605.746 ±   573690.581  ops/s
[info] FloatToString.shortWholeNumberBase   thrpt    5  25800380.170 ±  1021863.916  ops/s
[info] FloatToString.shortWholeNumberRyu    thrpt    5  38176970.832 ± 11035286.524  ops/s
```
### OpenJDK 16
```
[info] Benchmark                             Mode  Cnt         Score         Error  Units
[info] DoubleToString.longMantissaBase      thrpt    5   3890548.656 ±   21392.977  ops/s
[info] DoubleToString.longMantissaRyu       thrpt    5  16682118.028 ±  479024.548  ops/s
[info] DoubleToString.longWholeNumberBase   thrpt    5  16903469.949 ±   70175.973  ops/s
[info] DoubleToString.longWholeNumberRyu    thrpt    5  21001251.455 ±  729828.584  ops/s
[info] DoubleToString.shortMantissaBase     thrpt    5  16944664.704 ±  169422.549  ops/s
[info] DoubleToString.shortMantissaRyu      thrpt    5  22967208.887 ± 1003266.089  ops/s
[info] DoubleToString.shortWholeNumberBase  thrpt    5  31299932.726 ±  810218.068  ops/s
[info] DoubleToString.shortWholeNumberRyu   thrpt    5  42251736.407 ±  799980.805  ops/s
[info] FloatToString.longMantissaBase       thrpt    5   8788807.911 ±   34811.155  ops/s
[info] FloatToString.longMantissaRyu        thrpt    5  22206882.014 ±  221795.251  ops/s
[info] FloatToString.longWholeNumberBase    thrpt    5  23437515.611 ±  314022.235  ops/s
[info] FloatToString.longWholeNumberRyu     thrpt    5  29030000.160 ± 2419962.917  ops/s
[info] FloatToString.shortMantissaBase      thrpt    5  21028226.189 ±   90018.729  ops/s
[info] FloatToString.shortMantissaRyu       thrpt    5  23902003.634 ±  235473.312  ops/s
[info] FloatToString.shortWholeNumberBase   thrpt    5  31408478.910 ± 1055979.695  ops/s
[info] FloatToString.shortWholeNumberRyu    thrpt    5  41741988.084 ± 2781077.032  ops/s
```
### GraalVM CE 20.2.0-dev Java 11
```
[info] Benchmark                             Mode  Cnt         Score         Error  Units
[info] DoubleToString.longMantissaBase      thrpt    5   4002990.948 ±   12684.457  ops/s
[info] DoubleToString.longMantissaRyu       thrpt    5  14092895.922 ±  253288.503  ops/s
[info] DoubleToString.longWholeNumberBase   thrpt    5  17973827.091 ± 1685399.732  ops/s
[info] DoubleToString.longWholeNumberRyu    thrpt    5  21890495.335 ± 1954958.209  ops/s
[info] DoubleToString.shortMantissaBase     thrpt    5  18806704.705 ±  393220.318  ops/s
[info] DoubleToString.shortMantissaRyu      thrpt    5  17031011.100 ±  234565.975  ops/s
[info] DoubleToString.shortWholeNumberBase  thrpt    5  55771777.830 ± 2602349.734  ops/s
[info] DoubleToString.shortWholeNumberRyu   thrpt    5  38539992.059 ±  766810.191  ops/s
[info] FloatToString.longMantissaBase       thrpt    5   9567056.619 ±   25504.379  ops/s
[info] FloatToString.longMantissaRyu        thrpt    5  20177544.287 ±  368441.935  ops/s
[info] FloatToString.longWholeNumberBase    thrpt    5  29566690.710 ± 2888890.234  ops/s
[info] FloatToString.longWholeNumberRyu     thrpt    5  27750642.434 ±  512188.121  ops/s
[info] FloatToString.shortMantissaBase      thrpt    5  23489250.805 ±  135202.697  ops/s
[info] FloatToString.shortMantissaRyu       thrpt    5  21386248.285 ± 1163622.840  ops/s
[info] FloatToString.shortWholeNumberBase   thrpt    5  54559767.133 ±  407822.091  ops/s
[info] FloatToString.shortWholeNumberRyu    thrpt    5  40443370.635 ±  754191.261  ops/s
```
### GraalVM EE 2.1.0 Java 11
```
[info] Benchmark                             Mode  Cnt         Score         Error  Units
[info] DoubleToString.longMantissaBase      thrpt    5   4381286.784 ±   16317.780  ops/s
[info] DoubleToString.longMantissaRyu       thrpt    5  19513308.332 ±  101199.694  ops/s
[info] DoubleToString.longWholeNumberBase   thrpt    5  20074733.601 ±  656885.913  ops/s
[info] DoubleToString.longWholeNumberRyu    thrpt    5  40578473.451 ±  542812.991  ops/s
[info] DoubleToString.shortMantissaBase     thrpt    5  29162978.432 ±  215056.405  ops/s
[info] DoubleToString.shortMantissaRyu      thrpt    5  25647038.712 ± 1029904.860  ops/s
[info] DoubleToString.shortWholeNumberBase  thrpt    5  61598073.701 ±  161502.658  ops/s
[info] DoubleToString.shortWholeNumberRyu   thrpt    5  54632422.344 ±  611707.209  ops/s
[info] FloatToString.longMantissaBase       thrpt    5  11740147.759 ±   23156.845  ops/s
[info] FloatToString.longMantissaRyu        thrpt    5  33984590.758 ±  615327.796  ops/s
[info] FloatToString.longWholeNumberBase    thrpt    5  29715564.831 ± 1473692.557  ops/s
[info] FloatToString.longWholeNumberRyu     thrpt    5  45875740.942 ±   84882.425  ops/s
[info] FloatToString.shortMantissaBase      thrpt    5  47162304.041 ±  404442.856  ops/s
[info] FloatToString.shortMantissaRyu       thrpt    5  32437467.447 ±  531777.193  ops/s
[info] FloatToString.shortWholeNumberBase   thrpt    5  61232590.190 ±  346695.980  ops/s
[info] FloatToString.shortWholeNumberRyu    thrpt    5  54733037.511 ±   36335.651  ops/s
```