### PR TITLE
Add benchmarks for play-json-jsoniter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ lazy val commonSettings = Seq(
   resolvers ++= Seq(
     Resolver.mavenLocal,
     Resolver.sonatypeRepo("staging"),
+    Resolver.bintrayRepo("evolutiongaming", "maven"),
     "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
   ),
   scalaVersion := "2.13.5",
@@ -162,6 +163,7 @@ lazy val `jsoniter-scala-benchmark` = crossProject(JVMPlatform, JSPlatform)
     ),
     crossScalaVersions := Seq("2.13.5", "2.12.13"),
     libraryDependencies ++= Seq(
+      "com.evolutiongaming" %% "play-json-jsoniter" % "0.7.0",
       "com.rallyhealth" %% "weepickle-v1" % "1.4.0",
       "io.bullet" %%% "borer-derivation" % "1.6.3",
       "pl.iterators" %% "kebs-spray-json" % "1.8.0",

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -38,6 +38,9 @@ class ADTReading extends ADTBenchmark {
 
   @Benchmark
   def playJson(): ADTBase = Json.parse(jsonBytes).as[ADTBase](adtFormat)
+
+  @Benchmark
+  def playJsonJsoniter(): ADTBase = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[ADTBase](adtFormat))
 
   @Benchmark
   def sprayJson(): ADTBase = JsonParser(jsonBytes).convertTo[ADTBase](adtBaseJsonFormat)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -41,6 +41,9 @@ class ADTWriting extends ADTBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj)(adtFormat))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj)(adtFormat))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson(adtBaseJsonFormat).compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -45,6 +45,9 @@ class AnyValsReading extends AnyValsBenchmark {
 
   @Benchmark
   def playJson(): AnyVals = Json.parse(jsonBytes).as[AnyVals]
+
+  @Benchmark
+  def playJsonJsoniter(): AnyVals = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[AnyVals])
 
   @Benchmark
   def sprayJson(): AnyVals = JsonParser(jsonBytes).convertTo[AnyVals]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -48,6 +48,9 @@ class AnyValsWriting extends AnyValsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -42,6 +42,10 @@ class ArrayBufferOfBooleansReading extends ArrayBufferOfBooleansBenchmark {
 
   @Benchmark
   def playJson(): mutable.ArrayBuffer[Boolean] = Json.parse(jsonBytes).as[mutable.ArrayBuffer[Boolean]]
+
+  @Benchmark
+  def playJsonJsoniter(): mutable.ArrayBuffer[Boolean] =
+    PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[mutable.ArrayBuffer[Boolean]])
 
   @Benchmark
   def sprayJson(): mutable.ArrayBuffer[Boolean] = JsonParser(jsonBytes).convertTo[mutable.ArrayBuffer[Boolean]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -41,6 +41,9 @@ class ArrayBufferOfBooleansWriting extends ArrayBufferOfBooleansBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders.decodingConfig
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -41,6 +41,10 @@ class ArrayOfBigDecimalsReading extends ArrayOfBigDecimalsBenchmark {
 
   @Benchmark
   def playJson(): Array[BigDecimal] = Json.parse(jsonBytes).as[Array[BigDecimal]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[BigDecimal] =
+    PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[BigDecimal]])
 
   @Benchmark
   def sprayJson(): Array[BigDecimal] = JsonParser(jsonBytes).convertTo[Array[BigDecimal]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -41,6 +41,9 @@ class ArrayOfBigDecimalsWriting extends ArrayOfBigDecimalsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -37,6 +37,9 @@ class ArrayOfBooleansReading extends ArrayOfBooleansBenchmark {
 
   @Benchmark
   def playJson(): Array[Boolean] = Json.parse(jsonBytes).as[Array[Boolean]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Boolean] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Boolean]])
 
   @Benchmark
   def sprayJson(): Array[Boolean] = JsonParser(jsonBytes).convertTo[Array[Boolean]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -41,6 +41,9 @@ class ArrayOfBooleansWriting extends ArrayOfBooleansBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 //import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -38,6 +38,9 @@ class ArrayOfBytesReading extends ArrayOfBytesBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.parse(jsonBytes).as[Array[Byte]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Byte]])
 
   @Benchmark
   def sprayJson(): Array[Byte] = JsonParser(jsonBytes).convertTo[Array[Byte]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -42,6 +42,9 @@ class ArrayOfBytesWriting extends ArrayOfBytesBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -35,6 +35,9 @@ class ArrayOfCharsReading extends ArrayOfCharsBenchmark {
 
   @Benchmark
   def playJson(): Array[Char] = Json.parse(jsonBytes).as[Array[Char]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Char] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Char]])
 
   @Benchmark
   def sprayJson(): Array[Char] = JsonParser(jsonBytes).convertTo[Array[Char]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -39,6 +39,9 @@ class ArrayOfCharsWriting extends ArrayOfCharsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -37,6 +37,9 @@ class ArrayOfDoublesReading extends ArrayOfDoublesBenchmark {
 
   @Benchmark
   def playJson(): Array[Double] = Json.parse(jsonBytes).as[Array[Double]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Double] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Double]])
 
   @Benchmark
   def sprayJson(): Array[Double] = JsonParser(jsonBytes).convertTo[Array[Double]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -41,6 +41,9 @@ class ArrayOfDoublesWriting extends ArrayOfDoublesBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.Duration
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -34,6 +34,9 @@ class ArrayOfDurationsReading extends ArrayOfDurationsBenchmark {
 
   @Benchmark
   def playJson(): Array[Duration] = Json.parse(jsonBytes).as[Array[Duration]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Duration] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Duration]])
 
   @Benchmark
   def sprayJson(): Array[Duration] = JsonParser(jsonBytes).convertTo[Array[Duration]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -37,6 +37,9 @@ class ArrayOfDurationsWriting extends ArrayOfDurationsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -42,6 +42,9 @@ class ArrayOfEnumADTsReading extends ArrayOfEnumADTsBenchmark {
 
   @Benchmark
   def playJson(): Array[SuitADT] = Json.parse(jsonBytes).as[Array[SuitADT]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[SuitADT] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[SuitADT]])
 
   @Benchmark
   def sprayJson(): Array[SuitADT] = JsonParser(jsonBytes).convertTo[Array[SuitADT]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -45,6 +45,9 @@ class ArrayOfEnumADTsWriting extends ArrayOfEnumADTsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -39,6 +39,9 @@ class ArrayOfEnumsReading extends ArrayOfEnumsBenchmark {
 
   @Benchmark
   def playJson(): Array[SuitEnum] = Json.parse(jsonBytes).as[Array[SuitEnum]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[SuitEnum] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[SuitEnum]])
 
   @Benchmark
   def sprayJson(): Array[SuitEnum] = JsonParser(jsonBytes).convertTo[Array[SuitEnum]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -41,6 +41,9 @@ class ArrayOfEnumsWriting extends ArrayOfEnumsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.SprayFormats._
@@ -37,6 +37,9 @@ class ArrayOfFloatsReading extends ArrayOfFloatsBenchmark {
 
   @Benchmark
   def playJson(): Array[Float] = Json.parse(jsonBytes).as[Array[Float]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Float] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Float]])
 
   @Benchmark
   def sprayJson(): Array[Float] = JsonParser(jsonBytes).convertTo[Array[Float]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -41,6 +41,9 @@ class ArrayOfFloatsWriting extends ArrayOfFloatsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.Instant
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -36,6 +36,9 @@ class ArrayOfInstantsReading extends ArrayOfInstantsBenchmark {
 
   @Benchmark
   def playJson(): Array[Instant] = Json.parse(jsonBytes).as[Array[Instant]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Instant] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Instant]])
 
   @Benchmark
   def sprayJson(): Array[Instant] = JsonParser(jsonBytes).convertTo[Array[Instant]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -39,6 +39,9 @@ class ArrayOfInstantsWriting extends ArrayOfInstantsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -37,6 +37,9 @@ class ArrayOfIntsReading extends ArrayOfIntsBenchmark {
 
   @Benchmark
   def playJson(): Array[Int] = Json.parse(jsonBytes).as[Array[Int]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Int] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Int]])
 
   @Benchmark
   def sprayJson(): Array[Int] = JsonParser(jsonBytes).convertTo[Array[Int]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -41,6 +41,9 @@ class ArrayOfIntsWriting extends ArrayOfIntsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -41,6 +41,9 @@ class ArrayOfJavaEnumsReading extends ArrayOfJavaEnumsBenchmark {
 
   @Benchmark
   def playJson(): Array[Suit] = Json.parse(jsonBytes).as[Array[Suit]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Suit] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Suit]])
 
   @Benchmark
   def sprayJson(): Array[Suit] = JsonParser(jsonBytes).convertTo[Array[Suit]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -44,6 +44,9 @@ class ArrayOfJavaEnumsWriting extends ArrayOfJavaEnumsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.LocalDateTime
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -40,6 +40,10 @@ class ArrayOfLocalDateTimesReading extends ArrayOfLocalDateTimesBenchmark {
 
   @Benchmark
   def playJson(): Array[LocalDateTime] = Json.parse(jsonBytes).as[Array[LocalDateTime]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[LocalDateTime] =
+    PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[LocalDateTime]])
 
   @Benchmark
   def sprayJson(): Array[LocalDateTime] = JsonParser(jsonBytes).convertTo[Array[LocalDateTime]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -43,6 +43,9 @@ class ArrayOfLocalDateTimesWriting extends ArrayOfLocalDateTimesBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.LocalDate
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -40,6 +40,9 @@ class ArrayOfLocalDatesReading extends ArrayOfLocalDatesBenchmark {
 
   @Benchmark
   def playJson(): Array[LocalDate] = Json.parse(jsonBytes).as[Array[LocalDate]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[LocalDate] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[LocalDate]])
 
   @Benchmark
   def sprayJson(): Array[LocalDate] = JsonParser(jsonBytes).convertTo[Array[LocalDate]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -43,6 +43,9 @@ class ArrayOfLocalDatesWriting extends ArrayOfLocalDatesBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.LocalTime
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -40,6 +40,10 @@ class ArrayOfLocalTimesReading extends ArrayOfLocalTimesBenchmark {
 
   @Benchmark
   def playJson(): Array[LocalTime] = Json.parse(jsonBytes).as[Array[LocalTime]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[LocalTime] =
+    PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[LocalTime]])
 
   @Benchmark
   def sprayJson(): Array[LocalTime] = JsonParser(jsonBytes).convertTo[Array[LocalTime]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -43,6 +43,9 @@ class ArrayOfLocalTimesWriting extends ArrayOfLocalTimesBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -37,6 +37,9 @@ class ArrayOfLongsReading extends ArrayOfLongsBenchmark {
 
   @Benchmark
   def playJson(): Array[Long] = Json.parse(jsonBytes).as[Array[Long]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Long] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Long]])
 
   @Benchmark
   def sprayJson(): Array[Long] = JsonParser(jsonBytes).convertTo[Array[Long]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -41,6 +41,9 @@ class ArrayOfLongsWriting extends ArrayOfLongsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.MonthDay
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -35,6 +35,9 @@ class ArrayOfMonthDaysReading extends ArrayOfMonthDaysBenchmark {
 
   @Benchmark
   def playJson(): Array[MonthDay] = Json.parse(jsonBytes).as[Array[MonthDay]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[MonthDay] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[MonthDay]])
 
   @Benchmark
   def uPickle(): Array[MonthDay] = read[Array[MonthDay]](jsonBytes)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -38,6 +38,9 @@ class ArrayOfMonthDaysWriting extends ArrayOfMonthDaysBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.OffsetDateTime
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -40,6 +40,10 @@ class ArrayOfOffsetDateTimesReading extends ArrayOfOffsetDateTimesBenchmark {
 
   @Benchmark
   def playJson(): Array[OffsetDateTime] = Json.parse(jsonBytes).as[Array[OffsetDateTime]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[OffsetDateTime] =
+    PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[OffsetDateTime]])
 
   @Benchmark
   def sprayJson(): Array[OffsetDateTime] = JsonParser(jsonBytes).convertTo[Array[OffsetDateTime]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -43,6 +43,9 @@ class ArrayOfOffsetDateTimesWriting extends ArrayOfOffsetDateTimesBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.OffsetTime
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -39,6 +39,10 @@ class ArrayOfOffsetTimesReading extends ArrayOfOffsetTimesBenchmark {
 
   @Benchmark
   def playJson(): Array[OffsetTime] = Json.parse(jsonBytes).as[Array[OffsetTime]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[OffsetTime] =
+    PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[OffsetTime]])
 
   @Benchmark
   def sprayJson(): Array[OffsetTime] = JsonParser(jsonBytes).convertTo[Array[OffsetTime]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -42,6 +42,9 @@ class ArrayOfOffsetTimesWriting extends ArrayOfOffsetTimesBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.Period
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -34,6 +34,9 @@ class ArrayOfPeriodsReading extends ArrayOfPeriodsBenchmark {
 
   @Benchmark
   def playJson(): Array[Period] = Json.parse(jsonBytes).as[Array[Period]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Period] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Period]])
 
   @Benchmark
   def sprayJson(): Array[Period] = JsonParser(jsonBytes).convertTo[Array[Period]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -37,6 +37,9 @@ class ArrayOfPeriodsWriting extends ArrayOfPeriodsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -37,6 +37,9 @@ class ArrayOfShortsReading extends ArrayOfShortsBenchmark {
 
   @Benchmark
   def playJson(): Array[Short] = Json.parse(jsonBytes).as[Array[Short]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Short] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Short]])
 
   @Benchmark
   def sprayJson(): Array[Short] = JsonParser(jsonBytes).convertTo[Array[Short]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -41,6 +41,9 @@ class ArrayOfShortsWriting extends ArrayOfShortsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.UUID
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -40,6 +40,9 @@ class ArrayOfUUIDsReading extends ArrayOfUUIDsBenchmark {
 
   @Benchmark
   def playJson(): Array[UUID] = Json.parse(jsonBytes).as[Array[UUID]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[UUID] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[UUID]])
 
   @Benchmark
   def sprayJson(): Array[UUID] = JsonParser(jsonBytes).convertTo[Array[UUID]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -43,6 +43,9 @@ class ArrayOfUUIDsWriting extends ArrayOfUUIDsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.YearMonth
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -35,6 +35,9 @@ class ArrayOfYearMonthsReading extends ArrayOfYearMonthsBenchmark {
 
   @Benchmark
   def playJson(): Array[YearMonth] = Json.parse(jsonBytes).as[Array[YearMonth]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[YearMonth] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[YearMonth]])
 
   @Benchmark
   def sprayJson(): Array[YearMonth] = JsonParser(jsonBytes).convertTo[Array[YearMonth]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -38,6 +38,9 @@ class ArrayOfYearMonthsWriting extends ArrayOfYearMonthsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.Year
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -35,6 +35,9 @@ class ArrayOfYearsReading extends ArrayOfYearsBenchmark {
 
   @Benchmark
   def playJson(): Array[Year] = Json.parse(jsonBytes).as[Array[Year]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Year] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Year]])
 
   @Benchmark
   def sprayJson(): Array[Year] = JsonParser(jsonBytes).convertTo[Array[Year]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -38,6 +38,9 @@ class ArrayOfYearsWriting extends ArrayOfYearsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.ZoneId
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -34,6 +34,9 @@ class ArrayOfZoneIdsReading extends ArrayOfZoneIdsBenchmark {
 
   @Benchmark
   def playJson(): Array[ZoneId] = Json.parse(jsonBytes).as[Array[ZoneId]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[ZoneId] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[ZoneId]])
 
   @Benchmark
   def sprayJson(): Array[ZoneId] = JsonParser(jsonBytes).convertTo[Array[ZoneId]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -37,6 +37,9 @@ class ArrayOfZoneIdsWriting extends ArrayOfZoneIdsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.ZoneOffset
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -35,6 +35,10 @@ class ArrayOfZoneOffsetsReading extends ArrayOfZoneOffsetsBenchmark {
 
   @Benchmark
   def playJson(): Array[ZoneOffset] = Json.parse(jsonBytes).as[Array[ZoneOffset]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[ZoneOffset] =
+    PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[ZoneOffset]])
 
   @Benchmark
   def sprayJson(): Array[ZoneOffset] = JsonParser(jsonBytes).convertTo[Array[ZoneOffset]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -38,6 +38,9 @@ class ArrayOfZoneOffsetsWriting extends ArrayOfZoneOffsetsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesReading.scala
@@ -2,8 +2,8 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.ZonedDateTime
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 //import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -40,6 +40,9 @@ class ArrayOfZonedDateTimesReading extends ArrayOfZonedDateTimesBenchmark {
 
   @Benchmark
   def playJson(): Array[ZonedDateTime] = Json.parse(jsonBytes).as[Array[ZonedDateTime]]
+
+  @Benchmark
+  def playJsonJsoniter(): Array[ZonedDateTime] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[ZonedDateTime]])
 
   @Benchmark
   def sprayJson(): Array[ZonedDateTime] = JsonParser(jsonBytes).convertTo[Array[ZonedDateTime]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -43,6 +43,9 @@ class ArrayOfZonedDateTimesWriting extends ArrayOfZonedDateTimesBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -41,6 +41,9 @@ class BigDecimalWriting extends BigDecimalBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BitSetReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BitSetReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -33,4 +33,7 @@ class BitSetReading extends BitSetBenchmark {
 
   @Benchmark
   def playJson(): BitSet = Json.parse(jsonBytes).as[BitSet](bitSetFormat)
+
+  @Benchmark
+  def playJsonJsoniter(): BitSet = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[BitSet](bitSetFormat))
 }

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BitSetWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BitSetWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -35,4 +35,7 @@ class BitSetWriting extends BitSetBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 }

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -57,6 +57,9 @@ class ExtractFieldsReading extends CommonParams {
 
   @Benchmark
   def playJson(): ExtractFields = Json.parse(jsonBytes).as[ExtractFields]
+
+  @Benchmark
+  def playJsonJsoniter(): ExtractFields = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[ExtractFields])
 
   @Benchmark
   def sprayJson(): ExtractFields = JsonParser(jsonBytes).convertTo[ExtractFields]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -39,6 +39,9 @@ class GeoJSONReading extends GeoJSONBenchmark {
 
   @Benchmark
   def playJson(): GeoJSON = Json.parse(jsonBytes).as[GeoJSON](geoJSONFormat)
+
+  @Benchmark
+  def playJsonJsoniter(): GeoJSON = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[GeoJSON](geoJSONFormat))
 
   @Benchmark
   def sprayJson(): GeoJSON = JsonParser(jsonBytes).convertTo[GeoJSON](geoJSONJsonFormat)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -41,6 +41,9 @@ class GeoJSONWriting extends GeoJSONBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj)(geoJSONFormat))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj)(geoJSONFormat))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson(geoJSONJsonFormat).compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrinting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrinting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -36,6 +36,9 @@ class GoogleMapsAPIPrettyPrinting extends GoogleMapsAPIBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = prettyPrintBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = writeToArray(Json.toJson(obj), prettyConfig)(PlayJsonJsoniter.jsValueCodec)
 
   @Benchmark
   def sprayJson(): Array[Byte] = CustomPrettyPrinter(obj.toJson).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -43,6 +43,9 @@ class GoogleMapsAPIReading extends GoogleMapsAPIBenchmark {
 
   @Benchmark
   def playJson(): DistanceMatrix = Json.parse(jsonBytes1).as[DistanceMatrix]
+
+  @Benchmark
+  def playJsonJsoniter(): DistanceMatrix = PlayJsonJsoniter.deserialize(jsonBytes1).fold(throw _, _.as[DistanceMatrix])
 
   @Benchmark
   def sprayJson(): DistanceMatrix = JsonParser(jsonBytes1).convertTo[DistanceMatrix]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -45,6 +45,9 @@ class GoogleMapsAPIWriting extends GoogleMapsAPIBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 //import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -35,4 +35,7 @@ class IntMapOfBooleansReading extends IntMapOfBooleansBenchmark {
 
   @Benchmark
   def playJson(): IntMap[Boolean] = Json.parse(jsonBytes).as[IntMap[Boolean]]
+
+  @Benchmark
+  def playJsonJsoniter(): IntMap[Boolean] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[IntMap[Boolean]])
 }

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 //import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -35,4 +35,7 @@ class IntMapOfBooleansWriting extends IntMapOfBooleansBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 }

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -37,6 +37,9 @@ class IntReading extends IntBenchmark {
 
   @Benchmark
   def playJson(): Int = Json.parse(jsonBytes).as[Int]
+
+  @Benchmark
+  def playJsonJsoniter(): Int = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Int])
 
   @Benchmark
   def sprayJson(): Int = JsonParser(jsonBytes).convertTo[Int]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -39,6 +39,9 @@ class IntWriting extends IntBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -37,6 +37,9 @@ class ListOfBooleansReading extends ListOfBooleansBenchmark {
 
   @Benchmark
   def playJson(): List[Boolean] = Json.parse(jsonBytes).as[List[Boolean]]
+
+  @Benchmark
+  def playJsonJsoniter(): List[Boolean] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[List[Boolean]])
 
   @Benchmark
   def sprayJson(): List[Boolean] = JsonParser(jsonBytes).convertTo[List[Boolean]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -41,6 +41,9 @@ class ListOfBooleansWriting extends ListOfBooleansBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -37,6 +37,10 @@ class MapOfIntsToBooleansReading extends MapOfIntsToBooleansBenchmark {
 
   @Benchmark
   def playJson(): Map[Int, Boolean] = Json.parse(jsonBytes).as[Map[Int, Boolean]]
+
+  @Benchmark
+  def playJsonJsoniter(): Map[Int, Boolean] =
+    PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Map[Int, Boolean]])
 /* FIXME: Spray-JSON throws spray.json.DeserializationException: Expected Int as JsNumber, but got "-1"
   @Benchmark
   def sprayJson(): Map[Int, Boolean] = JsonParser(jsonBytes).convertTo[Map[Int, Boolean]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -39,6 +39,9 @@ class MapOfIntsToBooleansWriting extends MapOfIntsToBooleansBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 /* FIXME: Spray-JSON throws spray.json.SerializationException: Map key must be formatted as JsString, not '-130530'
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MissingRequiredFieldsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MissingRequiredFieldsReading.scala
@@ -2,9 +2,9 @@ package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.io.IOException
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.GenCodec
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
@@ -92,6 +92,14 @@ class MissingRequiredFieldsReading extends CommonParams {
   def playJson(): String =
     try {
       Json.parse(jsonBytes).as[MissingRequiredFields](missingReqFieldsFormat).toString // toString() should not be called
+    } catch {
+      case ex: JsResultException => ex.getMessage
+    }
+
+  @Benchmark
+  def playJsonJsoniter(): String =
+    try {
+      PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[MissingRequiredFields](missingReqFieldsFormat).toString) // toString() should not be called
     } catch {
       case ex: JsResultException => ex.getMessage
     }

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableBitSetReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableBitSetReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -33,4 +33,7 @@ class MutableBitSetReading extends MutableBitSetBenchmark {
 
   @Benchmark
   def playJson(): mutable.BitSet = Json.parse(jsonBytes).as[mutable.BitSet]
+
+  @Benchmark
+  def playJsonJsoniter(): mutable.BitSet = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[mutable.BitSet])
 }

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableBitSetWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableBitSetWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -35,4 +35,7 @@ class MutableBitSetWriting extends MutableBitSetBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 }

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 //import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -35,4 +35,7 @@ class MutableLongMapOfBooleansReading extends MutableLongMapOfBooleansBenchmark 
 
   @Benchmark
   def playJson(): mutable.LongMap[Boolean] = Json.parse(jsonBytes).as[mutable.LongMap[Boolean]]
+
+  @Benchmark
+  def playJsonJsoniter(): mutable.LongMap[Boolean] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[mutable.LongMap[Boolean]])
 }

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 //import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
@@ -35,4 +35,7 @@ class MutableLongMapOfBooleansWriting extends MutableLongMapOfBooleansBenchmark 
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 }

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -36,6 +36,10 @@ class MutableMapOfIntsToBooleansReading extends MutableMapOfIntsToBooleansBenchm
 
   @Benchmark
   def playJson(): mutable.Map[Int, Boolean] = Json.parse(jsonBytes).as[mutable.Map[Int, Boolean]]
+
+  @Benchmark
+  def playJsonJsoniter(): mutable.Map[Int, Boolean] =
+    PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[mutable.Map[Int, Boolean]])
 
   @Benchmark
   def weePickle(): mutable.Map[Int, Boolean] = FromJson(jsonBytes).transform(ToScala[mutable.Map[Int, Boolean]])

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -36,6 +36,9 @@ class MutableMapOfIntsToBooleansWriting extends MutableMapOfIntsToBooleansBenchm
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def weePickle(): Array[Byte] = FromScala(obj).transform(ToJson.bytes)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -37,6 +37,10 @@ class MutableSetOfIntsReading extends MutableSetOfIntsBenchmark {
 
   @Benchmark
   def playJson(): mutable.Set[Int] = Json.parse(jsonBytes).as[mutable.Set[Int]]
+
+  @Benchmark
+  def playJsonJsoniter(): mutable.Set[Int] =
+    PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[mutable.Set[Int]])
 
   @Benchmark
   def uPickle(): mutable.Set[Int] = read[mutable.Set[Int]](jsonBytes)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -39,6 +39,9 @@ class MutableSetOfIntsWriting extends MutableSetOfIntsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def uPickle(): Array[Byte] = write(obj).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 //import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -42,6 +42,9 @@ class NestedStructsReading extends NestedStructsBenchmark {
 
   @Benchmark
   def playJson(): NestedStructs = Json.parse(jsonBytes).as[NestedStructs]
+
+  @Benchmark
+  def playJsonJsoniter(): NestedStructs = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[NestedStructs])
 
   @Benchmark
   def sprayJson(): NestedStructs = JsonParser(jsonBytes).convertTo[NestedStructs](nestedStructsJsonFormat)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 //import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -44,6 +44,9 @@ class NestedStructsWriting extends NestedStructsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson(nestedStructsJsonFormat).compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -42,6 +42,9 @@ class PrimitivesReading extends PrimitivesBenchmark {
 
   @Benchmark
   def playJson(): Primitives = Json.parse(jsonBytes).as[Primitives]
+
+  @Benchmark
+  def playJsonJsoniter(): Primitives = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Primitives])
 
   @Benchmark
   def sprayJson(): Primitives = JsonParser(jsonBytes).convertTo[Primitives]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -45,6 +45,9 @@ class PrimitivesWriting extends PrimitivesBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -39,6 +39,9 @@ class SetOfIntsReading extends SetOfIntsBenchmark {
 
   @Benchmark
   def playJson(): Set[Int] = Json.parse(jsonBytes).as[Set[Int]]
+
+  @Benchmark
+  def playJsonJsoniter(): Set[Int] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Set[Int]])
 
   @Benchmark
   def sprayJson(): Set[Int] = JsonParser(jsonBytes).convertTo[Set[Int]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -41,6 +41,9 @@ class SetOfIntsWriting extends SetOfIntsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -36,6 +36,9 @@ class StringOfAsciiCharsReading extends StringOfAsciiCharsBenchmark {
 
   @Benchmark
   def playJson(): String = Json.parse(jsonBytes).as[String]
+
+  @Benchmark
+  def playJsonJsoniter(): String = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[String])
 
   @Benchmark
   def sprayJson(): String = spray.json.JsonParser(jsonBytes).convertTo[String]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -40,6 +40,9 @@ class StringOfAsciiCharsWriting extends StringOfAsciiCharsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = {

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsBenchmark.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsBenchmark.scala
@@ -13,7 +13,7 @@ class StringOfEscapedCharsBenchmark extends CommonParams {
   @Param(Array("1", "10", "100", "1000", "10000", "100000", "1000000"))
   var size: Int = 1000
   var obj: String = _
-  var jsonString: String = _
+  var jsonString1: String = _
   var jsonString2: String = _
   var jsonBytes: Array[Byte] = _
   var preallocatedBuf: Array[Byte] = _
@@ -38,9 +38,9 @@ class StringOfEscapedCharsBenchmark extends CommonParams {
       }
       new String(cs)
     }
-    jsonString = "\"" + obj.map(ch => f"\\u$ch%04x").mkString  + "\""
+    jsonString1 = "\"" + obj.map(ch => f"\\u$ch%04x").mkString  + "\""
     jsonString2 = "\"" + obj.map(ch => f"\\u$ch%04X").mkString  + "\""
-    jsonBytes = jsonString.getBytes(UTF_8)
+    jsonBytes = jsonString1.getBytes(UTF_8)
     preallocatedBuf = new Array[Byte](jsonBytes.length + 100/*to avoid possible out of bounds error*/)
   }
 }

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -36,6 +36,9 @@ class StringOfEscapedCharsReading extends StringOfEscapedCharsBenchmark {
 
   @Benchmark
   def playJson(): String = Json.parse(jsonBytes).as[String]
+
+  @Benchmark
+  def playJsonJsoniter(): String = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[String])
 
   @Benchmark
   def sprayJson(): String = spray.json.JsonParser(jsonBytes).convertTo[String]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -32,6 +32,9 @@ class StringOfEscapedCharsWriting extends StringOfEscapedCharsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.asciiStringify(Json.toJson(obj)).getBytes
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = writeToArray(Json.toJson(obj), escapingConfig)(PlayJsonJsoniter.jsValueCodec)
 
   @Benchmark
   def uPickle(): Array[Byte] = write(obj, escapeUnicode = true).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -36,6 +36,9 @@ class StringOfNonAsciiCharsReading extends StringOfNonAsciiCharsBenchmark {
 
   @Benchmark
   def playJson(): String = Json.parse(jsonBytes).as[String]
+
+  @Benchmark
+  def playJsonJsoniter(): String = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[String])
 
   @Benchmark
   def sprayJson(): String = spray.json.JsonParser(jsonBytes).convertTo[String]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -40,6 +40,9 @@ class StringOfNonAsciiCharsWriting extends StringOfNonAsciiCharsBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = {

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.AVSystemCodecs._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.BorerJsonEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
@@ -45,6 +45,9 @@ class TwitterAPIReading extends TwitterAPIBenchmark {
 
   @Benchmark
   def playJson(): Seq[Tweet] = Json.parse(jsonBytes).as[Seq[Tweet]]
+
+  @Benchmark
+  def playJsonJsoniter(): Seq[Tweet] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Seq[Tweet]])
 
   @Benchmark
   def sprayJson(): Seq[Tweet] = JsonParser(jsonBytes).convertTo[Seq[Tweet]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReading.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
@@ -37,6 +37,9 @@ class VectorOfBooleansReading extends VectorOfBooleansBenchmark {
 
   @Benchmark
   def playJson(): Vector[Boolean] = Json.parse(jsonBytes).as[Vector[Boolean]]
+
+  @Benchmark
+  def playJsonJsoniter(): Vector[Boolean] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Vector[Boolean]])
 
   @Benchmark
   def sprayJson(): Vector[Boolean] = JsonParser(jsonBytes).convertTo[Vector[Boolean]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansWriting.scala
@@ -1,8 +1,8 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.avsystem.commons.serialization.json._
+import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.DslPlatformJson._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
@@ -41,6 +41,9 @@ class VectorOfBooleansWriting extends VectorOfBooleansBenchmark {
 
   @Benchmark
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
+
+  @Benchmark
+  def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTWritingSpec.scala
@@ -13,6 +13,7 @@ class ADTWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString1
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString1
       toString(b.playJson()) shouldBe b.jsonString1
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString1
       toString(b.sprayJson()) shouldBe b.jsonString2
       toString(b.uPickle()) shouldBe b.jsonString1
       toString(b.weePickle()) shouldBe b.jsonString1

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsReadingSpec.scala
@@ -13,6 +13,7 @@ class AnyValsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsWritingSpec.scala
@@ -15,6 +15,7 @@ class AnyValsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString1
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString1
       toString(b.playJson()) shouldBe b.jsonString3
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString1
       toString(b.sprayJson()) shouldBe b.jsonString2
       toString(b.uPickle()) shouldBe b.jsonString1
       toString(b.weePickle()) shouldBe b.jsonString1

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansReadingSpec.scala
@@ -16,6 +16,7 @@ class ArrayBufferOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayBufferOfBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsReadingSpec.scala
@@ -14,6 +14,7 @@ class ArrayOfBigDecimalsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.sourceObj
       benchmark.jsoniterScala() shouldBe benchmark.sourceObj
       benchmark.playJson() shouldBe benchmark.sourceObj
+      benchmark.playJsonJsoniter() shouldBe benchmark.sourceObj
       benchmark.sprayJson() shouldBe benchmark.sourceObj
       benchmark.uPickle() shouldBe benchmark.sourceObj
       //FIXME: weePickle rounds mantissa to 16 digits

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfBigDecimalsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       //FIXME: weePickle writes BigDecimal as JSON strings by default

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReadingSpec.scala
@@ -14,6 +14,7 @@ class ArrayOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class ArrayOfBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReadingSpec.scala
@@ -15,6 +15,7 @@ class ArrayOfBytesReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class ArrayOfBytesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesWritingSpec.scala
@@ -17,6 +17,7 @@ class ArrayOfBytesWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsReadingSpec.scala
@@ -13,6 +13,7 @@ class ArrayOfCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -26,6 +27,7 @@ class ArrayOfCharsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsWritingSpec.scala
@@ -15,6 +15,7 @@ class ArrayOfCharsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReadingSpec.scala
@@ -14,6 +14,7 @@ class ArrayOfDoublesReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class ArrayOfDoublesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfDoublesWritingSpec extends BenchmarkSpecBase {
       check(toString(b.jsoniterScala()), b.jsonString)
       check(toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()), b.jsonString)
       check(toString(b.playJson()), b.jsonString)
+      check(toString(b.playJsonJsoniter()), b.jsonString)
       check(toString(b.sprayJson()), b.jsonString)
       check(toString(b.uPickle()), b.jsonString)
       check(toString(b.weePickle()), b.jsonString)

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsReadingSpec.scala
@@ -13,6 +13,7 @@ class ArrayOfDurationsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
     }
@@ -25,6 +26,7 @@ class ArrayOfDurationsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsWritingSpec.scala
@@ -15,6 +15,7 @@ class ArrayOfDurationsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsReadingSpec.scala
@@ -14,6 +14,7 @@ class ArrayOfEnumADTsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -29,6 +30,7 @@ class ArrayOfEnumADTsReadingSpec extends BenchmarkSpecBase {
         intercept[Throwable](b.jacksonScala())
         intercept[Throwable](b.jsoniterScala())
         intercept[Throwable](b.playJson())
+        intercept[Throwable](b.playJsonJsoniter())
         intercept[Throwable](b.sprayJson())
         intercept[Throwable](b.uPickle())
         intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfEnumADTsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsReadingSpec.scala
@@ -13,6 +13,7 @@ class ArrayOfEnumsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -27,6 +28,7 @@ class ArrayOfEnumsReadingSpec extends BenchmarkSpecBase {
         intercept[Throwable](b.jacksonScala())
         intercept[Throwable](b.jsoniterScala())
         intercept[Throwable](b.playJson())
+        intercept[Throwable](b.playJsonJsoniter())
         intercept[Throwable](b.sprayJson())
         intercept[Throwable](b.uPickle())
         intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsWritingSpec.scala
@@ -15,6 +15,7 @@ class ArrayOfEnumsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReadingSpec.scala
@@ -29,6 +29,7 @@ class ArrayOfFloatsReadingSpec extends BenchmarkSpecBase {
       //benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       //FIXME: weePickle parses 1.199999988079071 as 1.2f instead of 1.1999999f
@@ -42,6 +43,7 @@ class ArrayOfFloatsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circe())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfFloatsWritingSpec extends BenchmarkSpecBase {
       check(toString(b.jsoniterScala()), b.jsonString)
       check(toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()), b.jsonString)
       check(toString(b.playJson()), b.jsonString)
+      check(toString(b.playJsonJsoniter()), b.jsonString)
       check(toString(b.sprayJson()), b.jsonString)
       check(toString(b.uPickle()), b.jsonString)
       check(toString(b.weePickle()), b.jsonString)

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReadingSpec.scala
@@ -13,6 +13,7 @@ class ArrayOfInstantsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -26,6 +27,7 @@ class ArrayOfInstantsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsWritingSpec.scala
@@ -15,6 +15,7 @@ class ArrayOfInstantsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReadingSpec.scala
@@ -14,6 +14,7 @@ class ArrayOfIntsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -27,6 +28,7 @@ class ArrayOfIntsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsWritingSpec.scala
@@ -17,6 +17,7 @@ class ArrayOfIntsWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsReadingSpec.scala
@@ -14,6 +14,7 @@ class ArrayOfJavaEnumsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -29,6 +30,7 @@ class ArrayOfJavaEnumsReadingSpec extends BenchmarkSpecBase {
         intercept[Throwable](b.jacksonScala())
         intercept[Throwable](b.jsoniterScala())
         intercept[Throwable](b.playJson())
+        intercept[Throwable](b.playJsonJsoniter())
         intercept[Throwable](b.sprayJson())
         intercept[Throwable](b.uPickle())
         intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfJavaEnumsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesReadingSpec.scala
@@ -14,6 +14,7 @@ class ArrayOfLocalDateTimesReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class ArrayOfLocalDateTimesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfLocalDateTimesWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesReadingSpec.scala
@@ -14,6 +14,7 @@ class ArrayOfLocalDatesReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class ArrayOfLocalDatesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfLocalDatesWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesReadingSpec.scala
@@ -14,6 +14,7 @@ class ArrayOfLocalTimesReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class ArrayOfLocalTimesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfLocalTimesWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReadingSpec.scala
@@ -14,6 +14,7 @@ class ArrayOfLongsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class ArrayOfLongsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfLongsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysReadingSpec.scala
@@ -13,6 +13,7 @@ class ArrayOfMonthDaysReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
     }
@@ -25,6 +26,7 @@ class ArrayOfMonthDaysReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysWritingSpec.scala
@@ -15,6 +15,7 @@ class ArrayOfMonthDaysWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesReadingSpec.scala
@@ -14,6 +14,7 @@ class ArrayOfOffsetDateTimesReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class ArrayOfOffsetDateTimesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfOffsetDateTimesWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesReadingSpec.scala
@@ -14,6 +14,7 @@ class ArrayOfOffsetTimesReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
     }
@@ -27,6 +28,7 @@ class ArrayOfOffsetTimesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfOffsetTimesWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsReadingSpec.scala
@@ -13,6 +13,7 @@ class ArrayOfPeriodsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
     }
@@ -25,6 +26,7 @@ class ArrayOfPeriodsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsWritingSpec.scala
@@ -15,6 +15,7 @@ class ArrayOfPeriodsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReadingSpec.scala
@@ -14,6 +14,7 @@ class ArrayOfShortsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class ArrayOfShortsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfShortsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReadingSpec.scala
@@ -14,6 +14,7 @@ class ArrayOfUUIDsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class ArrayOfUUIDsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfUUIDsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsReadingSpec.scala
@@ -13,6 +13,7 @@ class ArrayOfYearMonthsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
     }
@@ -28,6 +29,7 @@ class ArrayOfYearMonthsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsWritingSpec.scala
@@ -15,6 +15,7 @@ class ArrayOfYearMonthsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsReadingSpec.scala
@@ -13,6 +13,7 @@ class ArrayOfYearsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
     }
@@ -25,6 +26,7 @@ class ArrayOfYearsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsWritingSpec.scala
@@ -15,6 +15,7 @@ class ArrayOfYearsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsReadingSpec.scala
@@ -13,6 +13,7 @@ class ArrayOfZoneIdsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
     }
@@ -25,6 +26,7 @@ class ArrayOfZoneIdsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsWritingSpec.scala
@@ -15,6 +15,7 @@ class ArrayOfZoneIdsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsReadingSpec.scala
@@ -13,6 +13,7 @@ class ArrayOfZoneOffsetsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
     }
@@ -25,6 +26,7 @@ class ArrayOfZoneOffsetsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsWritingSpec.scala
@@ -15,6 +15,7 @@ class ArrayOfZoneOffsetsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesReadingSpec.scala
@@ -15,6 +15,7 @@ class ArrayOfZonedDateTimesReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class ArrayOfZonedDateTimesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesWritingSpec.scala
@@ -17,6 +17,7 @@ class ArrayOfZonedDateTimesWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalWritingSpec.scala
@@ -16,6 +16,7 @@ class BigDecimalWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       BigDecimal(toString(b.playJson())) shouldBe b.obj
+      BigDecimal(toString(b.playJsonJsoniter())) shouldBe b.obj
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       //FIXME: weePickle serializes BigDecimal values as JSON strings

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BitSetReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BitSetReadingSpec.scala
@@ -15,6 +15,7 @@ class BitSetReadingSpec extends BenchmarkSpecBase {
       //benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
     }
     "fail on invalid input" in {
       val b = benchmark
@@ -23,6 +24,7 @@ class BitSetReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circe())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
     }
   }
 }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BitSetWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BitSetWritingSpec.scala
@@ -15,6 +15,7 @@ class BitSetWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
     }
   }
 }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReadingSpec.scala
@@ -14,6 +14,7 @@ class ExtractFieldsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class ExtractFieldsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReadingSpec.scala
@@ -11,6 +11,7 @@ class GeoJSONReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -27,6 +28,7 @@ class GeoJSONReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWritingSpec.scala
@@ -13,6 +13,7 @@ class GeoJSONWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString1
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString1
       toString(b.playJson()) shouldBe b.jsonString1
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString1
       toString(b.sprayJson()) shouldBe b.jsonString3
       toString(b.uPickle()) shouldBe b.jsonString1
       toString(b.weePickle()) shouldBe b.jsonString1

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrintingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrintingSpec.scala
@@ -12,6 +12,7 @@ class GoogleMapsAPIPrettyPrintingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString2
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString2
       toString(b.playJson()) shouldBe b.jsonString1
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString2
       toString(b.sprayJson()) shouldBe b.jsonString2
       toString(b.uPickle()) shouldBe b.jsonString2
       toString(b.weePickle()) shouldBe b.jsonString2

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReadingSpec.scala
@@ -12,6 +12,7 @@ class GoogleMapsAPIReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -26,6 +27,7 @@ class GoogleMapsAPIReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWritingSpec.scala
@@ -14,6 +14,7 @@ class GoogleMapsAPIWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.compactJsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.compactJsonString
       toString(b.playJson()) shouldBe b.compactJsonString
+      toString(b.playJsonJsoniter()) shouldBe b.compactJsonString
       toString(b.sprayJson()) shouldBe b.compactJsonString
       toString(b.uPickle()) shouldBe b.compactJsonString
       toString(b.weePickle()) shouldBe b.compactJsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansReadingSpec.scala
@@ -15,6 +15,7 @@ class IntMapOfBooleansReadingSpec extends BenchmarkSpecBase {
       //benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       //FIXME: uPickle doesn't support IntMap
       //benchmark.uPickle() shouldBe benchmark.obj
     }
@@ -25,6 +26,7 @@ class IntMapOfBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circe())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
     }
   }
 }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansWritingSpec.scala
@@ -16,6 +16,7 @@ class IntMapOfBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       //FIXME: uPickle doesn't support IntMap
       //toString(b.uPickle()) shouldBe b.jsonString
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReadingSpec.scala
@@ -12,6 +12,7 @@ class IntReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -26,6 +27,7 @@ class IntReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntWritingSpec.scala
@@ -14,6 +14,7 @@ class IntWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReadingSpec.scala
@@ -14,6 +14,7 @@ class ListOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class ListOfBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansWritingSpec.scala
@@ -16,6 +16,7 @@ class ListOfBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansReadingSpec.scala
@@ -13,6 +13,7 @@ class MapOfIntsToBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       //FIXME: Spray-JSON throws spray.json.DeserializationException: Expected Int as JsNumber, but got "-1"
       //benchmark.sprayJson() shouldBe benchmark.obj
       //FIXME: uPickle parses maps from JSON arrays only
@@ -28,6 +29,7 @@ class MapOfIntsToBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.weePickle())
     }
   }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MissingRequiredFieldsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MissingRequiredFieldsReadingSpec.scala
@@ -36,6 +36,7 @@ class MissingRequiredFieldsReadingSpec extends BenchmarkSpecBase {
           || 00000000 | 7b 7d                                           | {}               |
           |+----------+-------------------------------------------------+------------------+""".stripMargin
       b.playJson() should include("JsResultException")
+      b.playJsonJsoniter() should include("JsResultException")
       b.sprayJson() shouldBe
         "Object is missing required member 's'"
       b.uPickle() shouldBe
@@ -55,6 +56,7 @@ class MissingRequiredFieldsReadingSpec extends BenchmarkSpecBase {
       b.jsoniterScalaWithoutDump() shouldBe "MissingRequiredFields(VVV,1)"
       b.jsoniterScalaWithStacktrace() shouldBe "MissingRequiredFields(VVV,1)"
       b.playJson() shouldBe "MissingRequiredFields(VVV,1)"
+      b.playJsonJsoniter() shouldBe "MissingRequiredFields(VVV,1)"
       b.sprayJson() shouldBe "MissingRequiredFields(VVV,1)"
       b.uPickle() shouldBe "MissingRequiredFields(VVV,1)"
       b.weePickle() shouldBe "MissingRequiredFields(VVV,1)"

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableBitSetReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableBitSetReadingSpec.scala
@@ -15,6 +15,7 @@ class MutableBitSetReadingSpec extends BenchmarkSpecBase {
       //benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
     }
     "fail on invalid input" in {
       val b = benchmark
@@ -23,6 +24,7 @@ class MutableBitSetReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circe())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
     }
   }
 }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableBitSetWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableBitSetWritingSpec.scala
@@ -15,6 +15,7 @@ class MutableBitSetWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
     }
   }
 }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansReadingSpec.scala
@@ -15,6 +15,7 @@ class MutableLongMapOfBooleansReadingSpec extends BenchmarkSpecBase {
       //benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
     }
     "fail on invalid input" in {
       val b = benchmark
@@ -23,6 +24,7 @@ class MutableLongMapOfBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circe())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
     }
   }
 }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansWritingSpec.scala
@@ -16,6 +16,7 @@ class MutableLongMapOfBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
     }
   }
 }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansReadingSpec.scala
@@ -13,6 +13,7 @@ class MutableMapOfIntsToBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
     }
     "fail on invalid input" in {
@@ -24,6 +25,7 @@ class MutableMapOfIntsToBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.weePickle())
     }
   }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansWritingSpec.scala
@@ -15,6 +15,7 @@ class MutableMapOfIntsToBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString
     }
   }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsReadingSpec.scala
@@ -14,6 +14,7 @@ class MutableSetOfIntsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
     }
@@ -27,6 +28,7 @@ class MutableSetOfIntsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsWritingSpec.scala
@@ -16,6 +16,7 @@ class MutableSetOfIntsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString
     }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReadingSpec.scala
@@ -15,6 +15,7 @@ class NestedStructsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class NestedStructsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsWritingSpec.scala
@@ -18,6 +18,7 @@ class NestedStructsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReadingSpec.scala
@@ -12,6 +12,7 @@ class PrimitivesReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -26,6 +27,7 @@ class PrimitivesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesWritingSpec.scala
@@ -14,6 +14,7 @@ class PrimitivesWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString1
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString1
       toString(b.playJson()) shouldBe b.jsonString3
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString1
       toString(b.sprayJson()) shouldBe b.jsonString2
       toString(b.uPickle()) shouldBe b.jsonString1
       toString(b.weePickle()) shouldBe b.jsonString1

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReadingSpec.scala
@@ -14,6 +14,7 @@ class SetOfIntsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class SetOfIntsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsWritingSpec.scala
@@ -21,6 +21,7 @@ class SetOfIntsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       readFromArray[Set[Int]](b.sprayJson()) shouldBe b.obj
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReadingSpec.scala
@@ -14,6 +14,7 @@ class StringOfAsciiCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class StringOfAsciiCharsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsWritingSpec.scala
@@ -16,6 +16,7 @@ class StringOfAsciiCharsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReadingSpec.scala
@@ -14,6 +14,7 @@ class StringOfEscapedCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class StringOfEscapedCharsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsWritingSpec.scala
@@ -8,13 +8,14 @@ class StringOfEscapedCharsWritingSpec extends BenchmarkSpecBase {
   "StringOfEscapedCharsWriting" should {
     "write properly" in {
       val b = benchmark
-      toString(b.avSystemGenCodec()) shouldBe b.jsonString
-      toString(b.circe()) shouldBe b.jsonString
+      toString(b.avSystemGenCodec()) shouldBe b.jsonString1
+      toString(b.circe()) shouldBe b.jsonString1
       toString(b.jacksonScala()) shouldBe b.jsonString2
-      toString(b.jsoniterScala()) shouldBe b.jsonString
-      toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
+      toString(b.jsoniterScala()) shouldBe b.jsonString1
+      toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString1
       toString(b.playJson()) shouldBe b.jsonString2
-      toString(b.uPickle()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString1
+      toString(b.uPickle()) shouldBe b.jsonString1
       toString(b.weePickle()) shouldBe b.jsonString2
     }
   }

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReadingSpec.scala
@@ -14,6 +14,7 @@ class StringOfNonAsciiCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class StringOfNonAsciiCharsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsWritingSpec.scala
@@ -16,6 +16,7 @@ class StringOfNonAsciiCharsWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIReadingSpec.scala
@@ -12,6 +12,7 @@ class TwitterAPIReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -26,6 +27,7 @@ class TwitterAPIReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReadingSpec.scala
@@ -14,6 +14,7 @@ class VectorOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
+      benchmark.playJsonJsoniter() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -28,6 +29,7 @@ class VectorOfBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
+      intercept[Throwable](b.playJsonJsoniter())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansWritingSpec.scala
@@ -16,6 +16,7 @@ class VectorOfBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
+      toString(b.playJsonJsoniter()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString


### PR DESCRIPTION
Benchmark results from my laptop:
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                         Mode  Cnt     Score      Error  Units
[info] GeoJSONReading.playJson          thrpt    5  4212.860 ±  621.728  ops/s
[info] GeoJSONReading.playJsonJsoniter  thrpt    5  9999.170 ± 1398.665  ops/s
[info] GeoJSONWriting.playJson          thrpt    5  1791.183 ±    6.950  ops/s
[info] GeoJSONWriting.playJsonJsoniter  thrpt    5  2976.143 ±  340.579  ops/s
```