### PR TITLE
Add smithy4s benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -241,6 +241,7 @@ lazy val `jsoniter-scala-benchmark` = crossProject(JVMPlatform, JSPlatform)
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     crossScalaVersions := Seq("2.13.8"),
     libraryDependencies ++= Seq(
+      "com.disneystreaming.smithy4s" %%% "smithy4s-json" % "0.13.3",
       "dev.zio" %%% "zio-json" % "0.3.0-RC8",
       "com.evolutiongaming" %% "play-json-jsoniter" % "0.10.0",
       "com.rallyhealth" %% "weepickle-v1" % "1.7.2",

--- a/build.sbt
+++ b/build.sbt
@@ -241,7 +241,7 @@ lazy val `jsoniter-scala-benchmark` = crossProject(JVMPlatform, JSPlatform)
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     crossScalaVersions := Seq("2.13.8"),
     libraryDependencies ++= Seq(
-      "com.disneystreaming.smithy4s" %%% "smithy4s-json" % "0.13.4",
+      "com.disneystreaming.smithy4s" %%% "smithy4s-json" % "0.13.5",
       "dev.zio" %%% "zio-json" % "0.3.0-RC8",
       "com.evolutiongaming" %% "play-json-jsoniter" % "0.10.0",
       "com.rallyhealth" %% "weepickle-v1" % "1.7.2",

--- a/build.sbt
+++ b/build.sbt
@@ -241,7 +241,7 @@ lazy val `jsoniter-scala-benchmark` = crossProject(JVMPlatform, JSPlatform)
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     crossScalaVersions := Seq("2.13.8"),
     libraryDependencies ++= Seq(
-      "com.disneystreaming.smithy4s" %%% "smithy4s-json" % "0.13.3",
+      "com.disneystreaming.smithy4s" %%% "smithy4s-json" % "0.13.4",
       "dev.zio" %%% "zio-json" % "0.3.0-RC8",
       "com.evolutiongaming" %% "play-json-jsoniter" % "0.10.0",
       "com.rallyhealth" %% "weepickle-v1" % "1.7.2",

--- a/jsoniter-scala-benchmark/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Main.scala
+++ b/jsoniter-scala-benchmark/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Main.scala
@@ -781,6 +781,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -793,6 +794,8 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      //FIXME: smithy4s doesn't pad during serialization to Base64 encoded string
+      //B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -805,6 +808,8 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      //FIXME: smithy4s: don't know how to tune precision for parsing of BigDecimal values
+      //B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle())
     ))
   }, {
@@ -816,6 +821,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -828,6 +834,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle())
     ))
   }, {
@@ -839,6 +846,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -1242,6 +1250,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -1254,6 +1263,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -1266,6 +1276,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -1277,6 +1288,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle())
     ))
   }, {
@@ -1288,6 +1300,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -1300,6 +1313,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))

--- a/jsoniter-scala-benchmark/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Main.scala
+++ b/jsoniter-scala-benchmark/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Main.scala
@@ -44,6 +44,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -56,6 +57,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -865,6 +867,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -922,6 +925,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -934,6 +938,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -946,6 +951,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -976,6 +982,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -988,6 +995,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -1000,6 +1008,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -1012,6 +1021,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -1023,6 +1033,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("zioJson")(benchmark.zioJson())
     ))
   }, {
@@ -1033,6 +1044,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("zioJson")(benchmark.zioJson())
     ))
   }, {
@@ -1046,6 +1058,7 @@ object Main {
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaWithoutDump")(benchmark.jsoniterScalaWithoutDump()),
       B("jsoniterScalaWithStacktrace")(benchmark.jsoniterScalaWithStacktrace()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -1133,6 +1146,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle())
     ))
   }, {
@@ -1143,6 +1157,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle())
     ))
   }, {
@@ -1186,6 +1201,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -1198,6 +1214,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -1210,6 +1227,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -1314,6 +1332,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -1326,6 +1345,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))

--- a/jsoniter-scala-benchmark/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Main.scala
+++ b/jsoniter-scala-benchmark/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Main.scala
@@ -794,8 +794,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
-      //FIXME: smithy4s doesn't pad during serialization to Base64 encoded string
-      //B("smithy4s")(benchmark.smithy4s()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))

--- a/jsoniter-scala-benchmark/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Main.scala
+++ b/jsoniter-scala-benchmark/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Main.scala
@@ -94,6 +94,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -106,6 +107,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -118,6 +120,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -130,6 +133,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -142,6 +146,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -154,6 +159,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -166,6 +172,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -178,6 +185,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -214,6 +222,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -226,6 +235,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -310,6 +320,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -322,6 +333,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -358,6 +370,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -370,6 +383,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -478,6 +492,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -490,6 +505,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -598,6 +614,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -610,6 +627,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -622,6 +640,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -634,6 +653,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle()),
       B("zioJson")(benchmark.zioJson())
     ))
@@ -889,6 +909,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle())
     ))
   }, {
@@ -900,6 +921,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle())
     ))
   }, {

--- a/jsoniter-scala-benchmark/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Main.scala
+++ b/jsoniter-scala-benchmark/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Main.scala
@@ -22,6 +22,7 @@ object Main {
       B("circeJawn")(benchmark.circeJawn()),
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle())
     ))
   }, {
@@ -33,6 +34,7 @@ object Main {
       B("circeJsoniter")(benchmark.circeJsoniter()),
       B("jsoniterScala")(benchmark.jsoniterScala()),
       B("jsoniterScalaPrealloc")(benchmark.jsoniterScalaPrealloc()),
+      B("smithy4s")(benchmark.smithy4s()),
       B("uPickle")(benchmark.uPickle())
     ))
   }, {

--- a/jsoniter-scala-benchmark/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PlatformUtils.scala
+++ b/jsoniter-scala-benchmark/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PlatformUtils.scala
@@ -1,0 +1,10 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import smithy4s.Timestamp
+import java.time.Instant
+
+object PlatformUtils {
+  def toTimestamp(x: Instant): Timestamp = ???
+
+  def toInstant(x: Timestamp): Instant = ???
+}

--- a/jsoniter-scala-benchmark/jvm/src/main/java/com/github/plokhotnyuk/jsoniter_scala/benchmark/PlatformUtils.scala
+++ b/jsoniter-scala-benchmark/jvm/src/main/java/com/github/plokhotnyuk/jsoniter_scala/benchmark/PlatformUtils.scala
@@ -1,0 +1,11 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import smithy4s.Timestamp
+
+import java.time.Instant
+
+object PlatformUtils {
+  def toTimestamp(x: Instant): Timestamp = Timestamp.fromInstant(x)
+
+  def toInstant(x: Timestamp): Instant = x.toInstant
+}

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTReadingSpec.scala
@@ -15,6 +15,7 @@ class ADTReadingSpec extends BenchmarkSpecBase {
       benchmark.ninnyJson() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class ADTReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.ninnyJson())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTWritingSpec.scala
@@ -16,6 +16,7 @@ class ADTWritingSpec extends BenchmarkSpecBase {
       toString(b.ninnyJson()) shouldBe b.jsonString3
       toString(b.playJson()) shouldBe b.jsonString1
       toString(b.playJsonJsoniter()) shouldBe b.jsonString1
+      toString(b.smithy4s()) shouldBe b.jsonString1
       toString(b.sprayJson()) shouldBe b.jsonString2
       toString(b.uPickle()) shouldBe b.jsonString1
       toString(b.weePickle()) shouldBe b.jsonString1

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsReadingSpec.scala
@@ -16,6 +16,7 @@ class AnyValsReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -33,6 +34,7 @@ class AnyValsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsWritingSpec.scala
@@ -17,6 +17,7 @@ class AnyValsWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString1
       toString(b.playJson()) shouldBe b.jsonString3
       toString(b.playJsonJsoniter()) shouldBe b.jsonString1
+      toString(b.smithy4s()) shouldBe b.jsonString1
       toString(b.sprayJson()) shouldBe b.jsonString2
       toString(b.uPickle()) shouldBe b.jsonString1
       toString(b.weePickle()) shouldBe b.jsonString1

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsReadingSpec.scala
@@ -17,6 +17,7 @@ class ArrayOfBigDecimalsReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.sourceObj
       benchmark.playJson() shouldBe benchmark.sourceObj
       benchmark.playJsonJsoniter() shouldBe benchmark.sourceObj
+      benchmark.smithy4s() shouldBe benchmark.sourceObj
       benchmark.sprayJson() shouldBe benchmark.sourceObj
       benchmark.uPickle() shouldBe benchmark.sourceObj
       benchmark.weePickle() shouldBe benchmark.sourceObj
@@ -35,6 +36,7 @@ class ArrayOfBigDecimalsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.zioJson())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsWritingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfBigDecimalsWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       //FIXME: weePickle writes BigDecimal as JSON strings by default

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsReadingSpec.scala
@@ -17,6 +17,7 @@ class ArrayOfBigIntsReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       //FIXME: Play-JSON looses significant digits in BigInt values
       //benchmark.playJson() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -33,6 +34,7 @@ class ArrayOfBigIntsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsWritingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfBigIntsWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       //FIXME: Play-JSON uses BigDecimal with engineering decimal representation to serialize numbers
       //toString(b.playJson()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       //FIXME: weePickle writes BigDecimal as JSON strings by default

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReadingSpec.scala
@@ -17,6 +17,7 @@ class ArrayOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class ArrayOfBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansWritingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReadingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfBytesReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class ArrayOfBytesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesWritingSpec.scala
@@ -19,6 +19,7 @@ class ArrayOfBytesWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReadingSpec.scala
@@ -17,6 +17,7 @@ class ArrayOfDoublesReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class ArrayOfDoublesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesWritingSpec.scala
@@ -19,6 +19,7 @@ class ArrayOfDoublesWritingSpec extends BenchmarkSpecBase {
       check(toString(b.ninnyJson()), b.jsonString)
       check(toString(b.playJson()), b.jsonString)
       check(toString(b.playJsonJsoniter()), b.jsonString)
+      check(toString(b.smithy4s()), b.jsonString)
       check(toString(b.sprayJson()), b.jsonString)
       check(toString(b.uPickle()), b.jsonString)
       check(toString(b.weePickle()), b.jsonString)

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReadingSpec.scala
@@ -32,6 +32,7 @@ class ArrayOfFloatsReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -48,6 +49,7 @@ class ArrayOfFloatsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.zioJson())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsWritingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfFloatsWritingSpec extends BenchmarkSpecBase {
       check(toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()), b.jsonString)
       check(toString(b.playJson()), b.jsonString)
       check(toString(b.playJsonJsoniter()), b.jsonString)
+      check(toString(b.smithy4s()), b.jsonString)
       check(toString(b.sprayJson()), b.jsonString)
       check(toString(b.uPickle()), b.jsonString)
       check(toString(b.weePickle()), b.jsonString)

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReadingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfInstantsReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -33,6 +34,7 @@ class ArrayOfInstantsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsWritingSpec.scala
@@ -17,6 +17,7 @@ class ArrayOfInstantsWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReadingSpec.scala
@@ -17,6 +17,7 @@ class ArrayOfIntsReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -34,6 +35,7 @@ class ArrayOfIntsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsWritingSpec.scala
@@ -16,6 +16,7 @@ class ArrayOfIntsWritingSpec extends BenchmarkSpecBase {
       toString(b.jacksonScala()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReadingSpec.scala
@@ -17,6 +17,7 @@ class ArrayOfLongsReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class ArrayOfLongsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsWritingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfLongsWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReadingSpec.scala
@@ -17,6 +17,7 @@ class ArrayOfShortsReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class ArrayOfShortsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsWritingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfShortsWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReadingSpec.scala
@@ -17,6 +17,7 @@ class ArrayOfUUIDsReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class ArrayOfUUIDsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsWritingSpec.scala
@@ -18,6 +18,7 @@ class ArrayOfUUIDsWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64ReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64ReadingSpec.scala
@@ -17,6 +17,7 @@ class Base64ReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class Base64ReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64WritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64WritingSpec.scala
@@ -18,6 +18,8 @@ class Base64WritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      //FIXME: smithy4s doesn't pad during serialization to Base64 encoded string
+      //toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64WritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64WritingSpec.scala
@@ -18,8 +18,7 @@ class Base64WritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
-      //FIXME: smithy4s doesn't pad during serialization to Base64 encoded string
-      //toString(b.smithy4s()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalReadingSpec.scala
@@ -17,6 +17,8 @@ class BigDecimalReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.sourceObj
       //FIXME: Play-JSON: don't know how to tune precision for parsing of BigDecimal values
       //benchmark.playJson() shouldBe benchmark.sourceObj
+      //FIXME: smithy4s: don't know how to tune precision for parsing of BigDecimal values
+      //benchmark.smithy4s() shouldBe benchmark.sourceObj
       benchmark.sprayJson() shouldBe benchmark.sourceObj
       benchmark.uPickle() shouldBe benchmark.sourceObj
       benchmark.weePickle() shouldBe benchmark.sourceObj

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalWritingSpec.scala
@@ -18,6 +18,7 @@ class BigDecimalWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       BigDecimal(toString(b.playJson())) shouldBe b.obj
       BigDecimal(toString(b.playJsonJsoniter())) shouldBe b.obj
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       //FIXME: weePickle serializes BigDecimal values as JSON strings

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntReadingSpec.scala
@@ -17,6 +17,7 @@ class BigIntReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       //FIXME: Play-JSON looses significant digits in BigInt values
       //benchmark.playJson() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -32,6 +33,7 @@ class BigIntReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntWritingSpec.scala
@@ -18,6 +18,7 @@ class BigIntWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       //FIXME: Play-JSON serializes BigInt values as floating point numbers with a scientific representation
       //toString(b.playJson()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       //FIXME: weePickle serializes BigInt values as JSON strings

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReadingSpec.scala
@@ -18,6 +18,7 @@ class ExtractFieldsReadingSpec extends BenchmarkSpecBase {
       benchmark.ninnyJson() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -37,6 +38,7 @@ class ExtractFieldsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.ninnyJson())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReadingSpec.scala
@@ -14,6 +14,7 @@ class GeoJSONReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -34,6 +35,7 @@ class GeoJSONReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWritingSpec.scala
@@ -15,6 +15,7 @@ class GeoJSONWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString1
       toString(b.playJson()) shouldBe b.jsonString1
       toString(b.playJsonJsoniter()) shouldBe b.jsonString1
+      toString(b.smithy4s()) shouldBe b.jsonString1
       toString(b.sprayJson()) shouldBe b.jsonString3
       toString(b.uPickle()) shouldBe b.jsonString1
       toString(b.weePickle()) shouldBe b.jsonString1

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIReadingSpec.scala
@@ -13,6 +13,7 @@ class GitHubActionsAPIReadingSpec extends BenchmarkSpecBase {
       benchmark.jacksonScala() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.ninnyJson() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -29,6 +30,7 @@ class GitHubActionsAPIReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jacksonScala())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.ninnyJson())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.weePickle())
       intercept[Throwable](b.uPickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIWritingSpec.scala
@@ -14,6 +14,7 @@ class GitHubActionsAPIWritingSpec extends BenchmarkSpecBase {
       toString(b.jsoniterScala()) shouldBe b.compactJsonString1
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.compactJsonString1
       toString(b.ninnyJson()) shouldEqual b.compactJsonString3
+      toString(b.smithy4s()) shouldBe b.compactJsonString1
       toString(b.sprayJson()) shouldBe b.compactJsonString2
       toString(b.uPickle()) shouldBe b.compactJsonString1
       toString(b.weePickle()) shouldBe b.compactJsonString1

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrintingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrintingSpec.scala
@@ -14,6 +14,7 @@ class GoogleMapsAPIPrettyPrintingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString2
       toString(b.playJson()) shouldBe b.jsonString1
       toString(b.playJsonJsoniter()) shouldBe b.jsonString2
+      toString(b.smithy4s()) shouldBe b.jsonString2
       toString(b.sprayJson()) shouldBe b.jsonString2
       toString(b.uPickle()) shouldBe b.jsonString2
       toString(b.weePickle()) shouldBe b.jsonString2

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReadingSpec.scala
@@ -16,6 +16,7 @@ class GoogleMapsAPIReadingSpec extends BenchmarkSpecBase {
       benchmark.ninnyJson() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class GoogleMapsAPIReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.ninnyJson())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWritingSpec.scala
@@ -17,6 +17,7 @@ class GoogleMapsAPIWritingSpec extends BenchmarkSpecBase {
       toString(b.ninnyJson()) shouldBe b.compactJsonString2
       toString(b.playJson()) shouldBe b.compactJsonString1
       toString(b.playJsonJsoniter()) shouldBe b.compactJsonString1
+      toString(b.smithy4s()) shouldBe b.compactJsonString1
       toString(b.sprayJson()) shouldBe b.compactJsonString1
       toString(b.uPickle()) shouldBe b.compactJsonString1
       toString(b.weePickle()) shouldBe b.compactJsonString1

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReadingSpec.scala
@@ -15,6 +15,7 @@ class IntReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -33,6 +34,7 @@ class IntReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntWritingSpec.scala
@@ -16,6 +16,7 @@ class IntWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReadingSpec.scala
@@ -17,6 +17,7 @@ class ListOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class ListOfBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansWritingSpec.scala
@@ -18,6 +18,7 @@ class ListOfBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansReadingSpec.scala
@@ -16,6 +16,7 @@ class MapOfIntsToBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       //FIXME: Spray-JSON throws spray.json.DeserializationException: Expected Int as JsNumber, but got "-1"
       //benchmark.sprayJson() shouldBe benchmark.obj
       //FIXME: uPickle parses maps from JSON arrays only
@@ -35,6 +36,7 @@ class MapOfIntsToBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.weePickle())
       intercept[Throwable](b.zioJson())
     }

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansWritingSpec.scala
@@ -17,6 +17,7 @@ class MapOfIntsToBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       //FIXME: Spray-JSON throws spray.json.SerializationException: Map key must be formatted as JsString, not '-130530'
       //toString(b.sprayJson()) shouldBe b.jsonString
       //FIXME: uPickle serializes maps as JSON arrays

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MissingRequiredFieldsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MissingRequiredFieldsReadingSpec.scala
@@ -37,6 +37,7 @@ class MissingRequiredFieldsReadingSpec extends BenchmarkSpecBase {
           |+----------+-------------------------------------------------+------------------+""".stripMargin
       b.playJson() should include("JsResultException")
       b.playJsonJsoniter() should include("JsResultException")
+      b.smithy4s() shouldBe "Missing required field"
       b.sprayJson() shouldBe "Object is missing required member 's'"
       b.uPickle() shouldBe "missing keys in dictionary: s, i at index 1"
       b.weePickle() shouldBe "Parser or Visitor failure jsonPointer= index=2 line=1 col=3 token=END_OBJECT"
@@ -56,6 +57,7 @@ class MissingRequiredFieldsReadingSpec extends BenchmarkSpecBase {
       b.jsoniterScalaWithStacktrace() shouldBe "MissingRequiredFields(VVV,1)"
       b.playJson() shouldBe "MissingRequiredFields(VVV,1)"
       b.playJsonJsoniter() shouldBe "MissingRequiredFields(VVV,1)"
+      b.smithy4s() shouldBe "MissingRequiredFields(VVV,1)"
       b.sprayJson() shouldBe "MissingRequiredFields(VVV,1)"
       b.uPickle() shouldBe "MissingRequiredFields(VVV,1)"
       b.weePickle() shouldBe "MissingRequiredFields(VVV,1)"

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReadingSpec.scala
@@ -18,6 +18,7 @@ class NestedStructsReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -36,6 +37,7 @@ class NestedStructsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsWritingSpec.scala
@@ -20,6 +20,7 @@ class NestedStructsWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReadingSpec.scala
@@ -15,6 +15,7 @@ class PrimitivesReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -33,6 +34,7 @@ class PrimitivesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesWritingSpec.scala
@@ -16,6 +16,7 @@ class PrimitivesWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString1
       toString(b.playJson()) shouldBe b.jsonString3
       toString(b.playJsonJsoniter()) shouldBe b.jsonString1
+      toString(b.smithy4s()) shouldBe b.jsonString1
       toString(b.sprayJson()) shouldBe b.jsonString2
       toString(b.uPickle()) shouldBe b.jsonString1
       toString(b.weePickle()) shouldBe b.jsonString1

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReadingSpec.scala
@@ -17,6 +17,7 @@ class SetOfIntsReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class SetOfIntsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsWritingSpec.scala
@@ -22,6 +22,7 @@ class SetOfIntsWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       readFromArray[Set[Int]](b.sprayJson()) shouldBe b.obj
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReadingSpec.scala
@@ -17,6 +17,7 @@ class StringOfAsciiCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class StringOfAsciiCharsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsWritingSpec.scala
@@ -18,6 +18,7 @@ class StringOfAsciiCharsWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReadingSpec.scala
@@ -17,6 +17,7 @@ class StringOfEscapedCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class StringOfEscapedCharsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsWritingSpec.scala
@@ -16,6 +16,7 @@ class StringOfEscapedCharsWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString1
       toString(b.playJson()) shouldBe b.jsonString2
       toString(b.playJsonJsoniter()) shouldBe b.jsonString1
+      toString(b.smithy4s()) shouldBe b.jsonString1
       toString(b.uPickle()) shouldBe b.jsonString1
       toString(b.weePickle()) shouldBe b.jsonString2
     }

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReadingSpec.scala
@@ -17,6 +17,7 @@ class StringOfNonAsciiCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class StringOfNonAsciiCharsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsWritingSpec.scala
@@ -18,6 +18,7 @@ class StringOfNonAsciiCharsWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReadingSpec.scala
@@ -17,6 +17,7 @@ class VectorOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
+      benchmark.smithy4s() shouldBe benchmark.obj
       benchmark.sprayJson() shouldBe benchmark.obj
       benchmark.uPickle() shouldBe benchmark.obj
       benchmark.weePickle() shouldBe benchmark.obj
@@ -35,6 +36,7 @@ class VectorOfBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())
+      intercept[Throwable](b.smithy4s())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())
       intercept[Throwable](b.weePickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansWritingSpec.scala
@@ -18,6 +18,7 @@ class VectorOfBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.preallocatedBuf, 0, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString
       toString(b.playJsonJsoniter()) shouldBe b.jsonString
+      toString(b.smithy4s()) shouldBe b.jsonString
       toString(b.sprayJson()) shouldBe b.jsonString
       toString(b.uPickle()) shouldBe b.jsonString
       toString(b.weePickle()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTReading.scala
@@ -62,6 +62,13 @@ class ADTReading extends ADTBenchmark {
   def playJsonJsoniter(): ADTBase = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[ADTBase](adtFormat))
 
   @Benchmark
+  def smithy4s(): ADTBase = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[ADTBase](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): ADTBase = JsonParser(jsonBytes).convertTo[ADTBase](adtBaseJsonFormat)
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTWriting.scala
@@ -61,6 +61,13 @@ class ADTWriting extends ADTBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj)(adtFormat))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsReading.scala
@@ -63,6 +63,13 @@ class AnyValsReading extends AnyValsBenchmark {
   def playJsonJsoniter(): AnyVals = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[AnyVals])
 
   @Benchmark
+  def smithy4s(): AnyVals = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[AnyVals](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): AnyVals = JsonParser(jsonBytes).convertTo[AnyVals]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsWriting.scala
@@ -61,6 +61,13 @@ class AnyValsWriting extends AnyValsBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsReading.scala
@@ -59,6 +59,13 @@ class ArrayOfBigDecimalsReading extends ArrayOfBigDecimalsBenchmark {
     PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[BigDecimal]])
 
   @Benchmark
+  def smithy4s(): Array[BigDecimal] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Array[BigDecimal]](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): Array[BigDecimal] = JsonParser(jsonBytes).convertTo[Array[BigDecimal]]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsWriting.scala
@@ -52,6 +52,13 @@ class ArrayOfBigDecimalsWriting extends ArrayOfBigDecimalsBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsReading.scala
@@ -52,6 +52,12 @@ class ArrayOfBigIntsReading extends ArrayOfBigIntsBenchmark {
   @Benchmark
   def playJson(): Array[BigInt] = Json.parse(jsonBytes).as[Array[BigInt]](bigIntArrayFormat)
 */
+  @Benchmark
+  def smithy4s(): Array[BigInt] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Array[BigInt]](jsonBytes)
+  }
 
   @Benchmark
   def sprayJson(): Array[BigInt] = JsonParser(jsonBytes).convertTo[Array[BigInt]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsWriting.scala
@@ -50,6 +50,13 @@ class ArrayOfBigIntsWriting extends ArrayOfBigIntsBenchmark {
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
 */
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReading.scala
@@ -54,6 +54,13 @@ class ArrayOfBooleansReading extends ArrayOfBooleansBenchmark {
   def playJsonJsoniter(): Array[Boolean] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Boolean]])
 
   @Benchmark
+  def smithy4s(): Array[Boolean] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Array[Boolean]](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Boolean] = JsonParser(jsonBytes).convertTo[Array[Boolean]]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansWriting.scala
@@ -52,6 +52,13 @@ class ArrayOfBooleansWriting extends ArrayOfBooleansBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReading.scala
@@ -55,6 +55,13 @@ class ArrayOfBytesReading extends ArrayOfBytesBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Byte]])
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Array[Byte]](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = JsonParser(jsonBytes).convertTo[Array[Byte]]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesWriting.scala
@@ -53,6 +53,13 @@ class ArrayOfBytesWriting extends ArrayOfBytesBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReading.scala
@@ -54,6 +54,13 @@ class ArrayOfDoublesReading extends ArrayOfDoublesBenchmark {
   def playJsonJsoniter(): Array[Double] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Double]])
 
   @Benchmark
+  def smithy4s(): Array[Double] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Array[Double]](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Double] = JsonParser(jsonBytes).convertTo[Array[Double]]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesWriting.scala
@@ -60,6 +60,13 @@ class ArrayOfDoublesWriting extends ArrayOfDoublesBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReading.scala
@@ -54,6 +54,13 @@ class ArrayOfFloatsReading extends ArrayOfFloatsBenchmark {
   def playJsonJsoniter(): Array[Float] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Float]])
 
   @Benchmark
+  def smithy4s(): Array[Float] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Array[Float]](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Float] = JsonParser(jsonBytes).convertTo[Array[Float]]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsWriting.scala
@@ -52,6 +52,13 @@ class ArrayOfFloatsWriting extends ArrayOfFloatsBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReading.scala
@@ -57,6 +57,13 @@ class ArrayOfInstantsReading extends ArrayOfInstantsBenchmark {
   }
 
   @Benchmark
+  def smithy4s(): Array[Instant] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Array[Instant]](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Instant] = JsonParser(jsonBytes).convertTo[Array[Instant]]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsWriting.scala
@@ -54,6 +54,13 @@ class ArrayOfInstantsWriting extends ArrayOfInstantsBenchmark {
   }
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReading.scala
@@ -54,6 +54,13 @@ class ArrayOfIntsReading extends ArrayOfIntsBenchmark {
   def playJsonJsoniter(): Array[Int] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Int]])
 
   @Benchmark
+  def smithy4s(): Array[Int] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Array[Int]](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Int] = JsonParser(jsonBytes).convertTo[Array[Int]]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsWriting.scala
@@ -52,6 +52,13 @@ class ArrayOfIntsWriting extends ArrayOfIntsBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReading.scala
@@ -54,6 +54,13 @@ class ArrayOfLongsReading extends ArrayOfLongsBenchmark {
   def playJsonJsoniter(): Array[Long] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Long]])
 
   @Benchmark
+  def smithy4s(): Array[Long] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Array[Long]](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Long] = JsonParser(jsonBytes).convertTo[Array[Long]]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsWriting.scala
@@ -52,6 +52,13 @@ class ArrayOfLongsWriting extends ArrayOfLongsBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReading.scala
@@ -54,6 +54,13 @@ class ArrayOfShortsReading extends ArrayOfShortsBenchmark {
   def playJsonJsoniter(): Array[Short] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Short]])
 
   @Benchmark
+  def smithy4s(): Array[Short] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Array[Short]](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Short] = JsonParser(jsonBytes).convertTo[Array[Short]]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsWriting.scala
@@ -52,6 +52,13 @@ class ArrayOfShortsWriting extends ArrayOfShortsBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReading.scala
@@ -57,6 +57,13 @@ class ArrayOfUUIDsReading extends ArrayOfUUIDsBenchmark {
   def playJsonJsoniter(): Array[UUID] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[UUID]])
 
   @Benchmark
+  def smithy4s(): Array[UUID] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Array[UUID]](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): Array[UUID] = JsonParser(jsonBytes).convertTo[Array[UUID]]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsWriting.scala
@@ -54,6 +54,13 @@ class ArrayOfUUIDsWriting extends ArrayOfUUIDsBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64Reading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64Reading.scala
@@ -19,6 +19,7 @@ import io.circe.Decoder
 import io.circe.parser.decode
 import org.openjdk.jmh.annotations.Benchmark
 import play.api.libs.json.Json
+import smithy4s.ByteArray
 import spray.json.JsonParser
 import zio.json.DecoderOps
 
@@ -57,6 +58,13 @@ class Base64Reading extends Base64Benchmark {
   @Benchmark
   def playJsonJsoniter(): Array[Byte] =
     PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Array[Byte]](base64Format))
+
+  @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Array[Byte]](jsonBytes, tooLongStringConfig)(base64JCodec)
+  }
 
   @Benchmark
   def sprayJson(): Array[Byte] = JsonParser(jsonBytes).convertTo[Array[Byte]](base64JsonFormat)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64Writing.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64Writing.scala
@@ -54,14 +54,14 @@ class Base64Writing extends Base64Benchmark {
 
   @Benchmark
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj)(base64Format))
-/* FIXME: smithy4s doesn't pad during serialization to Base64 encoded string
+
   @Benchmark
   def smithy4s(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
 
     writeToArray(obj)(base64JCodec)
   }
-*/
+
   @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64Writing.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64Writing.scala
@@ -18,6 +18,7 @@ import com.rallyhealth.weepickle.v1.WeePickle.FromScala
 import org.openjdk.jmh.annotations.Benchmark
 import io.circe.syntax._
 import play.api.libs.json.Json
+import smithy4s.ByteArray
 
 class Base64Writing extends Base64Benchmark {
   @Benchmark
@@ -53,7 +54,14 @@ class Base64Writing extends Base64Benchmark {
 
   @Benchmark
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj)(base64Format))
+/* FIXME: smithy4s doesn't pad during serialization to Base64 encoded string
+  @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
 
+    writeToArray(obj)(base64JCodec)
+  }
+*/
   @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalReading.scala
@@ -50,6 +50,14 @@ class BigDecimalReading extends BigDecimalBenchmark {
   @Benchmark
   def playJson(): BigDecimal = Json.parse(jsonBytes).as[BigDecimal]
 */
+/* FIXME: smithy4s: don't know how to tune precision for parsing of BigDecimal values
+  @Benchmark
+  def smithy4s(): BigDecimal = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[BigDecimal](jsonBytes)(bigDecimalJCodec)
+  }
+*/
   @Benchmark
   def sprayJson(): BigDecimal = JsonParser(jsonBytes, jsonParserSettings).convertTo[BigDecimal]
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalWriting.scala
@@ -52,6 +52,13 @@ class BigDecimalWriting extends BigDecimalBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)(bigDecimalJCodec)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntReading.scala
@@ -51,6 +51,13 @@ class BigIntReading extends BigIntBenchmark {
   def playJson(): BigInt = Json.parse(jsonBytes).as[BigInt]
 */
   @Benchmark
+  def smithy4s(): BigInt = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[BigInt](jsonBytes)(bigIntJCodec)
+  }
+
+  @Benchmark
   def sprayJson(): BigInt = JsonParser(jsonBytes, jsonParserSettings).convertTo[BigInt]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntWriting.scala
@@ -48,6 +48,13 @@ class BigIntWriting extends BigIntBenchmark {
   def playJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
 */
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)(bigIntJCodec)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReading.scala
@@ -84,6 +84,13 @@ class ExtractFieldsReading extends CommonParams {
   def playJsonJsoniter(): ExtractFields = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[ExtractFields])
 
   @Benchmark
+  def smithy4s(): ExtractFields = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[ExtractFields](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): ExtractFields = JsonParser(jsonBytes).convertTo[ExtractFields]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReading.scala
@@ -57,6 +57,13 @@ class GeoJSONReading extends GeoJSONBenchmark {
   def playJsonJsoniter(): GeoJSON = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[GeoJSON](geoJSONFormat))
 
   @Benchmark
+  def smithy4s(): GeoJSON = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[GeoJSON](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): GeoJSON = JsonParser(jsonBytes).convertTo[GeoJSON](geoJSONJsonFormat)
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWriting.scala
@@ -53,6 +53,13 @@ class GeoJSONWriting extends GeoJSONBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj)(geoJSONFormat))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIReading.scala
@@ -56,6 +56,13 @@ class GitHubActionsAPIReading extends GitHubActionsAPIBenchmark {
     Json.parseArray(ArraySeq.unsafeWrapArray(jsonBytes)).to[GitHubActionsAPI.Response].get
 
   @Benchmark
+  def smithy4s(): GitHubActionsAPI.Response = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[GitHubActionsAPI.Response](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): GitHubActionsAPI.Response = JsonParser(jsonBytes).convertTo[GitHubActionsAPI.Response]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIWriting.scala
@@ -51,6 +51,13 @@ class GitHubActionsAPIWriting extends GitHubActionsAPIBenchmark {
   }
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrinting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrinting.scala
@@ -48,6 +48,13 @@ class GoogleMapsAPIPrettyPrinting extends GoogleMapsAPIBenchmark {
   def playJsonJsoniter(): Array[Byte] = writeToArray(Json.toJson(obj), prettyConfig)(PlayJsonJsoniter.jsValueCodec)
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj, prettyConfig)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReading.scala
@@ -67,6 +67,13 @@ class GoogleMapsAPIReading extends GoogleMapsAPIBenchmark {
   def playJsonJsoniter(): DistanceMatrix = PlayJsonJsoniter.deserialize(jsonBytes1).fold(throw _, _.as[DistanceMatrix])
 
   @Benchmark
+  def smithy4s(): DistanceMatrix = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[DistanceMatrix](jsonBytes1)
+  }
+
+  @Benchmark
   def sprayJson(): DistanceMatrix = JsonParser(jsonBytes1).convertTo[DistanceMatrix]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWriting.scala
@@ -65,6 +65,13 @@ class GoogleMapsAPIWriting extends GoogleMapsAPIBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReading.scala
@@ -54,6 +54,13 @@ class IntReading extends IntBenchmark {
   def playJsonJsoniter(): Int = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Int])
 
   @Benchmark
+  def smithy4s(): Int = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Int](jsonBytes)(intJCodec)
+  }
+
+  @Benchmark
   def sprayJson(): Int = JsonParser(jsonBytes).convertTo[Int]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntWriting.scala
@@ -51,6 +51,13 @@ class IntWriting extends IntBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)(intJCodec)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = Json.toBytes(Json.toJson(obj))
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReading.scala
@@ -54,6 +54,13 @@ class ListOfBooleansReading extends ListOfBooleansBenchmark {
   def playJsonJsoniter(): List[Boolean] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[List[Boolean]])
 
   @Benchmark
+  def smithy4s(): List[Boolean] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[List[Boolean]](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): List[Boolean] = JsonParser(jsonBytes).convertTo[List[Boolean]]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansWriting.scala
@@ -52,6 +52,13 @@ class ListOfBooleansWriting extends ListOfBooleansBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansReading.scala
@@ -52,6 +52,13 @@ class MapOfIntsToBooleansReading extends MapOfIntsToBooleansBenchmark {
   @Benchmark
   def playJsonJsoniter(): Map[Int, Boolean] =
     PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Map[Int, Boolean]])
+
+  @Benchmark
+  def smithy4s(): Map[Int, Boolean] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Map[Int, Boolean]](jsonBytes)
+  }
 /* FIXME: Spray-JSON throws spray.json.DeserializationException: Expected Int as JsNumber, but got "-1"
   @Benchmark
   def sprayJson(): Map[Int, Boolean] = JsonParser(jsonBytes).convertTo[Map[Int, Boolean]]

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansWriting.scala
@@ -49,6 +49,13 @@ class MapOfIntsToBooleansWriting extends MapOfIntsToBooleansBenchmark {
 
   @Benchmark
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
+
+  @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
 /* FIXME: Spray-JSON throws spray.json.SerializationException: Map key must be formatted as JsString, not '-130530'
   @Benchmark
   def sprayJson(): Array[Byte] = obj.toJson.compactPrint.getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MissingRequiredFieldsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MissingRequiredFieldsReading.scala
@@ -24,6 +24,7 @@ import io.circe.Decoder
 import io.circe.parser._
 import org.openjdk.jmh.annotations.Benchmark
 import play.api.libs.json.{JsResultException, Json}
+import smithy4s.http.PayloadError
 import spray.json._
 import zio.json.DecoderOps
 
@@ -116,6 +117,16 @@ class MissingRequiredFieldsReading extends CommonParams {
       PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[MissingRequiredFields](missingReqFieldsFormat).toString) // toString shouldn't be called
     } catch {
       case ex: JsResultException => ex.getMessage
+    }
+
+  @Benchmark
+  def smithy4s(): String =
+    try {
+      import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+      readFromArray[MissingRequiredFields](jsonBytes).toString // toString shouldn't be called
+    } catch {
+      case ex: PayloadError => ex.getMessage
     }
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReading.scala
@@ -59,6 +59,13 @@ class NestedStructsReading extends NestedStructsBenchmark {
   def playJsonJsoniter(): NestedStructs = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[NestedStructs])
 
   @Benchmark
+  def smithy4s(): NestedStructs = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[NestedStructs](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): NestedStructs = JsonParser(jsonBytes).convertTo[NestedStructs](nestedStructsJsonFormat)
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsWriting.scala
@@ -56,6 +56,13 @@ class NestedStructsWriting extends NestedStructsBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReading.scala
@@ -60,6 +60,13 @@ class PrimitivesReading extends PrimitivesBenchmark {
   def playJsonJsoniter(): Primitives = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Primitives])
 
   @Benchmark
+  def smithy4s(): Primitives = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Primitives](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): Primitives = JsonParser(jsonBytes).convertTo[Primitives]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesWriting.scala
@@ -57,6 +57,13 @@ class PrimitivesWriting extends PrimitivesBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReading.scala
@@ -55,6 +55,13 @@ class SetOfIntsReading extends SetOfIntsBenchmark {
   def playJsonJsoniter(): Set[Int] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Set[Int]])
 
   @Benchmark
+  def smithy4s(): Set[Int] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Set[Int]](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): Set[Int] = JsonParser(jsonBytes).convertTo[Set[Int]]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsWriting.scala
@@ -52,6 +52,13 @@ class SetOfIntsWriting extends SetOfIntsBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Smithy4sCodecs.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Smithy4sCodecs.scala
@@ -1,0 +1,105 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import smithy4s.http.json._
+import smithy4s.Schema
+import smithy4s.schema.Schema._
+
+object Smithy4sCodecs {
+  val exceptionWithoutDumpConfig: ReaderConfig = ReaderConfig.withAppendHexDumpToParseException(false)
+  val exceptionWithStacktraceConfig: ReaderConfig = ReaderConfig.withThrowReaderExceptionWithStackTrace(true)
+  val tooLongStringConfig: ReaderConfig = ReaderConfig.withPreferredCharBufSize(1024 * 1024)
+  val escapingConfig: WriterConfig = WriterConfig.withEscapeUnicode(true)
+  val prettyConfig: WriterConfig = WriterConfig.withIndentionStep(2).withPreferredBufSize(32768)
+  val anyValsSchema: Schema[AnyVals] =
+    struct(
+      byte.required[AnyVals]("b", _.b.a).addHints(smithy.api.Required()),
+      short.required[AnyVals]("s", _.s.a).addHints(smithy.api.Required()),
+      int.required[AnyVals]("i", _.i.a).addHints(smithy.api.Required()),
+      long.required[AnyVals]("l", _.l.a).addHints(smithy.api.Required()),
+      boolean.required[AnyVals]("bl", _.bl.a).addHints(smithy.api.Required()),
+      string.required[AnyVals]("ch", _.ch.a.toString).addHints(smithy.api.Required()),
+      double.required[AnyVals]("dbl", _.dbl.a).addHints(smithy.api.Required()),
+      float.required[AnyVals]("f", _.f.a).addHints(smithy.api.Required())
+    )((b, s, i, l, bl, st, dbl, f) => AnyVals.apply(ByteVal(b), ShortVal(s), IntVal(i), LongVal(l), BooleanVal(bl),
+      CharVal({
+        if (st.length == 1) st.charAt(0)
+        else sys.error("illegal char")
+      }), DoubleVal(dbl), FloatVal(f)))
+  implicit val anyValsJCodec: JCodec[AnyVals] = JCodec.deriveJCodecFromSchema(anyValsSchema)
+  val extractFieldsSchema: Schema[ExtractFields] =
+    struct(
+      string.required[ExtractFields]("s", _.s).addHints(smithy.api.Required()),
+      int.required[ExtractFields]("i", _.i).addHints(smithy.api.Required()),
+    )((s, i) => ExtractFields.apply(s, i))
+  implicit val extractFieldsJCodec: JCodec[ExtractFields] =
+    JCodec.deriveJCodecFromSchema(extractFieldsSchema)
+  val googleMapsAPISchema: Schema[GoogleMapsAPI.DistanceMatrix] = {
+    val valueSchema: Schema[GoogleMapsAPI.Value] =
+      struct(
+        string.required[GoogleMapsAPI.Value]("text", _.text),
+        int.required[GoogleMapsAPI.Value]("value", _.value),
+      )(GoogleMapsAPI.Value.apply)
+    val elementsSchema: Schema[GoogleMapsAPI.Elements] =
+      struct(
+        valueSchema.required[GoogleMapsAPI.Elements]("distance", _.distance),
+        valueSchema.required[GoogleMapsAPI.Elements]("duration", _.duration),
+        string.required[GoogleMapsAPI.Elements]("status", _.status)
+      )(GoogleMapsAPI.Elements.apply)
+    val rowsSchema: Schema[GoogleMapsAPI.Rows] =
+      struct(
+        list(elementsSchema).required[GoogleMapsAPI.Rows]("elements", _.elements.toList),
+      )(elements => GoogleMapsAPI.Rows.apply(elements.toVector))
+    struct(
+      list(string).required[GoogleMapsAPI.DistanceMatrix]("destination_addresses", _.destination_addresses.toList),
+      list(string).required[GoogleMapsAPI.DistanceMatrix]("origin_addresses", _.origin_addresses.toList),
+      list(rowsSchema).required[GoogleMapsAPI.DistanceMatrix]("rows", _.rows.toList),
+      string.required[GoogleMapsAPI.DistanceMatrix]("status", _.status),
+    ) { (destination_addresses, origin_addresses, rows, status) =>
+      GoogleMapsAPI.DistanceMatrix.apply(
+        destination_addresses.toVector,
+        origin_addresses.toVector,
+        rows.toVector,
+        status
+      )
+    }
+  }
+  implicit val googleMapsAPIJCodec: JCodec[GoogleMapsAPI.DistanceMatrix] =
+    JCodec.deriveJCodecFromSchema(googleMapsAPISchema)
+  val intJCodec: JCodec[Int] = JCodec.deriveJCodecFromSchema(int)
+  val listOfBooleansSchema: Schema[List[Boolean]] = list(boolean)
+  implicit val listOfBooleansJCodec: JCodec[List[Boolean]] = JCodec.deriveJCodecFromSchema(listOfBooleansSchema)
+  val mapOfIntsToBooleansSchema: Schema[Map[Int, Boolean]] = map(int, boolean)
+  implicit val mapOfIntsToBooleansJCodec: JCodec[Map[Int, Boolean]] =
+    JCodec.deriveJCodecFromSchema(mapOfIntsToBooleansSchema)
+  val missingRequiredFieldsSchema: Schema[MissingRequiredFields] =
+    struct(
+      string.required[MissingRequiredFields]("s", _.s).addHints(smithy.api.Required()),
+      int.required[MissingRequiredFields]("i", _.i).addHints(smithy.api.Required()),
+    )((s, i) => MissingRequiredFields.apply(s, i))
+  implicit val missingRequiredFieldsJCodec: JCodec[MissingRequiredFields] =
+    JCodec.deriveJCodecFromSchema(missingRequiredFieldsSchema)
+  val nestedStructsSchema: Schema[NestedStructs] =
+    recursive(struct(nestedStructsSchema.optional[NestedStructs]("n", _.n))(NestedStructs.apply))
+  implicit val nestedStructsJCodec: JCodec[NestedStructs] = JCodec.deriveJCodecFromSchema(nestedStructsSchema)
+  val primitivesSchema: Schema[Primitives] =
+    struct(
+      byte.required[Primitives]("b", _.b).addHints(smithy.api.Required()),
+      short.required[Primitives]("s", _.s).addHints(smithy.api.Required()),
+      int.required[Primitives]("i", _.i).addHints(smithy.api.Required()),
+      long.required[Primitives]("l", _.l).addHints(smithy.api.Required()),
+      boolean.required[Primitives]("bl", _.bl).addHints(smithy.api.Required()),
+      string.required[Primitives]("ch", _.ch.toString).addHints(smithy.api.Required()),
+      double.required[Primitives]("dbl", _.dbl).addHints(smithy.api.Required()),
+      float.required[Primitives]("f", _.f).addHints(smithy.api.Required())
+    )((b, s, i, l, bl, st, dbl, f) => Primitives.apply(b, s, i, l, bl, {
+      if (st.length == 1) st.charAt(0)
+      else sys.error("illegal char")
+    }, dbl, f))
+  implicit val primitivesJCodec: JCodec[Primitives] = JCodec.deriveJCodecFromSchema(primitivesSchema)
+  val setOfIntsSchema: Schema[Set[Int]] = set(int)
+  implicit val setOfIntsJCodec: JCodec[Set[Int]] = JCodec.deriveJCodecFromSchema(setOfIntsSchema)
+  val vectorOfBooleansSchema: Schema[Vector[Boolean]] =
+    bijection[List[Boolean], Vector[Boolean]](list(boolean), _.toVector, _.toList)
+  implicit val vectorOfBooleansJCodec: JCodec[Vector[Boolean]] = JCodec.deriveJCodecFromSchema(vectorOfBooleansSchema)
+}

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Smithy4sCodecs.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Smithy4sCodecs.scala
@@ -1,17 +1,11 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
-import com.github.plokhotnyuk.jsoniter_scala.core._
 import smithy4s.http.json._
-import smithy4s.Schema
+import smithy4s.{ByteArray, Schema}
 import smithy4s.api.Discriminated
 import smithy4s.schema.Schema._
 
 object Smithy4sCodecs {
-  val exceptionWithoutDumpConfig: ReaderConfig = ReaderConfig.withAppendHexDumpToParseException(false)
-  val exceptionWithStacktraceConfig: ReaderConfig = ReaderConfig.withThrowReaderExceptionWithStackTrace(true)
-  val tooLongStringConfig: ReaderConfig = ReaderConfig.withPreferredCharBufSize(1024 * 1024)
-  val escapingConfig: WriterConfig = WriterConfig.withEscapeUnicode(true)
-  val prettyConfig: WriterConfig = WriterConfig.withIndentionStep(2).withPreferredBufSize(32768)
   implicit val adtSchema: Schema[ADTBase] = recursive {
     val xAlt = struct(int.required[X]("a", _.a))(X.apply).oneOf[ADTBase]("X")
     val yAlt = struct(string.required[Y]("b", _.b))(Y.apply).oneOf[ADTBase]("Y")
@@ -23,30 +17,29 @@ object Smithy4sCodecs {
     }.addHints(Discriminated("type"))
   }
   implicit val adtJCodec: JCodec[ADTBase] = JCodec.deriveJCodecFromSchema(adtSchema)
-  val anyValsSchema: Schema[AnyVals] =
-    struct(
-      byte.required[AnyVals]("b", _.b.a).addHints(smithy.api.Required()),
-      short.required[AnyVals]("s", _.s.a).addHints(smithy.api.Required()),
-      int.required[AnyVals]("i", _.i.a).addHints(smithy.api.Required()),
-      long.required[AnyVals]("l", _.l.a).addHints(smithy.api.Required()),
-      boolean.required[AnyVals]("bl", _.bl.a).addHints(smithy.api.Required()),
-      string.required[AnyVals]("ch", _.ch.a.toString).addHints(smithy.api.Required()),
-      double.required[AnyVals]("dbl", _.dbl.a).addHints(smithy.api.Required()),
-      float.required[AnyVals]("f", _.f.a).addHints(smithy.api.Required())
-    )((b, s, i, l, bl, st, dbl, f) => AnyVals.apply(ByteVal(b), ShortVal(s), IntVal(i), LongVal(l), BooleanVal(bl),
-      CharVal({
-        if (st.length == 1) st.charAt(0)
-        else sys.error("illegal char")
-      }), DoubleVal(dbl), FloatVal(f)))
-  implicit val anyValsJCodec: JCodec[AnyVals] = JCodec.deriveJCodecFromSchema(anyValsSchema)
-  val extractFieldsSchema: Schema[ExtractFields] =
-    struct(
-      string.required[ExtractFields]("s", _.s).addHints(smithy.api.Required()),
-      int.required[ExtractFields]("i", _.i).addHints(smithy.api.Required()),
-    )((s, i) => ExtractFields.apply(s, i))
-  implicit val extractFieldsJCodec: JCodec[ExtractFields] =
-    JCodec.deriveJCodecFromSchema(extractFieldsSchema)
-  val googleMapsAPISchema: Schema[GoogleMapsAPI.DistanceMatrix] = {
+  implicit val anyValsJCodec: JCodec[AnyVals] = JCodec.deriveJCodecFromSchema(struct(
+    byte.required[AnyVals]("b", _.b.a),
+    short.required[AnyVals]("s", _.s.a),
+    int.required[AnyVals]("i", _.i.a),
+    long.required[AnyVals]("l", _.l.a),
+    boolean.required[AnyVals]("bl", _.bl.a),
+    string.required[AnyVals]("ch", _.ch.a.toString),
+    double.required[AnyVals]("dbl", _.dbl.a),
+    float.required[AnyVals]("f", _.f.a)
+  )((b, s, i, l, bl, st, dbl, f) => AnyVals(ByteVal(b), ShortVal(s), IntVal(i), LongVal(l), BooleanVal(bl),
+    CharVal({
+      if (st.length == 1) st.charAt(0)
+      else sys.error("illegal char")
+    }), DoubleVal(dbl), FloatVal(f))))
+  val base64JCodec: JCodec[Array[Byte]] =
+    JCodec.deriveJCodecFromSchema(bijection[ByteArray, Array[Byte]](bytes, _.array, ByteArray.apply))
+  val bigDecimalJCodec: JCodec[BigDecimal] = JCodec.deriveJCodecFromSchema(bigdecimal)
+  val bigIntJCodec: JCodec[BigInt] = JCodec.deriveJCodecFromSchema(bigint)
+  implicit val extractFieldsJCodec: JCodec[ExtractFields] = JCodec.deriveJCodecFromSchema(struct(
+    string.required[ExtractFields]("s", _.s),
+    int.required[ExtractFields]("i", _.i),
+  )(ExtractFields.apply))
+  implicit val googleMapsAPIJCodec: JCodec[GoogleMapsAPI.DistanceMatrix] = JCodec.deriveJCodecFromSchema({
     val valueSchema: Schema[GoogleMapsAPI.Value] =
       struct(
         string.required[GoogleMapsAPI.Value]("text", _.text),
@@ -68,50 +61,35 @@ object Smithy4sCodecs {
       list(rowsSchema).required[GoogleMapsAPI.DistanceMatrix]("rows", _.rows.toList),
       string.required[GoogleMapsAPI.DistanceMatrix]("status", _.status),
     ) { (destination_addresses, origin_addresses, rows, status) =>
-      GoogleMapsAPI.DistanceMatrix.apply(
-        destination_addresses.toVector,
-        origin_addresses.toVector,
-        rows.toVector,
-        status
-      )
+      GoogleMapsAPI.DistanceMatrix(destination_addresses.toVector, origin_addresses.toVector, rows.toVector, status)
     }
-  }
-  implicit val googleMapsAPIJCodec: JCodec[GoogleMapsAPI.DistanceMatrix] =
-    JCodec.deriveJCodecFromSchema(googleMapsAPISchema)
+  })
   val intJCodec: JCodec[Int] = JCodec.deriveJCodecFromSchema(int)
-  val listOfBooleansSchema: Schema[List[Boolean]] = list(boolean)
-  implicit val listOfBooleansJCodec: JCodec[List[Boolean]] = JCodec.deriveJCodecFromSchema(listOfBooleansSchema)
-  val mapOfIntsToBooleansSchema: Schema[Map[Int, Boolean]] = map(int, boolean)
-  implicit val mapOfIntsToBooleansJCodec: JCodec[Map[Int, Boolean]] =
-    JCodec.deriveJCodecFromSchema(mapOfIntsToBooleansSchema)
-  val missingRequiredFieldsSchema: Schema[MissingRequiredFields] =
-    struct(
-      string.required[MissingRequiredFields]("s", _.s).addHints(smithy.api.Required()),
-      int.required[MissingRequiredFields]("i", _.i).addHints(smithy.api.Required()),
-    )((s, i) => MissingRequiredFields.apply(s, i))
+  implicit val listOfBooleansJCodec: JCodec[List[Boolean]] = JCodec.deriveJCodecFromSchema(list(boolean))
+  implicit val mapOfIntsToBooleansJCodec: JCodec[Map[Int, Boolean]] = JCodec.deriveJCodecFromSchema(map(int, boolean))
   implicit val missingRequiredFieldsJCodec: JCodec[MissingRequiredFields] =
-    JCodec.deriveJCodecFromSchema(missingRequiredFieldsSchema)
+    JCodec.deriveJCodecFromSchema(struct(
+      string.required[MissingRequiredFields]("s", _.s),
+      int.required[MissingRequiredFields]("i", _.i),
+    )(MissingRequiredFields.apply))
   val nestedStructsSchema: Schema[NestedStructs] =
     recursive(struct(nestedStructsSchema.optional[NestedStructs]("n", _.n))(NestedStructs.apply))
   implicit val nestedStructsJCodec: JCodec[NestedStructs] = JCodec.deriveJCodecFromSchema(nestedStructsSchema)
-  val primitivesSchema: Schema[Primitives] =
-    struct(
-      byte.required[Primitives]("b", _.b).addHints(smithy.api.Required()),
-      short.required[Primitives]("s", _.s).addHints(smithy.api.Required()),
-      int.required[Primitives]("i", _.i).addHints(smithy.api.Required()),
-      long.required[Primitives]("l", _.l).addHints(smithy.api.Required()),
-      boolean.required[Primitives]("bl", _.bl).addHints(smithy.api.Required()),
-      string.required[Primitives]("ch", _.ch.toString).addHints(smithy.api.Required()),
-      double.required[Primitives]("dbl", _.dbl).addHints(smithy.api.Required()),
-      float.required[Primitives]("f", _.f).addHints(smithy.api.Required())
-    )((b, s, i, l, bl, st, dbl, f) => Primitives.apply(b, s, i, l, bl, {
-      if (st.length == 1) st.charAt(0)
-      else sys.error("illegal char")
-    }, dbl, f))
-  implicit val primitivesJCodec: JCodec[Primitives] = JCodec.deriveJCodecFromSchema(primitivesSchema)
-  val setOfIntsSchema: Schema[Set[Int]] = set(int)
-  implicit val setOfIntsJCodec: JCodec[Set[Int]] = JCodec.deriveJCodecFromSchema(setOfIntsSchema)
-  val vectorOfBooleansSchema: Schema[Vector[Boolean]] =
-    bijection[List[Boolean], Vector[Boolean]](list(boolean), _.toVector, _.toList)
-  implicit val vectorOfBooleansJCodec: JCodec[Vector[Boolean]] = JCodec.deriveJCodecFromSchema(vectorOfBooleansSchema)
+  implicit val primitivesJCodec: JCodec[Primitives] = JCodec.deriveJCodecFromSchema(struct(
+    byte.required[Primitives]("b", _.b),
+    short.required[Primitives]("s", _.s),
+    int.required[Primitives]("i", _.i),
+    long.required[Primitives]("l", _.l),
+    boolean.required[Primitives]("bl", _.bl),
+    string.required[Primitives]("ch", _.ch.toString),
+    double.required[Primitives]("dbl", _.dbl),
+    float.required[Primitives]("f", _.f)
+  )((b, s, i, l, bl, st, dbl, f) => Primitives(b, s, i, l, bl, {
+    if (st.length == 1) st.charAt(0)
+    else sys.error("illegal char")
+  }, dbl, f)))
+  implicit val setOfIntsJCodec: JCodec[Set[Int]] = JCodec.deriveJCodecFromSchema(set(int))
+  val stringJCodec: JCodec[String] = JCodec.deriveJCodecFromSchema(string)
+  implicit val vectorOfBooleansJCodec: JCodec[Vector[Boolean]] =
+    JCodec.deriveJCodecFromSchema(bijection[List[Boolean], Vector[Boolean]](list(boolean), _.toVector, _.toList))
 }

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Smithy4sCodecs.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Smithy4sCodecs.scala
@@ -1,12 +1,15 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
+import com.github.plokhotnyuk.jsoniter_scala.benchmark.GeoJSON.GeoJSON
 import smithy4s.http.json._
-import smithy4s.{ByteArray, Schema}
+import smithy4s.{ByteArray, Schema, Timestamp}
 import smithy4s.api.Discriminated
 import smithy4s.schema.Schema._
+import java.time.Instant
+import java.util.UUID
 
 object Smithy4sCodecs {
-  implicit val adtSchema: Schema[ADTBase] = recursive {
+  val adtSchema: Schema[ADTBase] = recursive {
     val xAlt = struct(int.required[X]("a", _.a))(X.apply).oneOf[ADTBase]("X")
     val yAlt = struct(string.required[Y]("b", _.b))(Y.apply).oneOf[ADTBase]("Y")
     val zAlt = struct(adtSchema.required[Z]("l", _.l), adtSchema.required[Z]("r", _.r))(Z.apply).oneOf[ADTBase]("Z")
@@ -31,19 +34,168 @@ object Smithy4sCodecs {
       if (st.length == 1) st.charAt(0)
       else sys.error("illegal char")
     }), DoubleVal(dbl), FloatVal(f))))
+  implicit val arrayOfBigDecimalsJCodec: JCodec[Array[BigDecimal]] =
+    JCodec.deriveJCodecFromSchema(bijection[List[BigDecimal], Array[BigDecimal]](list(bigdecimal), _.toArray, _.toList))
+  implicit val arrayOfBigIntsJCodec: JCodec[Array[BigInt]] =
+    JCodec.deriveJCodecFromSchema(bijection[List[BigInt], Array[BigInt]](list(bigint), _.toArray, _.toList))
+  implicit val arrayOfBooleansJCodec: JCodec[Array[Boolean]] =
+    JCodec.deriveJCodecFromSchema(bijection[List[Boolean], Array[Boolean]](list(boolean), _.toArray, _.toList))
+  implicit val arrayOfBytesJCodec: JCodec[Array[Byte]] =
+    JCodec.deriveJCodecFromSchema(bijection[List[Byte], Array[Byte]](list(byte), _.toArray, _.toList))
+  implicit val arrayOfDoublesJCodec: JCodec[Array[Double]] =
+    JCodec.deriveJCodecFromSchema(bijection[List[Double], Array[Double]](list(double), _.toArray, _.toList))
+  implicit val arrayOfFloatsJCodec: JCodec[Array[Float]] =
+    JCodec.deriveJCodecFromSchema(bijection[List[Float], Array[Float]](list(float), _.toArray, _.toList))
+  implicit val arrayOfInstantsJCodec: JCodec[Array[Instant]] =
+    JCodec.deriveJCodecFromSchema(bijection[List[Timestamp], Array[Instant]](list(timestamp),
+      _.map(PlatformUtils.toInstant).toArray, _.map(PlatformUtils.toTimestamp).toList))
+  implicit val arrayOfIntsJCodec: JCodec[Array[Int]] =
+    JCodec.deriveJCodecFromSchema(bijection[List[Int], Array[Int]](list(int), _.toArray, _.toList))
+  implicit val arrayOfLongsJCodec: JCodec[Array[Long]] =
+    JCodec.deriveJCodecFromSchema(bijection[List[Long], Array[Long]](list(long), _.toArray, _.toList))
+  implicit val arrayOfShortsJCodec: JCodec[Array[Short]] =
+    JCodec.deriveJCodecFromSchema(bijection[List[Short], Array[Short]](list(short), _.toArray, _.toList))
+  implicit val arrayOfUUIDsJCodec: JCodec[Array[UUID]] =
+    JCodec.deriveJCodecFromSchema(bijection[List[UUID], Array[UUID]](list(uuid), _.toArray, _.toList))
   val base64JCodec: JCodec[Array[Byte]] =
     JCodec.deriveJCodecFromSchema(bijection[ByteArray, Array[Byte]](bytes, _.array, ByteArray.apply))
   val bigDecimalJCodec: JCodec[BigDecimal] = JCodec.deriveJCodecFromSchema(bigdecimal)
   val bigIntJCodec: JCodec[BigInt] = JCodec.deriveJCodecFromSchema(bigint)
   implicit val extractFieldsJCodec: JCodec[ExtractFields] = JCodec.deriveJCodecFromSchema(struct(
     string.required[ExtractFields]("s", _.s),
-    int.required[ExtractFields]("i", _.i),
+    int.required[ExtractFields]("i", _.i)
   )(ExtractFields.apply))
+  implicit val geoJsonJCodec: JCodec[GeoJSON] = JCodec.deriveJCodecFromSchema {
+    def toIndexedSeqOfIndexedSeq[A](xs: List[List[A]]): IndexedSeq[IndexedSeq[A]] =
+      xs.foldLeft(IndexedSeq.newBuilder[IndexedSeq[A]])((a, x) => a.addOne(x.toIndexedSeq)).result()
+
+    def toListOfList[A](xs: IndexedSeq[IndexedSeq[A]]): List[List[A]] =
+      xs.foldLeft(List.newBuilder[List[A]])((a, x) => a.addOne(x.toList)).result()
+
+    val coordinatesSchema: Schema[(Double, Double)] =
+      bijection[List[Double], (Double, Double)](list(double), {
+        case (x: Double) :: (y: Double) :: Nil => (x, y)
+        case _ => sys.error("expecting array of 2 numbers")
+      }, x => x._1 :: x._2 :: Nil)
+    val bboxSchema: Schema[(Double, Double, Double, Double)] =
+      bijection[List[Double], (Double, Double, Double, Double)](list(double), {
+        case (x1: Double) :: (y1: Double) :: (x2: Double) :: (y2: Double) :: Nil => (x1, y1, x2, y2)
+        case _ => sys.error("expecting array of 4 numbers")
+      }, x => x._1 :: x._2 :: x._3 :: x._4 :: Nil)
+    val pointSchema: Schema[GeoJSON.Point] =
+      struct(
+        coordinatesSchema.required[GeoJSON.Point]("coordinates", _.coordinates),
+      )(GeoJSON.Point.apply)
+    val multiPointSchema: Schema[GeoJSON.MultiPoint] =
+      struct(
+        list(coordinatesSchema).required[GeoJSON.MultiPoint]("coordinates", _.coordinates.toList),
+      )(coordinates => GeoJSON.MultiPoint(coordinates.toIndexedSeq))
+    val lineStringSchema: Schema[GeoJSON.LineString] =
+      struct(
+        list(coordinatesSchema).required[GeoJSON.LineString]("coordinates", _.coordinates.toList),
+      )(coordinates => GeoJSON.LineString(coordinates.toIndexedSeq))
+    val multiLineStringSchema: Schema[GeoJSON.MultiLineString] =
+      struct(
+        list(list(coordinatesSchema)).required[GeoJSON.MultiLineString]("coordinates", x => toListOfList(x.coordinates)),
+      )(coordinates => GeoJSON.MultiLineString(toIndexedSeqOfIndexedSeq(coordinates)))
+    val polygonSchema: Schema[GeoJSON.Polygon] =
+      struct(
+        list(list(coordinatesSchema)).required[GeoJSON.Polygon]("coordinates", x => toListOfList(x.coordinates)),
+      )(coordinates => GeoJSON.Polygon(toIndexedSeqOfIndexedSeq(coordinates)))
+    val multiPolygonSchema: Schema[GeoJSON.MultiPolygon] =
+      struct(
+        list(list(list(coordinatesSchema)))
+          .required[GeoJSON.MultiPolygon]("coordinates", _.coordinates.map(toListOfList).toList),
+      )(coordinates => GeoJSON.MultiPolygon(coordinates.map(toIndexedSeqOfIndexedSeq).toIndexedSeq))
+    val simpleGeometrySchema: Schema[GeoJSON.SimpleGeometry] =  {
+      val pointAlt = pointSchema.oneOf[GeoJSON.SimpleGeometry]("Point")
+      val multiPointAlt = multiPointSchema.oneOf[GeoJSON.SimpleGeometry]("MultiPoint")
+      val lineStringAlt = lineStringSchema.oneOf[GeoJSON.SimpleGeometry]("LineString")
+      val multiLineStringAlt = multiLineStringSchema.oneOf[GeoJSON.SimpleGeometry]("MultiLineString")
+      val polygonAlt = polygonSchema.oneOf[GeoJSON.SimpleGeometry]("Polygon")
+      val multiPolygonAlt = multiPolygonSchema.oneOf[GeoJSON.SimpleGeometry]("MultiPolygon")
+      union(pointAlt, multiPointAlt, lineStringAlt, multiLineStringAlt, polygonAlt, multiPolygonAlt) {
+        case x: GeoJSON.Point => pointAlt(x)
+        case x: GeoJSON.MultiPoint => multiPointAlt(x)
+        case x: GeoJSON.LineString => lineStringAlt(x)
+        case x: GeoJSON.MultiLineString => multiLineStringAlt(x)
+        case x: GeoJSON.Polygon => polygonAlt(x)
+        case x: GeoJSON.MultiPolygon => multiPolygonAlt(x)
+      }.addHints(Discriminated("type"))
+    }
+    val geometryCollectionSchema: Schema[GeoJSON.GeometryCollection] =
+      struct(
+        list(simpleGeometrySchema).required[GeoJSON.GeometryCollection]("geometries", _.geometries.toList),
+      )(geometries => GeoJSON.GeometryCollection(geometries.toIndexedSeq))
+    val geometrySchema: Schema[GeoJSON.Geometry] = {
+      val pointAlt = pointSchema.oneOf[GeoJSON.Geometry]("Point")
+      val multiPointAlt = multiPointSchema.oneOf[GeoJSON.Geometry]("MultiPoint")
+      val lineStringAlt = lineStringSchema.oneOf[GeoJSON.Geometry]("LineString")
+      val multiLineStringAlt = multiLineStringSchema.oneOf[GeoJSON.Geometry]("MultiLineString")
+      val polygonAlt = polygonSchema.oneOf[GeoJSON.Geometry]("Polygon")
+      val multiPolygonAlt = multiPolygonSchema.oneOf[GeoJSON.Geometry]("MultiPolygon")
+      val geometryCollectionAlt = geometryCollectionSchema.oneOf[GeoJSON.Geometry]("GeometryCollection")
+      union(pointAlt, multiPointAlt, lineStringAlt, multiLineStringAlt, polygonAlt, multiPolygonAlt, geometryCollectionAlt) {
+        case x: GeoJSON.Point => pointAlt(x)
+        case x: GeoJSON.MultiPoint => multiPointAlt(x)
+        case x: GeoJSON.LineString => lineStringAlt(x)
+        case x: GeoJSON.MultiLineString => multiLineStringAlt(x)
+        case x: GeoJSON.Polygon => polygonAlt(x)
+        case x: GeoJSON.MultiPolygon => multiPolygonAlt(x)
+        case x: GeoJSON.GeometryCollection => geometryCollectionAlt(x)
+      }.addHints(Discriminated("type"))
+    }
+    val featureSchema: Schema[GeoJSON.Feature] =
+      struct(
+        map(string, string).required[GeoJSON.Feature]("properties", _.properties),
+        geometrySchema.required[GeoJSON.Feature]("geometry", _.geometry),
+        bboxSchema.optional[GeoJSON.Feature]("bbox", _.bbox)
+      )((properties, geometry, bbox) => GeoJSON.Feature(properties, geometry, bbox))
+    val simpleGeoJSONSchema: Schema[GeoJSON.SimpleGeoJSON] = {
+      val featureAlt = featureSchema.oneOf[GeoJSON.SimpleGeoJSON]("Feature")
+      union(featureAlt) {
+        case x: GeoJSON.Feature => featureAlt(x)
+      }.addHints(Discriminated("type"))
+    }
+    val featureCollectionSchema: Schema[GeoJSON.FeatureCollection] =
+      struct(
+        list(simpleGeoJSONSchema).required[GeoJSON.FeatureCollection]("features", _.features.toList),
+        bboxSchema.optional[GeoJSON.FeatureCollection]("bbox", _.bbox)
+      )((features, bbox) => GeoJSON.FeatureCollection(features.toIndexedSeq, bbox))
+    val featureAlt = featureSchema.oneOf[GeoJSON]("Feature")
+    val featureCollectionAlt = featureCollectionSchema.oneOf[GeoJSON]("FeatureCollection")
+    union(featureAlt, featureCollectionAlt) {
+      case x: GeoJSON.Feature => featureAlt(x)
+      case x: GeoJSON.FeatureCollection => featureCollectionAlt(x)
+    }.addHints(Discriminated("type"))
+  }
+  implicit val gitHubActionsAPIJCodec: JCodec[GitHubActionsAPI.Response] = JCodec.deriveJCodecFromSchema({
+    val rowsSchema: Schema[GitHubActionsAPI.Artifact] =
+      struct(
+        long.required[GitHubActionsAPI.Artifact]("id", _.id),
+        string.required[GitHubActionsAPI.Artifact]("node_id", _.node_id),
+        string.required[GitHubActionsAPI.Artifact]("name", _.name),
+        long.required[GitHubActionsAPI.Artifact]("size_in_bytes", _.size_in_bytes),
+        string.required[GitHubActionsAPI.Artifact]("url", _.url),
+        string.required[GitHubActionsAPI.Artifact]("archive_download_url", _.archive_download_url),
+        string.required[GitHubActionsAPI.Artifact]("expired", _.expired.toString),
+        timestamp.required[GitHubActionsAPI.Artifact]("created_at", x => PlatformUtils.toTimestamp(x.created_at)),
+        timestamp.required[GitHubActionsAPI.Artifact]("expires_at", x => PlatformUtils.toTimestamp(x.expires_at))
+      )((id, node_id, name, size_in_bytes, url, archive_download_url, expired, created_at, expires_at) =>
+        GitHubActionsAPI.Artifact(id, node_id, name, size_in_bytes, url, archive_download_url, expired.toBoolean,
+          PlatformUtils.toInstant(created_at), PlatformUtils.toInstant(expires_at)))
+    struct(
+      int.required[GitHubActionsAPI.Response]("total_count", _.total_count),
+      list(rowsSchema).required[GitHubActionsAPI.Response]("artifacts", _.artifacts.toList)
+    ) { (total_count, artifacts) =>
+      GitHubActionsAPI.Response(total_count, artifacts)
+    }
+  })
   implicit val googleMapsAPIJCodec: JCodec[GoogleMapsAPI.DistanceMatrix] = JCodec.deriveJCodecFromSchema({
     val valueSchema: Schema[GoogleMapsAPI.Value] =
       struct(
         string.required[GoogleMapsAPI.Value]("text", _.text),
-        int.required[GoogleMapsAPI.Value]("value", _.value),
+        int.required[GoogleMapsAPI.Value]("value", _.value)
       )(GoogleMapsAPI.Value.apply)
     val elementsSchema: Schema[GoogleMapsAPI.Elements] =
       struct(
@@ -53,13 +205,13 @@ object Smithy4sCodecs {
       )(GoogleMapsAPI.Elements.apply)
     val rowsSchema: Schema[GoogleMapsAPI.Rows] =
       struct(
-        list(elementsSchema).required[GoogleMapsAPI.Rows]("elements", _.elements.toList),
-      )(elements => GoogleMapsAPI.Rows.apply(elements.toVector))
+        list(elementsSchema).required[GoogleMapsAPI.Rows]("elements", _.elements.toList)
+      )(elements => GoogleMapsAPI.Rows(elements.toVector))
     struct(
       list(string).required[GoogleMapsAPI.DistanceMatrix]("destination_addresses", _.destination_addresses.toList),
       list(string).required[GoogleMapsAPI.DistanceMatrix]("origin_addresses", _.origin_addresses.toList),
       list(rowsSchema).required[GoogleMapsAPI.DistanceMatrix]("rows", _.rows.toList),
-      string.required[GoogleMapsAPI.DistanceMatrix]("status", _.status),
+      string.required[GoogleMapsAPI.DistanceMatrix]("status", _.status)
     ) { (destination_addresses, origin_addresses, rows, status) =>
       GoogleMapsAPI.DistanceMatrix(destination_addresses.toVector, origin_addresses.toVector, rows.toVector, status)
     }
@@ -70,7 +222,7 @@ object Smithy4sCodecs {
   implicit val missingRequiredFieldsJCodec: JCodec[MissingRequiredFields] =
     JCodec.deriveJCodecFromSchema(struct(
       string.required[MissingRequiredFields]("s", _.s),
-      int.required[MissingRequiredFields]("i", _.i),
+      int.required[MissingRequiredFields]("i", _.i)
     )(MissingRequiredFields.apply))
   val nestedStructsSchema: Schema[NestedStructs] =
     recursive(struct(nestedStructsSchema.optional[NestedStructs]("n", _.n))(NestedStructs.apply))

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReading.scala
@@ -53,6 +53,13 @@ class StringOfAsciiCharsReading extends StringOfAsciiCharsBenchmark {
   def playJsonJsoniter(): String = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[String])
 
   @Benchmark
+  def smithy4s(): String = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[String](jsonBytes, tooLongStringConfig)(stringJCodec)
+  }
+
+  @Benchmark
   def sprayJson(): String = spray.json.JsonParser(jsonBytes).convertTo[String]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsWriting.scala
@@ -52,6 +52,13 @@ class StringOfAsciiCharsWriting extends StringOfAsciiCharsBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)(stringJCodec)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReading.scala
@@ -53,6 +53,13 @@ class StringOfEscapedCharsReading extends StringOfEscapedCharsBenchmark {
   def playJsonJsoniter(): String = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[String])
 
   @Benchmark
+  def smithy4s(): String = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[String](jsonBytes, tooLongStringConfig)(stringJCodec)
+  }
+
+  @Benchmark
   def sprayJson(): String = spray.json.JsonParser(jsonBytes).convertTo[String]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsWriting.scala
@@ -5,7 +5,7 @@ import com.avsystem.commons.serialization.json._
 import com.evolutiongaming.jsonitertool.PlayJsonJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
-import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
+import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs.{escapingConfig, _}
 import com.github.plokhotnyuk.jsoniter_scala.benchmark.WeePickleFromTos._
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.rallyhealth.weepickle.v1.WeePickle.FromScala
@@ -43,6 +43,13 @@ class StringOfEscapedCharsWriting extends StringOfEscapedCharsBenchmark {
 
   @Benchmark
   def playJsonJsoniter(): Array[Byte] = writeToArray(Json.toJson(obj), escapingConfig)(PlayJsonJsoniter.jsValueCodec)
+
+  @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj, escapingConfig)(stringJCodec)
+  }
 
   @Benchmark
   def uPickle(): Array[Byte] = write(obj, escapeUnicode = true).getBytes(UTF_8)

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReading.scala
@@ -53,6 +53,13 @@ class StringOfNonAsciiCharsReading extends StringOfNonAsciiCharsBenchmark {
   def playJsonJsoniter(): String = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[String])
 
   @Benchmark
+  def smithy4s(): String = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[String](jsonBytes, tooLongStringConfig)(stringJCodec)
+  }
+
+  @Benchmark
   def sprayJson(): String = spray.json.JsonParser(jsonBytes).convertTo[String]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsWriting.scala
@@ -52,6 +52,13 @@ class StringOfNonAsciiCharsWriting extends StringOfNonAsciiCharsBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)(stringJCodec)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReading.scala
@@ -54,6 +54,13 @@ class VectorOfBooleansReading extends VectorOfBooleansBenchmark {
   def playJsonJsoniter(): Vector[Boolean] = PlayJsonJsoniter.deserialize(jsonBytes).fold(throw _, _.as[Vector[Boolean]])
 
   @Benchmark
+  def smithy4s(): Vector[Boolean] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    readFromArray[Vector[Boolean]](jsonBytes)
+  }
+
+  @Benchmark
   def sprayJson(): Vector[Boolean] = JsonParser(jsonBytes).convertTo[Vector[Boolean]]
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansWriting.scala
@@ -52,6 +52,13 @@ class VectorOfBooleansWriting extends VectorOfBooleansBenchmark {
   def playJsonJsoniter(): Array[Byte] = PlayJsonJsoniter.serialize(Json.toJson(obj))
 
   @Benchmark
+  def smithy4s(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Smithy4sCodecs._
+
+    writeToArray(obj)
+  }
+
+  @Benchmark
   def sprayJson(): Array[Byte] = {
     import spray.json._
 


### PR DESCRIPTION
Results from my old notebook:
```
[info] Benchmark                                   (size)   Mode  Cnt        Score        Error  Units
[info] NestedStructsReading.avSystemGenCodec          128  thrpt    5   103322.916 ±   3195.982  ops/s
[info] NestedStructsReading.circe                     128  thrpt    5    64123.056 ±   2350.009  ops/s
[info] NestedStructsReading.circeJawn                 128  thrpt    5    62138.290 ±   2854.840  ops/s
[info] NestedStructsReading.circeJsoniter             128  thrpt    5    72076.606 ±   8346.283  ops/s
[info] NestedStructsReading.dslJsonScala              128  thrpt    5   236350.722 ±  40362.958  ops/s
[info] NestedStructsReading.jacksonScala              128  thrpt    5   110741.243 ±  11518.448  ops/s
[info] NestedStructsReading.jsoniterScala             128  thrpt    5   385037.897 ±  29568.250  ops/s
[info] NestedStructsReading.playJson                  128  thrpt    5    34079.342 ±   2612.901  ops/s
[info] NestedStructsReading.playJsonJsoniter          128  thrpt    5    52496.308 ±   5520.923  ops/s
[info] NestedStructsReading.smithy4s                  128  thrpt    5    54985.713 ±   7192.883  ops/s
[info] NestedStructsReading.sprayJson                 128  thrpt    5   145225.125 ±  24760.091  ops/s
[info] NestedStructsReading.uPickle                   128  thrpt    5   127393.204 ±  17875.397  ops/s
[info] NestedStructsReading.weePickle                 128  thrpt    5   115324.576 ±  11061.477  ops/s
[info] NestedStructsWriting.avSystemGenCodec          128  thrpt    5   209578.324 ±  11633.772  ops/s
[info] NestedStructsWriting.circe                     128  thrpt    5    64829.106 ±   3847.585  ops/s
[info] NestedStructsWriting.circeJsoniter             128  thrpt    5    95073.734 ±   4750.386  ops/s
[info] NestedStructsWriting.jacksonScala              128  thrpt    5   202187.589 ±  26723.268  ops/s
[info] NestedStructsWriting.jsoniterScala             128  thrpt    5  1313212.681 ± 158271.152  ops/s
[info] NestedStructsWriting.jsoniterScalaPrealloc     128  thrpt    5  1408780.896 ± 126887.590  ops/s
[info] NestedStructsWriting.playJson                  128  thrpt    5    50700.122 ±   6170.528  ops/s
[info] NestedStructsWriting.playJsonJsoniter          128  thrpt    5    58167.373 ±   3552.462  ops/s
[info] NestedStructsWriting.smithy4s                  128  thrpt    5   150732.110 ±   6433.748  ops/s
[info] NestedStructsWriting.sprayJson                 128  thrpt    5    43053.388 ±   4692.225  ops/s
[info] NestedStructsWriting.uPickle                   128  thrpt    5   214527.693 ±  25307.050  ops/s
[info] NestedStructsWriting.weePickle                 128  thrpt    5   205820.314 ±  23199.138  ops/s
```

```
[info] Benchmark                                 Mode  Cnt         Score         Error  Units
[info] PrimitivesReading.avSystemGenCodec       thrpt    5   1020089.867 ±  165968.661  ops/s
[info] PrimitivesReading.borer                  thrpt    5   2286641.076 ±   26911.996  ops/s
[info] PrimitivesReading.circe                  thrpt    5    886837.630 ±   31472.986  ops/s
[info] PrimitivesReading.circeJawn              thrpt    5    849799.160 ±  120943.894  ops/s
[info] PrimitivesReading.circeJsoniter          thrpt    5   1017255.280 ±  153484.812  ops/s
[info] PrimitivesReading.dslJsonScala           thrpt    5   3859677.010 ±  706007.881  ops/s
[info] PrimitivesReading.jacksonScala           thrpt    5   1407273.567 ±  163307.086  ops/s
[info] PrimitivesReading.jsoniterScala          thrpt    5   5649949.208 ±   46837.427  ops/s
[info] PrimitivesReading.playJson               thrpt    5    618889.294 ±   80747.944  ops/s
[info] PrimitivesReading.playJsonJsoniter       thrpt    5    899394.225 ±   16729.877  ops/s
[info] PrimitivesReading.smithy4s               thrpt    5   1292951.155 ±  234335.300  ops/s
[info] PrimitivesReading.sprayJson              thrpt    5    694581.594 ±   68026.608  ops/s
[info] PrimitivesReading.uPickle                thrpt    5   1514957.519 ±  200665.925  ops/s
[info] PrimitivesReading.weePickle              thrpt    5   1600819.804 ±  190342.201  ops/s
[info] PrimitivesReading.zioJson                thrpt    5   1595611.642 ±  247879.241  ops/s
[info] PrimitivesWriting.avSystemGenCodec       thrpt    5   2182089.045 ±  333788.103  ops/s
[info] PrimitivesWriting.borer                  thrpt    5   2790739.604 ±  587871.778  ops/s
[info] PrimitivesWriting.circe                  thrpt    5   1073418.511 ±  181955.268  ops/s
[info] PrimitivesWriting.circeJsoniter          thrpt    5   1755384.180 ±  180879.887  ops/s
[info] PrimitivesWriting.dslJsonScala           thrpt    5   4019661.938 ±  237599.690  ops/s
[info] PrimitivesWriting.jacksonScala           thrpt    5   2569120.665 ±  257676.573  ops/s
[info] PrimitivesWriting.jsoniterScala          thrpt    5  18088773.798 ± 2475874.745  ops/s
[info] PrimitivesWriting.jsoniterScalaPrealloc  thrpt    5  17978178.147 ± 2234534.722  ops/s
[info] PrimitivesWriting.playJson               thrpt    5    306442.441 ±   29373.345  ops/s
[info] PrimitivesWriting.playJsonJsoniter       thrpt    5    422178.716 ±   39319.674  ops/s
[info] PrimitivesWriting.smithy4s               thrpt    5   2606165.002 ±  442282.466  ops/s
[info] PrimitivesWriting.sprayJson              thrpt    5    957017.399 ±   47120.239  ops/s
[info] PrimitivesWriting.uPickle                thrpt    5   1731691.228 ±  241538.461  ops/s
[info] PrimitivesWriting.weePickle              thrpt    5   2404915.100 ±  125408.057  ops/s
[info] PrimitivesWriting.zioJson                thrpt    5   2692747.328 ±  228018.306  ops/s
```

```
[info] Benchmark                                           Mode  Cnt      Score       Error  Units
[info] GoogleMapsAPIPrettyPrinting.avSystemGenCodec       thrpt    5  10352.756 ±  1710.989  ops/s
[info] GoogleMapsAPIPrettyPrinting.circe                  thrpt    5   9686.276 ±  1069.554  ops/s
[info] GoogleMapsAPIPrettyPrinting.circeJsoniter          thrpt    5  14050.787 ±  1546.531  ops/s
[info] GoogleMapsAPIPrettyPrinting.jacksonScala           thrpt    5  12754.271 ±   486.851  ops/s
[info] GoogleMapsAPIPrettyPrinting.jsoniterScala          thrpt    5  45723.153 ±   371.139  ops/s
[info] GoogleMapsAPIPrettyPrinting.jsoniterScalaPrealloc  thrpt    5  56068.324 ± 10433.534  ops/s
[info] GoogleMapsAPIPrettyPrinting.playJson               thrpt    5   3727.224 ±   622.772  ops/s
[info] GoogleMapsAPIPrettyPrinting.playJsonJsoniter       thrpt    5   5790.210 ±   587.668  ops/s
[info] GoogleMapsAPIPrettyPrinting.smithy4s               thrpt    5  10413.887 ±   996.446  ops/s
[info] GoogleMapsAPIPrettyPrinting.sprayJson              thrpt    5   7249.719 ±   615.495  ops/s
[info] GoogleMapsAPIPrettyPrinting.uPickle                thrpt    5  14374.854 ±  1194.877  ops/s
[info] GoogleMapsAPIPrettyPrinting.weePickle              thrpt    5  11912.337 ±  2007.437  ops/s
[info] GoogleMapsAPIPrettyPrinting.zioJson                thrpt    5  11911.633 ±   497.141  ops/s
[info] GoogleMapsAPIReading.avSystemGenCodec              thrpt    5   7019.040 ±   299.047  ops/s
[info] GoogleMapsAPIReading.borer                         thrpt    5  16218.679 ±  3538.777  ops/s
[info] GoogleMapsAPIReading.circe                         thrpt    5   7619.052 ±   745.480  ops/s
[info] GoogleMapsAPIReading.circeJawn                     thrpt    5   9008.924 ±  1352.888  ops/s
[info] GoogleMapsAPIReading.circeJsoniter                 thrpt    5  10004.869 ±   538.731  ops/s
[info] GoogleMapsAPIReading.dslJsonScala                  thrpt    5  11298.332 ±  1886.535  ops/s
[info] GoogleMapsAPIReading.jacksonScala                  thrpt    5  13563.595 ±  3467.274  ops/s
[info] GoogleMapsAPIReading.jsoniterScala                 thrpt    5  23844.551 ±  2627.165  ops/s
[info] GoogleMapsAPIReading.ninnyJson                     thrpt    5   8021.829 ±  1005.146  ops/s
[info] GoogleMapsAPIReading.playJson                      thrpt    5   5452.854 ±   267.276  ops/s
[info] GoogleMapsAPIReading.playJsonJsoniter              thrpt    5   8482.179 ±   568.309  ops/s
[info] GoogleMapsAPIReading.smithy4s                      thrpt    5   7916.034 ±   406.653  ops/s
[info] GoogleMapsAPIReading.sprayJson                     thrpt    5   6922.383 ±   574.581  ops/s
[info] GoogleMapsAPIReading.uPickle                       thrpt    5   8001.419 ±   640.830  ops/s
[info] GoogleMapsAPIReading.weePickle                     thrpt    5  11376.060 ±   203.200  ops/s
[info] GoogleMapsAPIReading.zioJson                       thrpt    5  10023.898 ±  1095.353  ops/s
[info] GoogleMapsAPIWriting.avSystemGenCodec              thrpt    5  18660.735 ±  1539.363  ops/s
[info] GoogleMapsAPIWriting.borer                         thrpt    5  18420.764 ±   212.593  ops/s
[info] GoogleMapsAPIWriting.circe                         thrpt    5  10140.804 ±  1365.863  ops/s
[info] GoogleMapsAPIWriting.circeJsoniter                 thrpt    5  16026.862 ±  1274.840  ops/s
[info] GoogleMapsAPIWriting.dslJsonScala                  thrpt    5  44686.951 ±  2195.649  ops/s
[info] GoogleMapsAPIWriting.jacksonScala                  thrpt    5  35868.035 ±  3130.016  ops/s
[info] GoogleMapsAPIWriting.jsoniterScala                 thrpt    5  65643.332 ±  6359.719  ops/s
[info] GoogleMapsAPIWriting.jsoniterScalaPrealloc         thrpt    5  88779.635 ±  2826.392  ops/s
[info] GoogleMapsAPIWriting.ninnyJson                     thrpt    5   7775.757 ±   777.863  ops/s
[info] GoogleMapsAPIWriting.playJson                      thrpt    5   4793.333 ±   523.975  ops/s
[info] GoogleMapsAPIWriting.playJsonJsoniter              thrpt    5   5955.668 ±    96.625  ops/s
[info] GoogleMapsAPIWriting.smithy4s                      thrpt    5  12088.323 ±  1815.843  ops/s
[info] GoogleMapsAPIWriting.sprayJson                     thrpt    5  10477.458 ±   757.757  ops/s
[info] GoogleMapsAPIWriting.uPickle                       thrpt    5  15899.221 ±   203.452  ops/s
[info] GoogleMapsAPIWriting.weePickle                     thrpt    5  31720.450 ±  4215.409  ops/s
[info] GoogleMapsAPIWriting.zioJson                       thrpt    5  18040.994 ±   496.251  ops/s
```