### PR TITLE
Remove rallyhealth bintray resolvers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -173,7 +173,6 @@ lazy val `jsoniter-scala-benchmark` = crossProject(JVMPlatform, JSPlatform)
   .settings(
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     resolvers ++= Seq(
-      "Rally Health" at "https://dl.bintray.com/rallyhealth/maven",
       "Playframework" at "https://dl.bintray.com/playframework/maven"
     ),
     crossScalaVersions := Seq("2.13.5"),


### PR DESCRIPTION
The bintray resolver can be removed now that weepickle has moved to maven central. Bintray currently returns 403 for all repos except [the ones](https://dl.bintray.com/typesafe/sbt-plugins/) with special agreements.

Others can probably be removed, too. Thanks for your patience with our less than rapid migration!

ref: https://github.com/rallyhealth/weePickle/issues/10