### PR TITLE
Use SWAR technique for more efficient serialization

### DIFF
--- a/jsoniter-scala-core/jvm/src/main/java/com/github/plokhotnyuk/jsoniter_scala/core/ByteArrayAsInt.java
+++ b/jsoniter-scala-core/jvm/src/main/java/com/github/plokhotnyuk/jsoniter_scala/core/ByteArrayAsInt.java
@@ -1,0 +1,14 @@
+package com.github.plokhotnyuk.jsoniter_scala.core;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
+class ByteArrayAsInt { // FIXME: Use Java wrapper as w/a for missing support of @PolymorphicSignature methods in Scala 3, see: https://github.com/lampepfl/dotty/issues/11332
+    private static final VarHandle VH_INT =
+            MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+
+    static void set(byte[] buf, int pos, int value) {
+        VH_INT.set(buf, pos, value);
+    }
+}

--- a/jsoniter-scala-core/jvm/src/main/java/com/github/plokhotnyuk/jsoniter_scala/core/ByteArrayAsLong.java
+++ b/jsoniter-scala-core/jvm/src/main/java/com/github/plokhotnyuk/jsoniter_scala/core/ByteArrayAsLong.java
@@ -1,0 +1,14 @@
+package com.github.plokhotnyuk.jsoniter_scala.core;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
+class ByteArrayAsLong { // FIXME: Use Java wrapper as w/a for missing support of @PolymorphicSignature methods in Scala 3, see: https://github.com/lampepfl/dotty/issues/11332
+    private static final VarHandle VH_LONG =
+            MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+
+    static void set(byte[] buf, int pos, long value) {
+        VH_LONG.set(buf, pos, value);
+    }
+}

--- a/jsoniter-scala-core/jvm/src/main/java/com/github/plokhotnyuk/jsoniter_scala/core/ByteArrayAsShort.java
+++ b/jsoniter-scala-core/jvm/src/main/java/com/github/plokhotnyuk/jsoniter_scala/core/ByteArrayAsShort.java
@@ -1,0 +1,14 @@
+package com.github.plokhotnyuk.jsoniter_scala.core;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
+class ByteArrayAsShort { // FIXME: Use Java wrapper as w/a for missing support of @PolymorphicSignature methods in Scala 3, see: https://github.com/lampepfl/dotty/issues/11332
+    private static final VarHandle VH_SHORT =
+            MethodHandles.byteArrayViewVarHandle(short[].class, ByteOrder.LITTLE_ENDIAN);
+
+    static void set(byte[] buf, int pos, short value) {
+        VH_SHORT.set(buf, pos, value);
+    }
+}

--- a/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1186,12 +1186,13 @@ final class JsonWriter private[jsoniter_scala](
 
   private[this] def writeBoolean(x: Boolean): Unit = count = {
     val pos = ensureBufCapacity(8) // bytes in Long
-    val buf = this.buf
-    val v =
-      if (x) 0x65757274L
-      else 0x65736c6166L
-    ByteArrayAsLong.set(buf, pos, v)
-    pos + 4 + (v >> 38).toInt
+    if (x) {
+      ByteArrayAsInt.set(buf, pos, 0x65757274)
+      pos + 4
+    } else {
+      ByteArrayAsLong.set(buf, pos, 0x65736c6166L)
+      pos + 5
+    }
   }
 
   private[this] def writeByte(x: Byte): Unit = count = {

--- a/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -867,7 +867,6 @@ final class JsonWriter private[jsoniter_scala](
 
   private[this] def writeUUID(mostSigBits: Long, leastSigBits: Long): Unit = count = {
     val ds = lowerCaseHexDigits
-    val vh = varHandleAsLong
     val pos = ensureBufCapacity(40) // 38 == (new java.util.UUID(0, 0)).toString.length + 2
     val buf = this.buf
     val mostSigBits1 = (mostSigBits >> 32).toInt
@@ -875,26 +874,26 @@ final class JsonWriter private[jsoniter_scala](
     val d2 = ds((mostSigBits1 >> 16) & 0xFF).toLong << 24
     val d3 = ds((mostSigBits1 >> 8) & 0xFF).toLong << 40
     val d4 = ds(mostSigBits1 & 0xFF)
-    vh.set(buf, pos, '"' | d1 | d2 | d3 | d4.toLong << 56)
+    ByteArrayAsLong.set(buf, pos, '"' | d1 | d2 | d3 | d4.toLong << 56)
     val mostSigBits2 = mostSigBits.toInt
     val d5 = ds(mostSigBits2 >>> 24) << 16
     val d6 = ds((mostSigBits2 >> 16) & 0xFF).toLong << 32
     val d7 = ds((mostSigBits2 >> 8) & 0xFF)
-    vh.set(buf, pos + 8, d4 >> 8 | d5 | d6 | d7.toLong << 56 | 0x2D000000002D00L) // 0x2D000000002D00L == '-'.toLong << 48 | '-' << 8
+    ByteArrayAsLong.set(buf, pos + 8, d4 >> 8 | d5 | d6 | d7.toLong << 56 | 0x2D000000002D00L) // 0x2D000000002D00L == '-'.toLong << 48 | '-' << 8
     val d8 = ds(mostSigBits2 & 0xFF) << 8
     val leastSigBits1 = (leastSigBits >> 32).toInt
     val d9 = ds(leastSigBits1 >>> 24).toLong << 32
     val d10 = ds((leastSigBits1 >> 16) & 0xFF).toLong << 48
-    vh.set(buf, pos + 16, d7 >> 8 | d8 | d9 | d10 | 0x2D000000) // 0x2D000000 == '-' << 24
+    ByteArrayAsLong.set(buf, pos + 16, d7 >> 8 | d8 | d9 | d10 | 0x2D000000) // 0x2D000000 == '-' << 24
     val d11 = ds((leastSigBits1 >> 8) & 0xFF) << 8
     val d12 = ds(leastSigBits1 & 0xFF).toLong << 24
     val leastSigBits2 = leastSigBits.toInt
     val d13 = ds(leastSigBits2 >>> 24).toLong << 40
     val d14 = ds((leastSigBits2 >> 16) & 0xFF)
-    vh.set(buf, pos + 24, '-' | d11 | d12| d13 | d14.toLong << 56)
+    ByteArrayAsLong.set(buf, pos + 24, '-' | d11 | d12| d13 | d14.toLong << 56)
     val d15 = ds((leastSigBits2 >> 8) & 0xFF) << 8
     val d16 = ds(leastSigBits2 & 0xFF).toLong << 24
-    vh.set(buf, pos + 32, d14 >> 8 | d15 | d16 | 0x220000000000L) // 0x220000000000L == '"'.toLong << 40
+    ByteArrayAsLong.set(buf, pos + 32, d14 >> 8 | d15 | d16 | 0x220000000000L) // 0x220000000000L == '"'.toLong << 40
     pos + 38
   }
 
@@ -1186,13 +1185,12 @@ final class JsonWriter private[jsoniter_scala](
   }
 
   private[this] def writeBoolean(x: Boolean): Unit = count = {
-    val vh = varHandleAsLong
     val pos = ensureBufCapacity(8) // bytes in Long
     val buf = this.buf
     val v =
       if (x) 0x65757274L
       else 0x65736c6166L
-    vh.set(buf, pos, v)
+    ByteArrayAsLong.set(buf, pos, v)
     pos + 4 + (v >> 38).toInt
   }
 
@@ -1673,7 +1671,6 @@ final class JsonWriter private[jsoniter_scala](
   }
 
   private[this] def write8Digits(q0: Int, pos: Int, buf: Array[Byte], ds: Array[Short]): Int = {
-    val vh = varHandleAsLong
     val y1 = q0 * 140737489L // James Anhalt's algorithm for 8 digits: https://jk-jeon.github.io/posts/2022/02/jeaiii-algorithm/
     val y2 = (y1 & 0x7FFFFFFFFFFFL) * 100
     val y3 = (y2 & 0x7FFFFFFFFFFFL) * 100
@@ -1682,7 +1679,7 @@ final class JsonWriter private[jsoniter_scala](
     val d2 = ds((y2 >>> 47).toInt) << 16
     val d3 = ds((y3 >>> 47).toInt).toLong << 32
     val d4 = ds((y4 >>> 47).toInt).toLong << 48
-    vh.set(buf, pos, d1 | d2 | d3 | d4)
+    ByteArrayAsLong.set(buf, pos, d1 | d2 | d3 | d4)
     pos + 8
   }
 
@@ -2125,8 +2122,6 @@ final class JsonWriter private[jsoniter_scala](
 }
 
 object JsonWriter {
-  private final val varHandleAsLong: VarHandle =
-    MethodHandles.byteArrayViewVarHandle(classOf[Array[Long]], ByteOrder.LITTLE_ENDIAN)
   private final val isGraalVM: Boolean =
     Option(System.getProperty("java.vendor.version")).getOrElse(System.getProperty("java.vm.name")).contains("GraalVM") ||
       java.lang.management.ManagementFactory.getRuntimeMXBean.getInputArguments.contains("-XX:+UseJVMCICompiler")

--- a/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
+++ b/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala
@@ -1648,12 +1648,7 @@ final class JsonWriter private[jsoniter_scala](
 
   private[this] def write4Digits(q0: Int, pos: Int, buf: Array[Byte], ds: Array[Short]): Int = {
     val q1 = q0 * 5243 >> 19 // divide a small positive int by 100
-    val d1 = ds(q1)
-    buf(pos) = d1.toByte
-    buf(pos + 1) = (d1 >> 8).toByte
-    val d2 = ds(q0 - q1 * 100)
-    buf(pos + 2) = d2.toByte
-    buf(pos + 3) = (d2 >> 8).toByte
+    ByteArrayAsInt.set(buf, pos, ds(q1) | ds(q0 - q1 * 100) << 16)
     pos + 4
   }
 
@@ -1661,13 +1656,8 @@ final class JsonWriter private[jsoniter_scala](
     val y0 = q0 * 429497L // James Anhalt's algorithm for 5 digits: https://jk-jeon.github.io/posts/2022/02/jeaiii-algorithm/
     buf(pos) = ((y0 >>> 32).toInt + '0').toByte
     val y1 = (y0 & 0xFFFFFFFFL) * 100
-    val d1 = ds((y1 >>> 32).toInt)
-    buf(pos + 1) = d1.toByte
-    buf(pos + 2) = (d1 >> 8).toByte
     val y2 = (y1 & 0xFFFFFFFFL) * 100
-    val d2 = ds((y2 >>> 32).toInt)
-    buf(pos + 3) = d2.toByte
-    buf(pos + 4) = (d2 >> 8).toByte
+    ByteArrayAsInt.set(buf, pos + 1, ds((y1 >>> 32).toInt) | ds((y2 >>> 32).toInt) << 16)
     pos + 5
   }
 
@@ -1676,11 +1666,8 @@ final class JsonWriter private[jsoniter_scala](
     val y2 = (y1 & 0x7FFFFFFFFFFFL) * 100
     val y3 = (y2 & 0x7FFFFFFFFFFFL) * 100
     val y4 = (y3 & 0x7FFFFFFFFFFFL) * 100
-    val d1 = ds((y1 >>> 47).toInt)
-    val d2 = ds((y2 >>> 47).toInt) << 16
-    val d3 = ds((y3 >>> 47).toInt).toLong << 32
-    val d4 = ds((y4 >>> 47).toInt).toLong << 48
-    ByteArrayAsLong.set(buf, pos, d1 | d2 | d3 | d4)
+    ByteArrayAsLong.set(buf, pos,
+      ds((y1 >>> 47).toInt) | ds((y2 >>> 47).toInt) << 16 | ds((y3 >>> 47).toInt).toLong << 32 | ds((y4 >>> 47).toInt).toLong << 48)
     pos + 8
   }
 


### PR DESCRIPTION
### Before
```
[info] Benchmark                                                              (size)   Mode  Cnt        Score       Error   Units
[info] ArrayOfBooleansWriting.jsoniterScala                                      128  thrpt   25  4458639.175 ± 63709.601   ops/s
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.alloc.rate                       128  thrpt   25     2062.367 ±    29.438  MB/sec
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.alloc.rate.norm                  128  thrpt   25      728.024 ±     0.001    B/op
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.churn.PS_Eden_Space              128  thrpt   25     2066.625 ±   134.569  MB/sec
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.churn.PS_Eden_Space.norm         128  thrpt   25      729.251 ±    43.522    B/op
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.churn.PS_Survivor_Space          128  thrpt   25        0.072 ±     0.043  MB/sec
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.churn.PS_Survivor_Space.norm     128  thrpt   25        0.026 ±     0.015    B/op
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.count                            128  thrpt   25      101.000              counts
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.time                             128  thrpt   25       49.000                  ms
[info] ArrayOfBooleansWriting.jsoniterScalaPrealloc                              128  thrpt   25  5082912.453 ± 99819.166   ops/s
[info] ArrayOfBooleansWriting.jsoniterScalaPrealloc:·gc.alloc.rate               128  thrpt   25       ≈ 10⁻⁴              MB/sec
[info] ArrayOfBooleansWriting.jsoniterScalaPrealloc:·gc.alloc.rate.norm          128  thrpt   25       ≈ 10⁻⁴                B/op
[info] ArrayOfBooleansWriting.jsoniterScalaPrealloc:·gc.count                    128  thrpt   25          ≈ 0              counts
[info] ArrayOfLongsWriting.jsoniterScala                                         128  thrpt   25   924508.495 ±  5984.689   ops/s
[info] ArrayOfLongsWriting.jsoniterScala:·gc.alloc.rate                          128  thrpt   25      878.784 ±     5.701  MB/sec
[info] ArrayOfLongsWriting.jsoniterScala:·gc.alloc.rate.norm                     128  thrpt   25     1496.060 ±     0.016    B/op
[info] ArrayOfLongsWriting.jsoniterScala:·gc.churn.PS_Eden_Space                 128  thrpt   25      920.769 ±   156.421  MB/sec
[info] ArrayOfLongsWriting.jsoniterScala:·gc.churn.PS_Eden_Space.norm            128  thrpt   25     1568.095 ±   267.530    B/op
[info] ArrayOfLongsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space             128  thrpt   25        0.828 ±     1.223  MB/sec
[info] ArrayOfLongsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space.norm        128  thrpt   25        1.413 ±     2.088    B/op
[info] ArrayOfLongsWriting.jsoniterScala:·gc.count                               128  thrpt   25       45.000              counts
[info] ArrayOfLongsWriting.jsoniterScala:·gc.time                                128  thrpt   25       55.000                  ms
[info] ArrayOfLongsWriting.jsoniterScalaPrealloc                                 128  thrpt   25   996838.828 ± 11775.262   ops/s
[info] ArrayOfLongsWriting.jsoniterScalaPrealloc:·gc.alloc.rate                  128  thrpt   25       ≈ 10⁻⁴              MB/sec
[info] ArrayOfLongsWriting.jsoniterScalaPrealloc:·gc.alloc.rate.norm             128  thrpt   25       ≈ 10⁻³                B/op
[info] ArrayOfLongsWriting.jsoniterScalaPrealloc:·gc.count                       128  thrpt   25          ≈ 0              counts
[info] ArrayOfShortsWriting.jsoniterScala                                        128  thrpt   25  2813370.127 ± 91263.532   ops/s
[info] ArrayOfShortsWriting.jsoniterScala:·gc.alloc.rate                         128  thrpt   25      958.158 ±    31.087  MB/sec
[info] ArrayOfShortsWriting.jsoniterScala:·gc.alloc.rate.norm                    128  thrpt   25      536.021 ±     0.004    B/op
[info] ArrayOfShortsWriting.jsoniterScala:·gc.churn.PS_Eden_Space                128  thrpt   25     1002.626 ±    76.636  MB/sec
[info] ArrayOfShortsWriting.jsoniterScala:·gc.churn.PS_Eden_Space.norm           128  thrpt   25      560.892 ±    42.496    B/op
[info] ArrayOfShortsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space            128  thrpt   25        0.823 ±     1.221  MB/sec
[info] ArrayOfShortsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space.norm       128  thrpt   25        0.461 ±     0.685    B/op
[info] ArrayOfShortsWriting.jsoniterScala:·gc.count                              128  thrpt   25       49.000              counts
[info] ArrayOfShortsWriting.jsoniterScala:·gc.time                               128  thrpt   25       54.000                  ms
[info] ArrayOfShortsWriting.jsoniterScalaPrealloc                                128  thrpt   25  2975819.637 ± 28745.179   ops/s
[info] ArrayOfShortsWriting.jsoniterScalaPrealloc:·gc.alloc.rate                 128  thrpt   25       ≈ 10⁻⁴              MB/sec
[info] ArrayOfShortsWriting.jsoniterScalaPrealloc:·gc.alloc.rate.norm            128  thrpt   25       ≈ 10⁻⁴                B/op
[info] ArrayOfShortsWriting.jsoniterScalaPrealloc:·gc.count                      128  thrpt   25          ≈ 0              counts
[info] ArrayOfUUIDsWriting.jsoniterScala                                         128  thrpt   25   684445.143 ±  3588.079   ops/s
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.alloc.rate                          128  thrpt   25     2181.365 ±    11.427  MB/sec
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.alloc.rate.norm                     128  thrpt   25     5016.163 ±     0.012    B/op
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.churn.PS_Eden_Space                 128  thrpt   25     2148.463 ±   156.448  MB/sec
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.churn.PS_Eden_Space.norm            128  thrpt   25     4940.934 ±   362.539    B/op
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space             128  thrpt   25        0.069 ±     0.028  MB/sec
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space.norm        128  thrpt   25        0.159 ±     0.064    B/op
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.count                               128  thrpt   25      105.000              counts
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.time                                128  thrpt   25       51.000                  ms
[info] ArrayOfUUIDsWriting.jsoniterScalaPrealloc                                 128  thrpt   25   896328.083 ±  3729.540   ops/s
[info] ArrayOfUUIDsWriting.jsoniterScalaPrealloc:·gc.alloc.rate                  128  thrpt   25       ≈ 10⁻⁴              MB/sec
[info] ArrayOfUUIDsWriting.jsoniterScalaPrealloc:·gc.alloc.rate.norm             128  thrpt   25       ≈ 10⁻³                B/op
[info] ArrayOfUUIDsWriting.jsoniterScalaPrealloc:·gc.count                       128  thrpt   25          ≈ 0              counts
[info] ArrayOfYearsWriting.jsoniterScala                                         128  thrpt   25  3022385.770 ± 16160.276   ops/s
[info] ArrayOfYearsWriting.jsoniterScala:·gc.alloc.rate                          128  thrpt   25     1766.753 ±     9.453  MB/sec
[info] ArrayOfYearsWriting.jsoniterScala:·gc.alloc.rate.norm                     128  thrpt   25      920.030 ±     0.003    B/op
[info] ArrayOfYearsWriting.jsoniterScala:·gc.churn.PS_Eden_Space                 128  thrpt   25     1739.229 ±   191.585  MB/sec
[info] ArrayOfYearsWriting.jsoniterScala:·gc.churn.PS_Eden_Space.norm            128  thrpt   25      905.992 ±   101.293    B/op
[info] ArrayOfYearsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space             128  thrpt   25        0.067 ±     0.036  MB/sec
[info] ArrayOfYearsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space.norm        128  thrpt   25        0.035 ±     0.019    B/op
[info] ArrayOfYearsWriting.jsoniterScala:·gc.count                               128  thrpt   25       85.000              counts
[info] ArrayOfYearsWriting.jsoniterScala:·gc.time                                128  thrpt   25       44.000                  ms
[info] ArrayOfYearsWriting.jsoniterScalaPrealloc                                 128  thrpt   25  3549626.006 ± 24661.944   ops/s
[info] ArrayOfYearsWriting.jsoniterScalaPrealloc:·gc.alloc.rate                  128  thrpt   25       ≈ 10⁻⁴              MB/sec
[info] ArrayOfYearsWriting.jsoniterScalaPrealloc:·gc.alloc.rate.norm             128  thrpt   25       ≈ 10⁻⁴                B/op
[info] ArrayOfYearsWriting.jsoniterScalaPrealloc:·gc.count                       128  thrpt   25          ≈ 0              counts
```
### After
```
[info] Benchmark                                                              (size)   Mode  Cnt        Score        Error   Units
[info] ArrayOfBooleansWriting.jsoniterScala                                      128  thrpt   25  6028369.424 ±  87069.283   ops/s
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.alloc.rate                       128  thrpt   25     2788.608 ±     40.348  MB/sec
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.alloc.rate.norm                  128  thrpt   25      728.024 ±      0.002    B/op
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.churn.PS_Eden_Space              128  thrpt   25     2782.930 ±    194.127  MB/sec
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.churn.PS_Eden_Space.norm         128  thrpt   25      726.823 ±     51.932    B/op
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.churn.PS_Survivor_Space          128  thrpt   25        0.091 ±      0.038  MB/sec
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.churn.PS_Survivor_Space.norm     128  thrpt   25        0.024 ±      0.010    B/op
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.count                            128  thrpt   25      136.000               counts
[info] ArrayOfBooleansWriting.jsoniterScala:·gc.time                             128  thrpt   25       67.000                   ms
[info] ArrayOfBooleansWriting.jsoniterScalaPrealloc                              128  thrpt   25  7414436.038 ±  34629.583   ops/s
[info] ArrayOfBooleansWriting.jsoniterScalaPrealloc:·gc.alloc.rate               128  thrpt   25       ≈ 10⁻⁴               MB/sec
[info] ArrayOfBooleansWriting.jsoniterScalaPrealloc:·gc.alloc.rate.norm          128  thrpt   25       ≈ 10⁻⁴                 B/op
[info] ArrayOfBooleansWriting.jsoniterScalaPrealloc:·gc.count                    128  thrpt   25          ≈ 0               counts
[info] ArrayOfLongsWriting.jsoniterScala                                         128  thrpt   25   931553.345 ±   6671.878   ops/s
[info] ArrayOfLongsWriting.jsoniterScala:·gc.alloc.rate                          128  thrpt   25      885.482 ±      6.337  MB/sec
[info] ArrayOfLongsWriting.jsoniterScala:·gc.alloc.rate.norm                     128  thrpt   25     1496.059 ±      0.016    B/op
[info] ArrayOfLongsWriting.jsoniterScala:·gc.churn.PS_Eden_Space                 128  thrpt   25      920.768 ±    156.414  MB/sec
[info] ArrayOfLongsWriting.jsoniterScala:·gc.churn.PS_Eden_Space.norm            128  thrpt   25     1555.806 ±    264.557    B/op
[info] ArrayOfLongsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space             128  thrpt   25        0.819 ±      1.216  MB/sec
[info] ArrayOfLongsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space.norm        128  thrpt   25        1.380 ±      2.050    B/op
[info] ArrayOfLongsWriting.jsoniterScala:·gc.count                               128  thrpt   25       45.000               counts
[info] ArrayOfLongsWriting.jsoniterScala:·gc.time                                128  thrpt   25       52.000                   ms
[info] ArrayOfLongsWriting.jsoniterScalaPrealloc                                 128  thrpt   25  1009089.996 ±  10250.336   ops/s
[info] ArrayOfLongsWriting.jsoniterScalaPrealloc:·gc.alloc.rate                  128  thrpt   25       ≈ 10⁻⁴               MB/sec
[info] ArrayOfLongsWriting.jsoniterScalaPrealloc:·gc.alloc.rate.norm             128  thrpt   25       ≈ 10⁻³                 B/op
[info] ArrayOfLongsWriting.jsoniterScalaPrealloc:·gc.count                       128  thrpt   25          ≈ 0               counts
[info] ArrayOfShortsWriting.jsoniterScala                                        128  thrpt   25  2733561.211 ± 107113.747   ops/s
[info] ArrayOfShortsWriting.jsoniterScala:·gc.alloc.rate                         128  thrpt   25      930.968 ±     36.464  MB/sec
[info] ArrayOfShortsWriting.jsoniterScala:·gc.alloc.rate.norm                    128  thrpt   25      536.020 ±      0.005    B/op
[info] ArrayOfShortsWriting.jsoniterScala:·gc.churn.PS_Eden_Space                128  thrpt   25      920.770 ±    156.427  MB/sec
[info] ArrayOfShortsWriting.jsoniterScala:·gc.churn.PS_Eden_Space.norm           128  thrpt   25      529.962 ±     89.023    B/op
[info] ArrayOfShortsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space            128  thrpt   25        0.817 ±      1.214  MB/sec
[info] ArrayOfShortsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space.norm       128  thrpt   25        0.475 ±      0.707    B/op
[info] ArrayOfShortsWriting.jsoniterScala:·gc.count                              128  thrpt   25       45.000               counts
[info] ArrayOfShortsWriting.jsoniterScala:·gc.time                               128  thrpt   25       50.000                   ms
[info] ArrayOfShortsWriting.jsoniterScalaPrealloc                                128  thrpt   25  3299744.917 ± 154775.030   ops/s
[info] ArrayOfShortsWriting.jsoniterScalaPrealloc:·gc.alloc.rate                 128  thrpt   25       ≈ 10⁻⁴               MB/sec
[info] ArrayOfShortsWriting.jsoniterScalaPrealloc:·gc.alloc.rate.norm            128  thrpt   25       ≈ 10⁻⁴                 B/op
[info] ArrayOfShortsWriting.jsoniterScalaPrealloc:·gc.count                      128  thrpt   25          ≈ 0               counts
[info] ArrayOfUUIDsWriting.jsoniterScala                                         128  thrpt   25   713388.120 ±   4744.069   ops/s
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.alloc.rate                          128  thrpt   25     2273.627 ±     15.128  MB/sec
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.alloc.rate.norm                     128  thrpt   25     5016.164 ±      0.014    B/op
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.churn.PS_Eden_Space                 128  thrpt   25     2250.761 ±    191.581  MB/sec
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.churn.PS_Eden_Space.norm            128  thrpt   25     4965.525 ±    419.947    B/op
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space             128  thrpt   25        0.081 ±      0.033  MB/sec
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space.norm        128  thrpt   25        0.178 ±      0.071    B/op
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.count                               128  thrpt   25      110.000               counts
[info] ArrayOfUUIDsWriting.jsoniterScala:·gc.time                                128  thrpt   25       55.000                   ms
[info] ArrayOfUUIDsWriting.jsoniterScalaPrealloc                                 128  thrpt   25   924222.447 ±  11440.995   ops/s
[info] ArrayOfUUIDsWriting.jsoniterScalaPrealloc:·gc.alloc.rate                  128  thrpt   25       ≈ 10⁻⁴               MB/sec
[info] ArrayOfUUIDsWriting.jsoniterScalaPrealloc:·gc.alloc.rate.norm             128  thrpt   25       ≈ 10⁻³                 B/op
[info] ArrayOfUUIDsWriting.jsoniterScalaPrealloc:·gc.count                       128  thrpt   25          ≈ 0               counts
[info] ArrayOfYearsWriting.jsoniterScala                                         128  thrpt   25  3303992.916 ±  24660.536   ops/s
[info] ArrayOfYearsWriting.jsoniterScala:·gc.alloc.rate                          128  thrpt   25     1931.381 ±     14.422  MB/sec
[info] ArrayOfYearsWriting.jsoniterScala:·gc.alloc.rate.norm                     128  thrpt   25      920.030 ±      0.003    B/op
[info] ArrayOfYearsWriting.jsoniterScala:·gc.churn.PS_Eden_Space                 128  thrpt   25     1923.424 ±    167.021  MB/sec
[info] ArrayOfYearsWriting.jsoniterScala:·gc.churn.PS_Eden_Space.norm            128  thrpt   25      916.449 ±     80.539    B/op
[info] ArrayOfYearsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space             128  thrpt   25        0.056 ±      0.028  MB/sec
[info] ArrayOfYearsWriting.jsoniterScala:·gc.churn.PS_Survivor_Space.norm        128  thrpt   25        0.027 ±      0.013    B/op
[info] ArrayOfYearsWriting.jsoniterScala:·gc.count                               128  thrpt   25       94.000               counts
[info] ArrayOfYearsWriting.jsoniterScala:·gc.time                                128  thrpt   25       47.000                   ms
[info] ArrayOfYearsWriting.jsoniterScalaPrealloc                                 128  thrpt   25  3566464.404 ±  34206.451   ops/s
[info] ArrayOfYearsWriting.jsoniterScalaPrealloc:·gc.alloc.rate                  128  thrpt   25       ≈ 10⁻⁴               MB/sec
[info] ArrayOfYearsWriting.jsoniterScalaPrealloc:·gc.alloc.rate.norm             128  thrpt   25       ≈ 10⁻⁴                 B/op
[info] ArrayOfYearsWriting.jsoniterScalaPrealloc:·gc.count                       128  thrpt   25          ≈ 0               counts
```