### PR TITLE
Test parsing of doubles with FastDoubleParser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -172,6 +172,7 @@ lazy val `jsoniter-scala-benchmark` = crossProject(JVMPlatform, JSPlatform)
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     crossScalaVersions := Seq("2.13.6"),
     libraryDependencies ++= Seq(
+      "ch.randelshofer" % "fastdoubleparser" % "0.3.0",
       "dev.zio" %%% "zio-json" % "0.1.5",
       "com.evolutiongaming" %% "play-json-jsoniter" % "0.9.1",
       "com.rallyhealth" %% "weepickle-v1" % "1.4.2",

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/DoubleReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/DoubleReading.scala
@@ -1,0 +1,69 @@
+package com.github.plokhotnyuk.jsoniter_scala.core
+
+import ch.randelshofer.fastdoubleparser.FastDoubleParser
+import com.github.plokhotnyuk.jsoniter_scala.benchmark.CommonParams
+import org.openjdk.jmh.annotations.Benchmark
+
+class DoubleReading extends CommonParams {
+  private[this] val parseDouble: String => Double = {
+    new ThreadLocal[(Array[Byte], JsonReader)] with JsonValueCodec[Double] with (String => Double) {
+      def apply(x: String): Double = {
+        val (buf, reader) = get
+        val len = x.length
+        var i = 0
+        while (i < len) {
+          buf(i) = x.charAt(i).toByte
+          i += 1
+        }
+        reader.read(this, buf, 0, len, ReaderConfig)
+      }
+
+      override def decodeValue(in: JsonReader, default: Double): Double = in.readDouble()
+
+      override def encodeValue(x: Double, out: JsonWriter): Unit = out.writeVal(x)
+
+      override def initialValue(): (Array[Byte], JsonReader) = {
+        val buf = new Array[Byte](32)
+        (buf, new JsonReader(buf, charBuf = new Array[Char](32)))
+      }
+
+      override val nullValue: Double = 0.0
+    }
+  }
+
+  @Benchmark
+  def longMantissaBase(): Double = java.lang.Double.parseDouble("123456.7890123456")
+
+  @Benchmark
+  def longMantissaJsoniterScala(): Double = parseDouble("123456.7890123456")
+
+  @Benchmark
+  def longMantissaFastDoubleParser(): Double = FastDoubleParser.parseDouble("123456.7890123456")
+
+  @Benchmark
+  def longWholeNumberBase(): Double = java.lang.Double.parseDouble("1234567890123456.0")
+
+  @Benchmark
+  def longWholeNumberJsoniterScala(): Double = parseDouble("1234567890123456.0")
+
+  @Benchmark
+  def longWholeNumberFastDoubleParser(): Double = FastDoubleParser.parseDouble("1234567890123456.0")
+
+  @Benchmark
+  def shortMantissaBase(): Double = java.lang.Double.parseDouble("1.2")
+
+  @Benchmark
+  def shortMantissaJsoniterScala(): Double = parseDouble("1.2")
+
+  @Benchmark
+  def shortMantissaFastDoubleParser(): Double = FastDoubleParser.parseDouble("1.2")
+
+  @Benchmark
+  def shortWholeNumberBase(): Double = java.lang.Double.parseDouble("12.0")
+
+  @Benchmark
+  def shortWholeNumberJsoniterScala(): Double = parseDouble("12.0")
+
+  @Benchmark
+  def shortWholeNumberFastDoubleParser(): Double = FastDoubleParser.parseDouble("12.0")
+}


### PR DESCRIPTION
Results of benchmarks:
```
[info] Benchmark                                        Mode  Cnt         Score         Error  Units
[info] DoubleReading.longMantissaBase                  thrpt    5   8637888.699 ±  583783.705  ops/s
[info] DoubleReading.longMantissaFastDoubleParser      thrpt    5  28191251.395 ±  186921.346  ops/s
[info] DoubleReading.longMantissaJsoniterScala         thrpt    5  19680074.864 ±  188218.892  ops/s
[info] DoubleReading.longWholeNumberBase               thrpt    5  10520995.552 ±  559877.839  ops/s
[info] DoubleReading.longWholeNumberFastDoubleParser   thrpt    5   7238300.568 ±  307790.256  ops/s
[info] DoubleReading.longWholeNumberJsoniterScala      thrpt    5  17053799.048 ±  132748.116  ops/s
[info] DoubleReading.shortMantissaBase                 thrpt    5  43959720.857 ± 2069580.823  ops/s
[info] DoubleReading.shortMantissaFastDoubleParser     thrpt    5  55547413.335 ± 3607601.457  ops/s
[info] DoubleReading.shortMantissaJsoniterScala        thrpt    5  43277797.093 ± 2252612.195  ops/s
[info] DoubleReading.shortWholeNumberBase              thrpt    5  44600941.752 ± 1677539.096  ops/s
[info] DoubleReading.shortWholeNumberFastDoubleParser  thrpt    5  50718808.912 ± 3413681.214  ops/s
[info] DoubleReading.shortWholeNumberJsoniterScala     thrpt    5  39975486.359 ± 3355070.084  ops/s
```