### PR TITLE
Reduce memory usage when parsing `BigInt` and `BigDecimal` values with JVMs

### DIFF
--- a/jsoniter-scala-core/jvm/src/main/java/com/github/plokhotnyuk/jsoniter_scala/core/ByteArrayAccess.java
+++ b/jsoniter-scala-core/jvm/src/main/java/com/github/plokhotnyuk/jsoniter_scala/core/ByteArrayAccess.java
@@ -24,6 +24,10 @@ class ByteArrayAccess { // FIXME: Use Java wrapper as w/a for missing support of
         VH_INT.set(buf, pos, value);
     }
 
+    static int getInt(byte[] buf, int pos) {
+        return (int) VH_INT.get(buf, pos);
+    }
+
     static void setShort(byte[] buf, int pos, short value) {
         VH_SHORT.set(buf, pos, value);
     }


### PR DESCRIPTION
## Before
```
[info] Benchmark                                                                 (size)   Mode  Cnt        Score         Error   Units
[info] BigDecimalReading.jsoniterScala                                              100  thrpt    5  4225351.033 ±  117047.611   ops/s
[info] BigDecimalReading.jsoniterScala:·gc.alloc.rate                               100  thrpt    5      794.899 ±      22.092  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.alloc.rate.norm                          100  thrpt    5      296.010 ±       0.013    B/op
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Eden_Space                      100  thrpt    5      818.768 ±    1079.239  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Eden_Space.norm                 100  thrpt    5      305.231 ±     405.943    B/op
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Survivor_Space                  100  thrpt    5        0.010 ±       0.039  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Survivor_Space.norm             100  thrpt    5        0.004 ±       0.015    B/op
[info] BigDecimalReading.jsoniterScala:·gc.count                                    100  thrpt    5        8.000                counts
[info] BigDecimalReading.jsoniterScala:·gc.time                                     100  thrpt    5       14.000                    ms
[info] BigDecimalReading.jsoniterScala                                             1000  thrpt    5   202583.561 ±   16209.487   ops/s
[info] BigDecimalReading.jsoniterScala:·gc.alloc.rate                              1000  thrpt    5      764.245 ±      60.911  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.alloc.rate.norm                         1000  thrpt    5     5936.186 ±       0.280    B/op
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Eden_Space                     1000  thrpt    5      716.437 ±    1079.488  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Eden_Space.norm                1000  thrpt    5     5576.734 ±    8546.358    B/op
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Survivor_Space                 1000  thrpt    5        0.011 ±       0.083  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Survivor_Space.norm            1000  thrpt    5        0.088 ±       0.665    B/op
[info] BigDecimalReading.jsoniterScala:·gc.count                                   1000  thrpt    5        7.000                counts
[info] BigDecimalReading.jsoniterScala:·gc.time                                    1000  thrpt    5       12.000                    ms
[info] BigDecimalReading.jsoniterScala                                            10000  thrpt    5     4806.663 ±     244.167   ops/s
[info] BigDecimalReading.jsoniterScala:·gc.alloc.rate                             10000  thrpt    5     1518.617 ±      77.074  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.alloc.rate.norm                        10000  thrpt    5   497082.053 ±      12.287    B/op
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Eden_Space                    10000  thrpt    5     1535.042 ±       0.959  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Eden_Space.norm               10000  thrpt    5   502529.800 ±   26034.123    B/op
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Survivor_Space                10000  thrpt    5        0.826 ±       7.069  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Survivor_Space.norm           10000  thrpt    5      269.804 ±    2308.538    B/op
[info] BigDecimalReading.jsoniterScala:·gc.count                                  10000  thrpt    5       15.000                counts
[info] BigDecimalReading.jsoniterScala:·gc.time                                   10000  thrpt    5        8.000                    ms
[info] BigIntReading.jsoniterScala                                                  100  thrpt    5  4069295.004 ±  518129.632   ops/s
[info] BigIntReading.jsoniterScala:·gc.alloc.rate                                   100  thrpt    5      765.532 ±      97.482  MB/sec
[info] BigIntReading.jsoniterScala:·gc.alloc.rate.norm                              100  thrpt    5      296.009 ±       0.013    B/op
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Eden_Space                          100  thrpt    5      716.457 ±    1079.372  MB/sec
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Eden_Space.norm                     100  thrpt    5      275.659 ±     395.485    B/op
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Survivor_Space                      100  thrpt    5        0.012 ±       0.052  MB/sec
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Survivor_Space.norm                 100  thrpt    5        0.005 ±       0.021    B/op
[info] BigIntReading.jsoniterScala:·gc.count                                        100  thrpt    5        7.000                counts
[info] BigIntReading.jsoniterScala:·gc.time                                         100  thrpt    5       13.000                    ms
[info] BigIntReading.jsoniterScala                                                 1000  thrpt    5   202512.828 ±   28504.343   ops/s
[info] BigIntReading.jsoniterScala:·gc.alloc.rate                                  1000  thrpt    5      764.016 ±     107.464  MB/sec
[info] BigIntReading.jsoniterScala:·gc.alloc.rate.norm                             1000  thrpt    5     5936.188 ±       0.296    B/op
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Eden_Space                         1000  thrpt    5      716.462 ±    1079.388  MB/sec
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Eden_Space.norm                    1000  thrpt    5     5613.836 ±    9018.925    B/op
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Survivor_Space                     1000  thrpt    5        0.007 ±       0.035  MB/sec
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Survivor_Space.norm                1000  thrpt    5        0.054 ±       0.267    B/op
[info] BigIntReading.jsoniterScala:·gc.count                                       1000  thrpt    5        7.000                counts
[info] BigIntReading.jsoniterScala:·gc.time                                        1000  thrpt    5       14.000                    ms
[info] BigIntReading.jsoniterScala                                                10000  thrpt    5     4751.414 ±     359.787   ops/s
[info] BigIntReading.jsoniterScala:·gc.alloc.rate                                 10000  thrpt    5     1501.067 ±     113.646  MB/sec
[info] BigIntReading.jsoniterScala:·gc.alloc.rate.norm                            10000  thrpt    5   497082.259 ±      12.236    B/op
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Eden_Space                        10000  thrpt    5     1535.115 ±       0.389  MB/sec
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Eden_Space.norm                   10000  thrpt    5   508517.897 ±   39317.784    B/op
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Survivor_Space                    10000  thrpt    5        0.828 ±       7.000  MB/sec
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Survivor_Space.norm               10000  thrpt    5      272.543 ±    2300.855    B/op
[info] BigIntReading.jsoniterScala:·gc.count                                      10000  thrpt    5       15.000                counts
[info] BigIntReading.jsoniterScala:·gc.time                                       10000  thrpt    5        9.000                    ms
```
## After
```
[info] Benchmark                                                                 (size)   Mode  Cnt        Score         Error   Units
[info] BigDecimalReading.jsoniterScala                                              100  thrpt    5  4051339.605 ±  232278.651   ops/s
[info] BigDecimalReading.jsoniterScala:·gc.alloc.rate                               100  thrpt    5      597.386 ±      34.263  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.alloc.rate.norm                          100  thrpt    5      232.008 ±       0.012    B/op
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Eden_Space                      100  thrpt    5      614.084 ±     881.276  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Eden_Space.norm                 100  thrpt    5      239.613 ±     363.183    B/op
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Survivor_Space                  100  thrpt    5        0.016 ±       0.083  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Survivor_Space.norm             100  thrpt    5        0.006 ±       0.032    B/op
[info] BigDecimalReading.jsoniterScala:·gc.count                                    100  thrpt    5        6.000                counts
[info] BigDecimalReading.jsoniterScala:·gc.time                                     100  thrpt    5       11.000                    ms
[info] BigDecimalReading.jsoniterScala                                             1000  thrpt    5   200434.350 ±   26275.696   ops/s
[info] BigDecimalReading.jsoniterScala:·gc.alloc.rate                              1000  thrpt    5      695.030 ±      91.073  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.alloc.rate.norm                         1000  thrpt    5     5456.189 ±       0.285    B/op
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Eden_Space                     1000  thrpt    5      716.462 ±    1079.401  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Eden_Space.norm                1000  thrpt    5     5641.464 ±    8682.780    B/op
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Survivor_Space                 1000  thrpt    5        0.006 ±       0.032  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Survivor_Space.norm            1000  thrpt    5        0.047 ±       0.251    B/op
[info] BigDecimalReading.jsoniterScala:·gc.count                                   1000  thrpt    5        7.000                counts
[info] BigDecimalReading.jsoniterScala:·gc.time                                    1000  thrpt    5       13.000                    ms
[info] BigDecimalReading.jsoniterScala                                            10000  thrpt    5     4607.746 ±     448.741   ops/s
[info] BigDecimalReading.jsoniterScala:·gc.alloc.rate                             10000  thrpt    5     1441.367 ±     140.818  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.alloc.rate.norm                        10000  thrpt    5   492217.697 ±      17.793    B/op
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Eden_Space                    10000  thrpt    5     1432.730 ±     880.979  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Eden_Space.norm               10000  thrpt    5   490016.213 ±  316528.735    B/op
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Survivor_Space                10000  thrpt    5        0.834 ±       6.954  MB/sec
[info] BigDecimalReading.jsoniterScala:·gc.churn.PS_Survivor_Space.norm           10000  thrpt    5      280.011 ±    2335.892    B/op
[info] BigDecimalReading.jsoniterScala:·gc.count                                  10000  thrpt    5       14.000                counts
[info] BigDecimalReading.jsoniterScala:·gc.time                                   10000  thrpt    5       10.000                    ms
[info] BigIntReading.jsoniterScala                                                  100  thrpt    5  4097304.126 ±  105014.618   ops/s
[info] BigIntReading.jsoniterScala:·gc.alloc.rate                                   100  thrpt    5      499.993 ±      12.665  MB/sec
[info] BigIntReading.jsoniterScala:·gc.alloc.rate.norm                              100  thrpt    5      192.007 ±       0.001    B/op
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Eden_Space                          100  thrpt    5      511.752 ±       0.099  MB/sec
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Eden_Space.norm                     100  thrpt    5      196.529 ±       5.037    B/op
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Survivor_Space                      100  thrpt    5        0.010 ±       0.056  MB/sec
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Survivor_Space.norm                 100  thrpt    5        0.004 ±       0.021    B/op
[info] BigIntReading.jsoniterScala:·gc.count                                        100  thrpt    5        5.000                counts
[info] BigIntReading.jsoniterScala:·gc.time                                         100  thrpt    5       10.000                    ms
[info] BigIntReading.jsoniterScala                                                 1000  thrpt    5   200884.356 ±   20363.124   ops/s
[info] BigIntReading.jsoniterScala:·gc.alloc.rate                                  1000  thrpt    5      696.609 ±      70.691  MB/sec
[info] BigIntReading.jsoniterScala:·gc.alloc.rate.norm                             1000  thrpt    5     5456.189 ±       0.284    B/op
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Eden_Space                         1000  thrpt    5      716.477 ±    1079.462  MB/sec
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Eden_Space.norm                    1000  thrpt    5     5616.583 ±    8506.238    B/op
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Survivor_Space                     1000  thrpt    5        0.021 ±       0.096  MB/sec
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Survivor_Space.norm                1000  thrpt    5        0.167 ±       0.760    B/op
[info] BigIntReading.jsoniterScala:·gc.count                                       1000  thrpt    5        7.000                counts
[info] BigIntReading.jsoniterScala:·gc.time                                        1000  thrpt    5       13.000                    ms
[info] BigIntReading.jsoniterScala                                                10000  thrpt    5     4664.211 ±      95.845   ops/s
[info] BigIntReading.jsoniterScala:·gc.alloc.rate                                 10000  thrpt    5     1458.970 ±      29.240  MB/sec
[info] BigIntReading.jsoniterScala:·gc.alloc.rate.norm                            10000  thrpt    5   492217.476 ±      17.952    B/op
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Eden_Space                        10000  thrpt    5     1432.628 ±     880.713  MB/sec
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Eden_Space.norm                   10000  thrpt    5   483130.293 ±  292252.387    B/op
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Survivor_Space                    10000  thrpt    5        0.829 ±       7.046  MB/sec
[info] BigIntReading.jsoniterScala:·gc.churn.PS_Survivor_Space.norm               10000  thrpt    5      280.386 ±    2384.025    B/op
[info] BigIntReading.jsoniterScala:·gc.count                                      10000  thrpt    5       14.000                counts
[info] BigIntReading.jsoniterScala:·gc.time                                       10000  thrpt    5        8.000                    ms
```