### PR TITLE
Drop JDK 8 support for more efficient parsing and serialization of some types of numbers and `java.time._` classes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         java:
           - zulu@1.11
-          - zulu@1.8
+          - zulu@1.17
         os:
           - ubuntu-latest
           - macOS-latest
@@ -44,7 +44,7 @@ jobs:
         run: "sbt -batch clean +test +mimaReportBinaryIssues"
         shell: bash
       - name: Test with coverage
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.java == 'zulu@1.8' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.java == 'zulu@1.11' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: "sbt -batch ++2.13.6! coverage jsoniter-scala-coreJVM/test jsoniter-scala-macrosJVM/test jsoniter-scala-benchmarkJVM/test coverageAggregate coveralls"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ serialization performance of jsoniter-scala with [AVSystem's scala-commons](http
 [Spray-JSON](https://github.com/spray/spray-json), [uPickle](https://github.com/lihaoyi/upickle),
 [weePickle](https://github.com/rallyhealth/weePickle), and [zio-json](https://github.com/zio/zio-json) 
 libraries using different JDK and GraalVM versions on the following environment: Intel® Core™ i9-9880H CPU @ 2.3GHz
-(max 4.8GHz), RAM 16Gb DDR4-2400, macOS Mojave 10.14.6, and latest versions of Amazon Corretto 8/11, OpenJDK 18
+(max 4.8GHz), RAM 16Gb DDR4-2400, macOS Mojave 10.14.6, and latest versions of Amazon Corretto 11/17, OpenJDK 18
 (early-access build) [*](https://docs.google.com/spreadsheets/d/1IxIvLoLlLb0bxUaRgSsaaRuXV0RUQ3I04vFqhDc2Bt8/edit?usp=sharing),
-GraalVM CE 21.3 (dev build) for Java 11/16, GraalVM EE 21.2 (release) for Java 8/11/16.
+GraalVM CE 21.3 (dev build) for Java 11/17, GraalVM EE 21.2 (release) for Java 11/16.
 
 [**Latest results of benchmarks on browsers**](https://plokhotnyuk.github.io/jsoniter-scala/index-scalajs.html) that 
 compares the same libraries on the same environment by the same code which is compiled by Scala.js to ES 5.1 with GCC
@@ -78,7 +78,7 @@ and run-time configuration instances, combined with compile-time annotations and
 representation of JSON providing a pretty printing option, provide a hex dump in the error message to speed up the
 view of an error context
 
-The library targets JDK 8+ and GraalVM 19+ (including compilation to native images) without any platform restrictions.
+The library targets JDK 11+ and GraalVM 19+ (including compilation to native images) without any platform restrictions.
 
 ## Features and limitations
 
@@ -499,7 +499,7 @@ More info about extras, options, and ability to generate flame graphs see in [Sb
 
 Other benchmarks with results for jsoniter-scala:
 - [comparison](https://github.com/sirthias/borer/pull/30) with other JSON parsers for Scala mostly on samples from real
-  APIs, but with mapping to simple types only like strings and primitives and results for GraalVM EE Java8 only
+  APIs, but with mapping to simple types only like strings and primitives and results for GraalVM EE Java 8 only
 - [comparison](https://github.com/dkomanov/scala-serialization/pull/8) with the best binary parsers and serializers for
   Scala
 - [comparison](https://github.com/saint1991/serialization-benchmark) with different binary and text serializers for 

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val commonSettings = Seq(
     "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
   ),
   scalaVersion := "2.13.6",
-  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+  javacOptions ++= Seq("-source", "11", "-target", "11"),
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding", "UTF-8",
@@ -47,7 +47,7 @@ lazy val commonSettings = Seq(
         )
         case 13 => Seq()
       }) ++ Seq(
-        "-target:jvm-1.8",
+        "-target:11",
         "-Xmacro-settings:" + sys.props.getOrElse("macro.settings", "none")
       )
     } else Seq()

--- a/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1224,7 +1224,7 @@ final class JsonWriter private[jsoniter_scala](
       val effectiveTotalSecs =
         if (totalSecs < 0) (-nano >> 31) - totalSecs
         else totalSecs
-      val hours = effectiveTotalSecs / 3600 // FIXME: Use Math.multiplyHigh(x >> 4, 655884233731895169L) >> 3 after dropping JDK 8 support
+      val hours = Math.multiplyHigh(effectiveTotalSecs >> 4, 655884233731895169L) >> 3 // effectiveTotalSecs / 3600
       val secsOfHour = (effectiveTotalSecs - hours * 3600).toInt
       val minutes = secsOfHour * 17477 >> 20 // divide a small positive int by 60
       val seconds = secsOfHour - minutes * 60
@@ -1237,7 +1237,7 @@ final class JsonWriter private[jsoniter_scala](
         pos =
           if (hours.toInt == hours) writePositiveInt(hours.toInt, pos, buf, ds)
           else {
-            val q1 = hours / 100000000 // FIXME: Use Math.multiplyHigh(hours, 193428131138340668L) >>> 20 after dropping JDK 8 support
+            val q1 = Math.multiplyHigh(hours, 193428131138340668L) >>> 20 // hours / 100000000
             val r1 = (hours - q1 * 100000000).toInt
             write8Digits(r1, writePositiveInt(q1.toInt, pos, buf, ds), buf, ds)
           }
@@ -1662,7 +1662,7 @@ final class JsonWriter private[jsoniter_scala](
   }
 
   private[this] def write18Digits(q0: Long, pos: Int, buf: Array[Byte], ds: Array[Short]): Int = {
-    val q1 = q0 / 100000000 // FIXME: Use Math.multiplyHigh(q0, 193428131138340668L) >>> 20 after dropping JDK 8 support
+    val q1 = Math.multiplyHigh(q0, 193428131138340668L) >>> 20 // q0 / 100000000
     val r1 = (q0 - q1 * 100000000).toInt
     val q2 = (q1 >> 8) * 1441151881 >> 49 // divide a small positive long by 100000000
     val r2 = (q1 - q2 * 100000000).toInt
@@ -1730,7 +1730,7 @@ final class JsonWriter private[jsoniter_scala](
       }
     if (q0.toInt == q0) writePositiveInt(q0.toInt, pos, buf, ds)
     else {
-      val q1 = q0 / 100000000 // FIXME: Use Math.multiplyHigh(q0, 193428131138340668L) >>> 20 after dropping JDK 8 support
+      val q1 = Math.multiplyHigh(q0, 193428131138340668L) >>> 20 // q0 / 100000000
       val r1 = (q0 - q1 * 100000000).toInt
       if (q1.toInt == q1) write8Digits(r1, writePositiveInt(q1.toInt, pos, buf, ds), buf, ds)
       else {
@@ -1866,7 +1866,7 @@ final class JsonWriter private[jsoniter_scala](
   }
 
   private[this] def rop(g: Long, cp: Int): Int = {
-    val x1 = ((g & 0xFFFFFFFFL) * cp >>> 32) + (g >>> 32) * cp // FIXME: Use Math.multiplyHigh after dropping JDK 8 support
+    val x1 = Math.multiplyHigh(g, cp.toLong << 32) // ((g & 0xFFFFFFFFL) * cp >>> 32) + (g >>> 32) * cp
     (x1 >>> 31).toInt | -x1.toInt >>> 31
   }
 
@@ -1923,7 +1923,7 @@ final class JsonWriter private[jsoniter_scala](
         val vbrd = outm1 - rop(g1, g0, cb + 2 << h)
         val s = vb >> 2
         if (s < 100 || {
-          dv = s / 10 // FIXME: Use Math.multiplyHigh(s, 1844674407370955168L) instead after dropping JDK 8 support
+          dv = Math.multiplyHigh(s, 1844674407370955168L) // s / 10
           val sp40 = dv * 40
           val upin = (vbls - sp40).toInt
           (((sp40 + vbrd).toInt + 40) ^ upin) >= 0 || {
@@ -1993,20 +1993,10 @@ final class JsonWriter private[jsoniter_scala](
   }
 
   private[this] def rop(g1: Long, g0: Long, cp: Long): Long = {
-    val x1 = multiplyHigh(g0, cp) // FIXME: Use Math.multiplyHigh after dropping JDK 8 support
+    val x1 = Math.multiplyHigh(g0, cp)
     val z = (g1 * cp >>> 1) + x1
-    val y1 = multiplyHigh(g1, cp) // FIXME: Use Math.multiplyHigh after dropping JDK 8 support
+    val y1 = Math.multiplyHigh(g1, cp)
     (z >>> 63) + y1 | -(z & 0x7FFFFFFFFFFFFFFFL) >>> 63
-  }
-
-  private[this] def multiplyHigh(x: Long, y: Long): Long = { // Use Karatsuba technique with two base 2^32 digits
-    val x2 = x & 0xFFFFFFFFL
-    val y2 = y & 0xFFFFFFFFL
-    val b = x2 * y2
-    val x1 = x >>> 32
-    val y1 = y >>> 32
-    val a = x1 * y1
-    (((b >>> 32) + (x1 + x2) * (y1 + y2) - b - a) >>> 32) + a
   }
 
   // Adoption of a nice trick from Daniel Lemire's blog that works for numbers up to 10^18:
@@ -2016,7 +2006,7 @@ final class JsonWriter private[jsoniter_scala](
   private[this] def writeSignificantFractionDigits(q0: Long, pos: Int, posLim: Int, buf: Array[Byte], ds: Array[Short]): Int =
     if (q0.toInt == q0) writeSignificantFractionDigits(q0.toInt, pos, posLim, buf, ds)
     else {
-      val q1 = q0 / 100000000 // FIXME: Use Math.multiplyHigh(q0, 193428131138340668L) >>> 20 after dropping JDK 8 support
+      val q1 = Math.multiplyHigh(q0, 193428131138340668L) >>> 20 // q0 / 100000000
       val r1 = (q0 - q1 * 100000000).toInt
       if (r1 == 0) writeSignificantFractionDigits(q1.toInt, pos - 8, posLim, buf, ds)
       else {

--- a/release.sbt
+++ b/release.sbt
@@ -1,9 +1,11 @@
 import scala.sys.process._
 import sbtrelease.ReleaseStateTransformations._
 
+import scala.util.Try
+
 lazy val ensureJDK8: ReleaseStep = { st: State =>
-  val javaVersion = System.getProperty("java.specification.version")
-  if (javaVersion != "1.8") throw new IllegalStateException("Cancelling release, please use JDK 1.8")
+  val javaMajorVersion = Try(System.getProperty("java.specification.version").split('.')(0).toInt).getOrElse(0)
+  if (javaMajorVersion != 11) throw new IllegalStateException("Cancelling release, please use JDK 11")
   st
 }
 


### PR DESCRIPTION
Performance improvements on JDK 17 are too small to drop JDK 8 support now.
## Before
```
[info] Benchmark                                    (size)   Mode  Cnt       Score       Error  Units
[info] ArrayOfDoublesReading.jsoniterScala             128  thrpt    5  226446.023 ± 49427.780  ops/s
[info] ArrayOfDoublesWriting.jsoniterScala             128  thrpt    5  168589.640 ± 11525.663  ops/s
[info] ArrayOfDoublesWriting.jsoniterScalaPrealloc     128  thrpt    5  160991.678 ± 33580.137  ops/s
[info] ArrayOfFloatsReading.jsoniterScala              128  thrpt    5  322841.853 ±  3838.026  ops/s
[info] ArrayOfFloatsWriting.jsoniterScala              128  thrpt    5  273020.114 ±  6094.720  ops/s
[info] ArrayOfFloatsWriting.jsoniterScalaPrealloc      128  thrpt    5  275820.840 ± 28968.697  ops/s
```
## After
```
[info] Benchmark                                    (size)   Mode  Cnt       Score       Error  Units
[info] ArrayOfDoublesReading.jsoniterScala             128  thrpt    5  231053.087 ± 36165.692  ops/s
[info] ArrayOfDoublesWriting.jsoniterScala             128  thrpt    5  173660.841 ± 20153.898  ops/s
[info] ArrayOfDoublesWriting.jsoniterScalaPrealloc     128  thrpt    5  180128.598 ± 42129.485  ops/s
[info] ArrayOfFloatsReading.jsoniterScala              128  thrpt    5  314440.050 ± 29804.469  ops/s
[info] ArrayOfFloatsWriting.jsoniterScala              128  thrpt    5  272804.634 ±  3313.528  ops/s
[info] ArrayOfFloatsWriting.jsoniterScalaPrealloc      128  thrpt    5  289814.814 ±  1391.401  ops/s
```