### PR TITLE
Add an optional ability to skip comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ List of options that change parsing and serialization in runtime:
 - Preferred size of internal output buffers when serializing to `java.io.OutputStream` or `java.nio.DirectByteBuffer`
 - Max size of char buffers when parsing string values
 - Preferred size of char buffers when parsing string values
+- Ability to skip one-line and multi-line JavaScript-like comments
 
 For upcoming features and fixes see [Commits](https://github.com/plokhotnyuk/jsoniter-scala/commits/master)
 and [Issues page](https://github.com/plokhotnyuk/jsoniter-scala/issues).

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import com.typesafe.tools.mima.core._
 import org.scalajs.linker.interface.{CheckedBehavior, ESVersion}
 import sbt._
 import scala.sys.process._
@@ -102,7 +103,10 @@ lazy val publishSettings = Seq(
     if (isCheckingRequired) Set(organization.value %%% moduleName.value % oldVersion)
     else Set()
   },
-  mimaReportSignatureProblems := true
+  mimaReportSignatureProblems := true,
+  mimaBinaryIssueFilters := Seq( // ignore changes of some private constructor in Core API
+    ProblemFilters.exclude[DirectMissingMethodProblem]("com.github.plokhotnyuk.jsoniter_scala.core.ReaderConfig.this")
+  )
 )
 
 lazy val `jsoniter-scala` = project.in(file("."))

--- a/jsoniter-scala-core/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
+++ b/jsoniter-scala-core/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
@@ -696,13 +696,14 @@ final class JsonReader private[jsoniter_scala](
   private[jsoniter_scala] def skipWhitespaces(): Boolean = {
     var pos = head
     var buf = this.buf
+    val ns = nibbles
     while ((pos < tail || {
       pos = loadMore(pos)
       buf = this.buf
       pos < tail
     }) && {
       val b = buf(pos)
-      b == ' ' || b == '\n' || (b | 0x4) == '\r' || b == '/' && config.allowComments && {
+      ns(b & 0xFF) == -2 || b == '/' && config.allowComments && {
         pos = skipComment(pos + 1) - 1
         true
       }
@@ -772,16 +773,16 @@ final class JsonReader private[jsoniter_scala](
     } else nextByteOrError(t, loadMoreOrError(pos))
 
   @tailrec
-  private[this] def nextToken(pos: Int): Byte =
+  private[this] def nextToken(pos: Int, ns: Array[Byte] = nibbles): Byte =
     if (pos < tail) {
       val b = buf(pos)
-      if (b == ' ' || b == '\n' || (b | 0x4) == '\r') nextToken(pos + 1)
-      else if (b == '/' && config.allowComments) nextToken(skipComment(pos + 1))
+      if (ns(b & 0xFF) == -2) nextToken(pos + 1, ns)
+      else if (b == '/' && config.allowComments) nextToken(skipComment(pos + 1), ns)
       else {
         head = pos + 1
         b
       }
-    } else nextToken(loadMoreOrError(pos))
+    } else nextToken(loadMoreOrError(pos), ns)
 
   @tailrec
   private[this] def nextTokenOrError(t: Byte, pos: Int): Unit =
@@ -1168,7 +1169,7 @@ final class JsonReader private[jsoniter_scala](
           false
         } else parseBoolean(isToken, loadMoreOrError(pos))
       } else if (isToken) {
-        if (b1 == ' ' || b1 == '\n' || (b1 | 0x4) == '\r') parseBoolean(isToken, pos + 1)
+        if (nibbles(b1 & 0xFF) == -2) parseBoolean(isToken, pos + 1)
         else if (b1 == '/' && config.allowComments) parseBoolean(isToken, skipComment(pos + 1))
         else booleanError(pos)
       } else booleanError(pos)
@@ -3292,6 +3293,10 @@ object JsonReader {
   /* Use the following code to generate `nibbles` in Scala REPL:
     val ns = new Array[Byte](256)
     java.util.Arrays.fill(ns, -1: Byte)
+    ns(' ') = -2
+    ns('\n') = -2
+    ns('\t') = -2
+    ns('\r') = -2
     ns('0') = 0
     ns('1') = 1
     ns('2') = 2
@@ -3317,9 +3322,9 @@ object JsonReader {
     ns.grouped(16).map(_.mkString(", ")).mkString("Array(\n", ",\n", "\n)")
    */
   private final val nibbles: Array[Byte] = Array(
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -2, -2, -1, -1, -2, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -2, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, -1, -1, -1, -1, -1, -1,
     -1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,

--- a/jsoniter-scala-core/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
+++ b/jsoniter-scala-core/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
@@ -526,9 +526,13 @@ final class JsonReader private[jsoniter_scala](
     else if ((b >= '0' && b <= '9') || b == '-') skipNumber(head)
     else if (b == 'n' || b == 't') skipFixedBytes(3, head)
     else if (b == 'f') skipFixedBytes(4, head)
-    else if (b == '[') skipArray(0, head)
-    else if (b == '{') skipObject(0, head)
-    else decodeError("expected value")
+    else if (b == '[') {
+      if (config.allowComments) skipArrayWithComments(0, head)
+      else skipArray(0, head)
+    } else if (b == '{') {
+      if (config.allowComments) skipObjectWithComments(0, head)
+      else skipObject(0, head)
+    } else decodeError("expected value")
   }
 
   def commaError(): Nothing = decodeError("expected ','")
@@ -698,7 +702,10 @@ final class JsonReader private[jsoniter_scala](
       pos < tail
     }) && {
       val b = buf(pos)
-      b == ' ' || b == '\n' || (b | 0x4) == '\r'
+      b == ' ' || b == '\n' || (b | 0x4) == '\r' || b == '/' && config.allowComments && {
+        pos = skipComment(pos + 1) - 1
+        true
+      }
     }) pos += 1
     head = pos
     pos != tail
@@ -769,6 +776,7 @@ final class JsonReader private[jsoniter_scala](
     if (pos < tail) {
       val b = buf(pos)
       if (b == ' ' || b == '\n' || (b | 0x4) == '\r') nextToken(pos + 1)
+      else if (b == '/' && config.allowComments) nextToken(skipComment(pos + 1))
       else {
         head = pos + 1
         b
@@ -780,7 +788,7 @@ final class JsonReader private[jsoniter_scala](
     if (pos < tail) {
       val b = buf(pos)
       head = pos + 1
-      if (b != t && ((b != ' ' && b != '\n' && (b | 0x4) != '\r') || nextToken(pos + 1) != t)) tokenError(t, head - 1)
+      if (b != t && nextToken(pos) != t) tokenError(t, head - 1)
     } else nextTokenOrError(t, loadMoreOrError(pos))
 
   @tailrec
@@ -788,7 +796,7 @@ final class JsonReader private[jsoniter_scala](
     if (pos < tail) {
       val b = buf(pos)
       head = pos + 1
-      b == t || ((b == ' ' || b == '\n' || (b | 0x4) == '\r') && nextToken(pos + 1) == t)
+      b == t || nextToken(pos) == t
     } else isNextToken(t, loadMoreOrError(pos))
 
   private[this] def isCurrentToken(t: Byte, pos: Int): Boolean = {
@@ -1159,8 +1167,11 @@ final class JsonReader private[jsoniter_scala](
           if (b5 != 'e') booleanError(pos + 4)
           false
         } else parseBoolean(isToken, loadMoreOrError(pos))
-      } else if (isToken && (b1 == ' ' || b1 == '\n' || (b1 | 0x4) == '\r')) parseBoolean(isToken, pos + 1)
-      else booleanError(pos)
+      } else if (isToken) {
+        if (b1 == ' ' || b1 == '\n' || (b1 | 0x4) == '\r') parseBoolean(isToken, pos + 1)
+        else if (b1 == '/' && config.allowComments) parseBoolean(isToken, skipComment(pos + 1))
+        else booleanError(pos)
+      } else booleanError(pos)
     } else parseBoolean(isToken, loadMoreOrError(pos))
 
   private[this] def booleanError(pos: Int): Nothing = decodeError("illegal boolean", pos)
@@ -2955,10 +2966,11 @@ final class JsonReader private[jsoniter_scala](
     if (pos < tail) {
       val b = buf(pos)
       if (b == '"') skipObject(level, skipString(evenBackSlashes = true, pos + 1))
-      else if (b == '{') skipObject(level + 1, pos + 1)
-      else if (b != '}') skipObject(level, pos + 1)
-      else if (level != 0) skipObject(level - 1, pos + 1)
-      else pos + 1
+      else if (b == '}') {
+        if (level == 0) pos + 1
+        else skipObject(level - 1, pos + 1)
+      } else if (b == '{') skipObject(level + 1, pos + 1)
+      else skipObject(level, pos + 1)
     } else skipObject(level, loadMoreOrError(pos))
 
   @tailrec
@@ -2966,11 +2978,63 @@ final class JsonReader private[jsoniter_scala](
     if (pos < tail) {
       val b = buf(pos)
       if (b == '"') skipArray(level, skipString(evenBackSlashes = true, pos + 1))
-      else if (b == '[') skipArray(level + 1, pos + 1)
-      else if (b != ']') skipArray(level, pos + 1)
-      else if (level != 0) skipArray(level - 1, pos + 1)
-      else pos + 1
+      else if (b == ']') {
+        if (level == 0) pos + 1
+        else skipArray(level - 1, pos + 1)
+      } else if (b == '[') skipArray(level + 1, pos + 1)
+      else skipArray(level, pos + 1)
     } else skipArray(level, loadMoreOrError(pos))
+
+  @tailrec
+  private[this] def skipObjectWithComments(level: Int, pos: Int): Int =
+    if (pos < tail) {
+      val b = buf(pos)
+      if (b == '"') skipObjectWithComments(level, skipString(evenBackSlashes = true, pos + 1))
+      else if (b == '}') {
+        if (level == 0) pos + 1
+        else skipObjectWithComments(level - 1, pos + 1)
+      } else if (b == '{') skipObjectWithComments(level + 1, pos + 1)
+      else if (b == '/') skipObjectWithComments(level, skipComment(pos + 1))
+      else skipObjectWithComments(level, pos + 1)
+    } else skipObjectWithComments(level, loadMoreOrError(pos))
+
+  @tailrec
+  private[this] def skipArrayWithComments(level: Int, pos: Int): Int =
+    if (pos < tail) {
+      val b = buf(pos)
+      if (b == '"') skipArrayWithComments(level, skipString(evenBackSlashes = true, pos + 1))
+      else if (b == ']') {
+        if (level == 0) pos + 1
+        else skipArrayWithComments(level - 1, pos + 1)
+      } else if (b == '[') skipArrayWithComments(level + 1, pos + 1)
+      else if (b == '/') skipArrayWithComments(level, skipComment(pos + 1))
+      else skipArrayWithComments(level, pos + 1)
+    } else skipArrayWithComments(level, loadMoreOrError(pos))
+
+  @tailrec
+  private[this] def skipComment(pos: Int): Int =
+    if (pos < tail) {
+      val b = buf(pos)
+      if (b == '/') skipOneLineComment(pos + 1)
+      else if (b == '*') skipMultiLineComment(pos + 1)
+      else tokensError('/', '*', pos)
+    } else skipComment(loadMoreOrError(pos))
+
+  @tailrec
+  private[this] def skipOneLineComment(pos: Int): Int =
+    if (pos < tail) {
+      if (buf(pos) != '\n') skipOneLineComment(pos + 1)
+      else pos + 1
+    } else skipOneLineComment(loadMoreOrError(pos))
+
+  @tailrec
+  private[this] def skipMultiLineComment(pos: Int): Int =
+    if (pos + 1 < tail) {
+      val b1 = buf(pos)
+      val b2 = buf(pos + 1)
+      if (b1 != '*' || b2 != '/') skipMultiLineComment(pos + 1)
+      else pos + 2
+    } else skipMultiLineComment(loadMoreOrError(pos))
 
   @tailrec
   private[this] def skipFixedBytes(n: Int, pos: Int): Int = {

--- a/jsoniter-scala-core/jvm/src/main/java/com/github/plokhotnyuk/jsoniter_scala/core/ByteArrayAccess.java
+++ b/jsoniter-scala-core/jvm/src/main/java/com/github/plokhotnyuk/jsoniter_scala/core/ByteArrayAccess.java
@@ -36,6 +36,10 @@ class ByteArrayAccess { // FIXME: Use Java wrapper as w/a for missing support of
         VH_SHORT.set(buf, pos, value);
     }
 
+    static short getShort(byte[] buf, int pos) {
+        return (short) VH_SHORT.get(buf, pos);
+    }
+
     static void setLongReversed(byte[] buf, int pos, long value) {
         VH_LONG_REVERSED.set(buf, pos, value);
     }

--- a/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
+++ b/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
@@ -549,9 +549,13 @@ final class JsonReader private[jsoniter_scala](
     else if ((b >= '0' && b <= '9') || b == '-') skipNumber(head)
     else if (b == 'n' || b == 't') skipFixedBytes(3, head)
     else if (b == 'f') skipFixedBytes(4, head)
-    else if (b == '[') skipArray(0, head)
-    else if (b == '{') skipObject(0, head)
-    else decodeError("expected value")
+    else if (b == '[') {
+      if (config.allowComments) skipArrayWithComments(0, head)
+      else skipArray(0, head)
+    } else if (b == '{') {
+      if (config.allowComments) skipObjectWithComments(0, head)
+      else skipObject(0, head)
+    } else decodeError("expected value")
   }
 
   def commaError(): Nothing = decodeError("expected ','")
@@ -721,7 +725,10 @@ final class JsonReader private[jsoniter_scala](
       pos < tail
     }) && {
       val b = buf(pos)
-      b == ' ' || b == '\n' || (b | 0x4) == '\r'
+      b == ' ' || b == '\n' || (b | 0x4) == '\r' || b == '/' && config.allowComments && {
+        pos = skipComment(pos + 1) - 1
+        true
+      }
     }) pos += 1
     head = pos
     pos != tail
@@ -792,6 +799,7 @@ final class JsonReader private[jsoniter_scala](
     if (pos < tail) {
       val b = buf(pos)
       if (b == ' ' || b == '\n' || (b | 0x4) == '\r') nextToken(pos + 1)
+      else if (b == '/' && config.allowComments) nextToken(skipComment(pos + 1))
       else {
         head = pos + 1
         b
@@ -803,7 +811,7 @@ final class JsonReader private[jsoniter_scala](
     if (pos < tail) {
       val b = buf(pos)
       head = pos + 1
-      if (b != t && ((b != ' ' && b != '\n' && (b | 0x4) != '\r') || nextToken(pos + 1) != t)) tokenError(t, head - 1)
+      if (b != t && nextToken(pos) != t) tokenError(t, head - 1)
     } else nextTokenOrError(t, loadMoreOrError(pos))
 
   @tailrec
@@ -811,7 +819,7 @@ final class JsonReader private[jsoniter_scala](
     if (pos < tail) {
       val b = buf(pos)
       head = pos + 1
-      b == t || ((b == ' ' || b == '\n' || (b | 0x4) == '\r') && nextToken(pos + 1) == t)
+      b == t || nextToken(pos) == t
     } else isNextToken(t, loadMoreOrError(pos))
 
   private[this] def isCurrentToken(t: Byte, pos: Int): Boolean = {
@@ -1168,11 +1176,12 @@ final class JsonReader private[jsoniter_scala](
       } else if (bs == 0x736C6166) {
         if (nextByte(pos + 4) != 'e') booleanError(pos + 4)
         false
-      } else if (isToken && {
-        val b1 = bs.toByte
-        b1 == ' ' || b1 == '\n' || (b1 | 0x4) == '\r'
-      }) parseBoolean(isToken, pos + 1)
-      else booleanError(bs, pos)
+      } else if (isToken) {
+        val b = bs.toByte
+        if (b == ' ' || b == '\n' || (b | 0x4) == '\r') parseBoolean(isToken, pos + 1)
+        else if (b == '/' && config.allowComments) parseBoolean(isToken, skipComment(pos + 1))
+        else booleanError(bs, pos)
+      } else booleanError(bs, pos)
     } else parseBoolean(isToken, loadMoreOrError(pos))
 
   private[this] def booleanError(bs: Int, pos: Int): Nothing = booleanError({
@@ -3448,10 +3457,11 @@ final class JsonReader private[jsoniter_scala](
     if (pos < tail) {
       val b = buf(pos)
       if (b == '"') skipObject(level, skipString(evenBackSlashes = true, pos + 1))
-      else if (b == '{') skipObject(level + 1, pos + 1)
-      else if (b != '}') skipObject(level, pos + 1)
-      else if (level != 0) skipObject(level - 1, pos + 1)
-      else pos + 1
+      else if (b == '}') {
+        if (level == 0) pos + 1
+        else skipObject(level - 1, pos + 1)
+      } else if (b == '{') skipObject(level + 1, pos + 1)
+      else skipObject(level, pos + 1)
     } else skipObject(level, loadMoreOrError(pos))
 
   @tailrec
@@ -3459,11 +3469,61 @@ final class JsonReader private[jsoniter_scala](
     if (pos < tail) {
       val b = buf(pos)
       if (b == '"') skipArray(level, skipString(evenBackSlashes = true, pos + 1))
-      else if (b == '[') skipArray(level + 1, pos + 1)
-      else if (b != ']') skipArray(level, pos + 1)
-      else if (level != 0) skipArray(level - 1, pos + 1)
-      else pos + 1
+      else if (b == ']') {
+        if (level == 0) pos + 1
+        else skipArray(level - 1, pos + 1)
+      } else if (b == '[') skipArray(level + 1, pos + 1)
+      else skipArray(level, pos + 1)
     } else skipArray(level, loadMoreOrError(pos))
+
+  @tailrec
+  private[this] def skipObjectWithComments(level: Int, pos: Int): Int =
+    if (pos < tail) {
+      val b = buf(pos)
+      if (b == '"') skipObjectWithComments(level, skipString(evenBackSlashes = true, pos + 1))
+      else if (b == '}') {
+        if (level == 0) pos + 1
+        else skipObjectWithComments(level - 1, pos + 1)
+      } else if (b == '{') skipObjectWithComments(level + 1, pos + 1)
+      else if (b == '/') skipObjectWithComments(level, skipComment(pos + 1))
+      else skipObjectWithComments(level, pos + 1)
+    } else skipObjectWithComments(level, loadMoreOrError(pos))
+
+  @tailrec
+  private[this] def skipArrayWithComments(level: Int, pos: Int): Int =
+    if (pos < tail) {
+      val b = buf(pos)
+      if (b == '"') skipArrayWithComments(level, skipString(evenBackSlashes = true, pos + 1))
+      else if (b == ']') {
+        if (level == 0) pos + 1
+        else skipArrayWithComments(level - 1, pos + 1)
+      } else if (b == '[') skipArrayWithComments(level + 1, pos + 1)
+      else if (b == '/') skipArrayWithComments(level, skipComment(pos + 1))
+      else skipArrayWithComments(level, pos + 1)
+    } else skipArrayWithComments(level, loadMoreOrError(pos))
+
+  @tailrec
+  private[this] def skipComment(pos: Int): Int =
+    if (pos < tail) {
+      val b = buf(pos)
+      if (b == '/') skipOneLineComment(pos + 1)
+      else if (b == '*') skipMultiLineComment(pos + 1)
+      else tokensError('/', '*', pos)
+    } else skipComment(loadMoreOrError(pos))
+
+  @tailrec
+  private[this] def skipOneLineComment(pos: Int): Int =
+    if (pos < tail) {
+      if (buf(pos) != '\n') skipOneLineComment(pos + 1)
+      else pos + 1
+    } else skipOneLineComment(loadMoreOrError(pos))
+
+  @tailrec
+  private[this] def skipMultiLineComment(pos: Int): Int =
+    if (pos + 1 < tail) {
+      if (ByteArrayAccess.getShort(buf, pos) != 0x2F2A) skipMultiLineComment(pos + 1)
+      else pos + 2
+    } else skipMultiLineComment(loadMoreOrError(pos))
 
   @tailrec
   private[this] def skipFixedBytes(n: Int, pos: Int): Int = {

--- a/jsoniter-scala-core/native/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/ByteArrayAccess.scala
+++ b/jsoniter-scala-core/native/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/ByteArrayAccess.scala
@@ -24,6 +24,9 @@ private[core] object ByteArrayAccess {
   def setShort(buf: Array[Byte], pos: Int, value: Short): Unit = storeShort(toPtr(buf, pos), value)
 
   @inline
+  def getShort(buf: Array[Byte], pos: Int): Short = loadShort(toPtr(buf, pos))
+
+  @inline
   def setLongReversed(buf: Array[Byte], pos: Int, value: Long): Unit = storeLong(toPtr(buf, pos), `llvm.bswap.i64`(value))
 
   @inline

--- a/jsoniter-scala-core/native/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
+++ b/jsoniter-scala-core/native/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
@@ -719,13 +719,14 @@ final class JsonReader private[jsoniter_scala](
   private[jsoniter_scala] def skipWhitespaces(): Boolean = {
     var pos = head
     var buf = this.buf
+    val ns = nibbles
     while ((pos < tail || {
       pos = loadMore(pos)
       buf = this.buf
       pos < tail
     }) && {
       val b = buf(pos)
-      b == ' ' || b == '\n' || (b | 0x4) == '\r' || b == '/' && config.allowComments && {
+      ns(b & 0xFF) == -2 || b == '/' && config.allowComments && {
         pos = skipComment(pos + 1) - 1
         true
       }
@@ -795,16 +796,16 @@ final class JsonReader private[jsoniter_scala](
     } else nextByteOrError(t, loadMoreOrError(pos))
 
   @tailrec
-  private[this] def nextToken(pos: Int): Byte =
+  private[this] def nextToken(pos: Int, ns: Array[Byte] = nibbles): Byte =
     if (pos < tail) {
       val b = buf(pos)
-      if (b == ' ' || b == '\n' || (b | 0x4) == '\r') nextToken(pos + 1)
-      else if (b == '/' && config.allowComments) nextToken(skipComment(pos + 1))
+      if (ns(b & 0xFF) == -2) nextToken(pos + 1, ns)
+      else if (b == '/' && config.allowComments) nextToken(skipComment(pos + 1), ns)
       else {
         head = pos + 1
         b
       }
-    } else nextToken(loadMoreOrError(pos))
+    } else nextToken(loadMoreOrError(pos), ns)
 
   @tailrec
   private[this] def nextTokenOrError(t: Byte, pos: Int): Unit =
@@ -1176,12 +1177,11 @@ final class JsonReader private[jsoniter_scala](
       } else if (bs == 0x736C6166) {
         if (nextByte(pos + 4) != 'e') booleanError(pos + 4)
         false
-      } else if (isToken && {
-        val b1 = bs.toByte
-        b1 == ' ' || b1 == '\n' || (b1 | 0x4) == '\r'
-      }) parseBoolean(isToken, pos + 1)
-      else if (bs.toByte == '/' && config.allowComments) parseBoolean(isToken, skipComment(pos + 1))
-      else booleanError(bs, pos)
+      } else if (isToken) {
+        if (nibbles(bs & 0xFF) == -2) parseBoolean(isToken, pos + 1)
+        else if (bs.toByte == '/' && config.allowComments) parseBoolean(isToken, skipComment(pos + 1))
+        else booleanError(bs, pos)
+      } else booleanError(bs, pos)
     } else parseBoolean(isToken, loadMoreOrError(pos))
 
   private[this] def booleanError(bs: Int, pos: Int): Nothing = booleanError({
@@ -3518,9 +3518,7 @@ final class JsonReader private[jsoniter_scala](
   @tailrec
   private[this] def skipMultiLineComment(pos: Int): Int =
     if (pos + 1 < tail) {
-      val b1 = buf(pos)
-      val b2 = buf(pos + 1)
-      if (b1 != '*' || b2 != '/') skipMultiLineComment(pos + 1)
+      if (ByteArrayAccess.getShort(buf, pos) != 0x2F2A) skipMultiLineComment(pos + 1)
       else pos + 2
     } else skipMultiLineComment(loadMoreOrError(pos))
 
@@ -3780,6 +3778,10 @@ object JsonReader {
   /* Use the following code to generate `nibbles` in Scala REPL:
     val ns = new Array[Byte](256)
     java.util.Arrays.fill(ns, -1: Byte)
+    ns(' ') = -2
+    ns('\n') = -2
+    ns('\t') = -2
+    ns('\r') = -2
     ns('0') = 0
     ns('1') = 1
     ns('2') = 2
@@ -3805,9 +3807,9 @@ object JsonReader {
     ns.grouped(16).map(_.mkString(", ")).mkString("Array(\n", ",\n", "\n)")
    */
   private final val nibbles: Array[Byte] = Array(
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -2, -2, -1, -1, -2, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -2, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, -1, -1, -1, -1, -1, -1,
     -1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,

--- a/jsoniter-scala-core/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/ReaderConfig.scala
+++ b/jsoniter-scala-core/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/ReaderConfig.scala
@@ -34,11 +34,12 @@ package com.github.plokhotnyuk.jsoniter_scala.core
   * @param checkForEndOfInput a flag to check and raise an error if some non whitespace bytes will be detected after
   *                           successful parsing of the value
   * @param hexDumpSize a size of the hex dump in 16-byte lines before and after the 16-byte line where an error occurs
+  * @param allowComments a flag to allow one-line and multi-line JavaScript-like comments
   */
 class ReaderConfig private (val preferredBufSize: Int, val preferredCharBufSize: Int, val maxBufSize: Int,
                             val maxCharBufSize: Int, val checkForEndOfInput: Boolean,
                             val throwReaderExceptionWithStackTrace: Boolean, val appendHexDumpToParseException: Boolean,
-                            val hexDumpSize: Int) extends Serializable {
+                            val hexDumpSize: Int, val allowComments: Boolean) extends Serializable {
   def withThrowReaderExceptionWithStackTrace(throwReaderExceptionWithStackTrace: Boolean): ReaderConfig =
     copy(throwReaderExceptionWithStackTrace = throwReaderExceptionWithStackTrace)
 
@@ -69,26 +70,27 @@ class ReaderConfig private (val preferredBufSize: Int, val preferredCharBufSize:
     copy(preferredCharBufSize = preferredCharBufSize)
   }
 
-  def withCheckForEndOfInput(checkForEndOfInput: Boolean): ReaderConfig =
-    copy(checkForEndOfInput = checkForEndOfInput)
+  def withCheckForEndOfInput(checkForEndOfInput: Boolean): ReaderConfig = copy(checkForEndOfInput = checkForEndOfInput)
 
   def withHexDumpSize(hexDumpSize: Int): ReaderConfig = {
     if (hexDumpSize < 1) throw new IllegalArgumentException("'hexDumpSize' should be not less than 1")
     copy(hexDumpSize = hexDumpSize)
   }
 
+  def withAllowComments(allowComments: Boolean): ReaderConfig = copy(allowComments = allowComments)
+
   private[this] def copy(preferredBufSize: Int = preferredBufSize, preferredCharBufSize: Int = preferredCharBufSize,
                          maxBufSize: Int = maxBufSize, maxCharBufSize: Int = maxCharBufSize,
                          checkForEndOfInput: Boolean = checkForEndOfInput,
                          throwReaderExceptionWithStackTrace: Boolean = throwReaderExceptionWithStackTrace,
                          appendHexDumpToParseException: Boolean = appendHexDumpToParseException,
-                         hexDumpSize: Int = hexDumpSize): ReaderConfig =
+                         hexDumpSize: Int = hexDumpSize, allowComments: Boolean = allowComments): ReaderConfig =
     new ReaderConfig(throwReaderExceptionWithStackTrace = throwReaderExceptionWithStackTrace,
       appendHexDumpToParseException = appendHexDumpToParseException, maxBufSize = maxBufSize,
       maxCharBufSize = maxCharBufSize, preferredBufSize = preferredBufSize, preferredCharBufSize = preferredCharBufSize,
-      checkForEndOfInput = checkForEndOfInput, hexDumpSize = hexDumpSize)
+      checkForEndOfInput = checkForEndOfInput, hexDumpSize = hexDumpSize, allowComments = allowComments)
 }
 
 object ReaderConfig extends ReaderConfig(preferredBufSize = 32768, preferredCharBufSize = 4096, maxBufSize = 33554432,
   maxCharBufSize = 4194304, throwReaderExceptionWithStackTrace = false, appendHexDumpToParseException = true,
-  checkForEndOfInput = true, hexDumpSize = 2)
+  checkForEndOfInput = true, hexDumpSize = 2, allowComments = false)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.20.8-SNAPSHOT"
+ThisBuild / version := "2.21.0-SNAPSHOT"


### PR DESCRIPTION
Throughput of parsing with Zulu 17

## Before
```
[info] Benchmark                                               (size)   Mode  Cnt         Score        Error   Units
[info] ADTReading.jsoniterScala                                   N/A  thrpt    5   5838254.845 ±  82581.432   ops/s
[info] AnyValsReading.jsoniterScala                               N/A  thrpt    5   8902001.249 ±  77923.479   ops/s
[info] ArrayBufferOfBooleansReading.jsoniterScala                 128  thrpt    5   2043279.701 ±  48458.294   ops/s
[info] ArrayOfBigDecimalsReading.jsoniterScala                    128  thrpt    5    145220.747 ±    657.771   ops/s
[info] ArrayOfBigIntsReading.jsoniterScala                        128  thrpt    5    227700.054 ±   3370.713   ops/s
[info] ArrayOfBooleansReading.jsoniterScala                       128  thrpt    5   2626008.631 ±  65010.511   ops/s
[info] ArrayOfBytesReading.jsoniterScala                          128  thrpt    5   1714490.536 ±  15383.768   ops/s
[info] ArrayOfCharsReading.jsoniterScala                          128  thrpt    5   1848570.468 ±  47932.488   ops/s
[info] ArrayOfDoublesReading.jsoniterScala                        128  thrpt    5    390446.982 ±   3221.216   ops/s
[info] ArrayOfDurationsReading.jsoniterScala                      128  thrpt    5    280538.524 ±   9880.198   ops/s
[info] ArrayOfEnumADTsReading.jsoniterScala                       128  thrpt    5    784598.372 ±  15261.733   ops/s
[info] ArrayOfEnumsReading.jsoniterScala                          128  thrpt    5    414009.422 ±   2953.813   ops/s
[info] ArrayOfFloatsReading.jsoniterScala                         128  thrpt    5    542573.775 ±  32585.431   ops/s
[info] ArrayOfInstantsReading.jsoniterScala                       128  thrpt    5    437053.970 ±  19668.575   ops/s
[info] ArrayOfIntsReading.jsoniterScala                           128  thrpt    5   1006065.699 ±   5411.792   ops/s
[info] ArrayOfJavaEnumsReading.jsoniterScala                      128  thrpt    5    838367.979 ±   9132.671   ops/s
[info] ArrayOfLocalDateTimesReading.jsoniterScala                 128  thrpt    5    432353.945 ±  13039.243   ops/s
[info] ArrayOfLocalDatesReading.jsoniterScala                     128  thrpt    5    946205.338 ±  56606.333   ops/s
[info] ArrayOfLocalTimesReading.jsoniterScala                     128  thrpt    5    659429.451 ±   8660.142   ops/s
[info] ArrayOfLongsReading.jsoniterScala                          128  thrpt    5    655863.312 ±  12942.692   ops/s
[info] ArrayOfMonthDaysReading.jsoniterScala                      128  thrpt    5   1260573.440 ±  19486.110   ops/s
[info] ArrayOfOffsetDateTimesReading.jsoniterScala                128  thrpt    5    371107.446 ±   4972.295   ops/s
[info] ArrayOfOffsetTimesReading.jsoniterScala                    128  thrpt    5    504312.482 ±   3287.725   ops/s
[info] ArrayOfPeriodsReading.jsoniterScala                        128  thrpt    5    325271.888 ±  11641.394   ops/s
[info] ArrayOfShortsReading.jsoniterScala                         128  thrpt    5   1475340.626 ±  10143.470   ops/s
[info] ArrayOfUUIDsReading.jsoniterScala                          128  thrpt    5    571735.112 ±   9234.696   ops/s
[info] ArrayOfYearMonthsReading.jsoniterScala                     128  thrpt    5   1457355.387 ±   8629.311   ops/s
[info] ArrayOfYearsReading.jsoniterScala                          128  thrpt    5   1702012.502 ±  48309.547   ops/s
[info] ArrayOfZoneIdsReading.jsoniterScala                        128  thrpt    5    394645.230 ±  13163.507   ops/s
[info] ArrayOfZoneOffsetsReading.jsoniterScala                    128  thrpt    5   1398263.414 ±  16157.069   ops/s
[info] ArrayOfZonedDateTimesReading.jsoniterScala                 128  thrpt    5    153648.030 ±   2513.474   ops/s
[info] ArraySeqOfBooleansReading.jsoniterScala                    128  thrpt    5   2610933.363 ±  43704.805   ops/s
[info] Base16Reading.jsoniterScala                                128  thrpt    5   8871585.392 ± 114876.198   ops/s
[info] Base64Reading.jsoniterScala                                128  thrpt    5   6494143.562 ± 163408.876   ops/s
[info] BigDecimalReading.jsoniterScala                            128  thrpt    5   6850270.879 ±  95210.586   ops/s
[info] BigIntReading.jsoniterScala                                128  thrpt    5   6756491.191 ± 183275.044   ops/s
[info] BitSetReading.jsoniterScala                                128  thrpt    5   1818506.133 ±  78906.477   ops/s
[info] ExtractFieldsReading.jsoniterScala                         128  thrpt    5    252291.591 ±   1036.051   ops/s
[info] GeoJSONReading.jsoniterScala                               N/A  thrpt    5     71415.145 ±    509.459   ops/s
[info] GitHubActionsAPIReading.jsoniterScala                      N/A  thrpt    5    771116.036 ±   6044.520   ops/s
[info] GoogleMapsAPIReading.jsoniterScala                         N/A  thrpt    5     36262.653 ±    144.401   ops/s
[info] IntMapOfBooleansReading.jsoniterScala                      128  thrpt    5    264945.490 ±  19575.321   ops/s
[info] IntReading.jsoniterScala                                   N/A  thrpt    5  86674670.478 ± 327517.377   ops/s
[info] ListOfBooleansReading.jsoniterScala                        128  thrpt    5   2375661.382 ±  44846.864   ops/s
[info] MapOfIntsToBooleansReading.jsoniterScala                   128  thrpt    5    212510.751 ±   2307.272   ops/s
[info] MissingRequiredFieldsReading.jsoniterScala                 N/A  thrpt    5   6179343.979 ±  93491.269   ops/s
[info] MissingRequiredFieldsReading.jsoniterScalaWithStacktrace   N/A  thrpt    5   1014403.744 ±  44355.536   ops/s
[info] MissingRequiredFieldsReading.jsoniterScalaWithoutDump      N/A  thrpt    5  11935097.222 ± 157861.180   ops/s
[info] MutableBitSetReading.jsoniterScala                         128  thrpt    5   1997689.247 ±  18351.717   ops/s
[info] MutableLongMapOfBooleansReading.jsoniterScala              128  thrpt    5    429808.917 ±   9082.678   ops/s
[info] MutableMapOfIntsToBooleansReading.jsoniterScala            128  thrpt    5    473097.845 ±  13637.323   ops/s
[info] MutableSetOfIntsReading.jsoniterScala                      128  thrpt    5    566357.815 ±  12396.315   ops/s
[info] NestedStructsReading.jsoniterScala                         128  thrpt    5    560310.042 ±  12683.813   ops/s
[info] OpenRTBReading.jsoniterScala                               N/A  thrpt    5    375201.115 ±   2892.235   ops/s
[info] PrimitivesReading.jsoniterScala                            N/A  thrpt    5   9636541.731 ±  60582.585   ops/s
[info] SetOfIntsReading.jsoniterScala                             128  thrpt    5    273997.579 ±   5638.281   ops/s
[info] StringOfAsciiCharsReading.jsoniterScala                    128  thrpt    5  10024396.316 ± 300910.621   ops/s
[info] StringOfEscapedCharsReading.jsoniterScala                  128  thrpt    5   3151768.387 ±  54043.885   ops/s
[info] StringOfNonAsciiCharsReading.jsoniterScala                 128  thrpt    5   3590377.573 ±  49702.075   ops/s
[info] TwitterAPIReading.jsoniterScala                            N/A  thrpt    5     57575.812 ±   1531.197   ops/s
[info] VectorOfBooleansReading.jsoniterScala                      128  thrpt    5   2588563.723 ±  16079.294   ops/s
```
## After
```
[info] Benchmark                                               (size)   Mode  Cnt         Score         Error   Units
[info] ADTReading.jsoniterScala                                   N/A  thrpt    5   6098381.091 ±  266409.259   ops/s
[info] AnyValsReading.jsoniterScala                               N/A  thrpt    5   8643265.108 ±  119079.434   ops/s
[info] ArrayBufferOfBooleansReading.jsoniterScala                 128  thrpt    5   2151282.322 ±   58182.061   ops/s
[info] ArrayOfBigDecimalsReading.jsoniterScala                    128  thrpt    5    133179.483 ±    1235.737   ops/s
[info] ArrayOfBigIntsReading.jsoniterScala                        128  thrpt    5    227879.055 ±    5509.348   ops/s
[info] ArrayOfBooleansReading.jsoniterScala                       128  thrpt    5   2862539.970 ±   89024.495   ops/s
[info] ArrayOfBytesReading.jsoniterScala                          128  thrpt    5   1679502.227 ±   20180.209   ops/s
[info] ArrayOfCharsReading.jsoniterScala                          128  thrpt    5   1835618.448 ±   20472.310   ops/s
[info] ArrayOfDoublesReading.jsoniterScala                        128  thrpt    5    387785.772 ±    2711.145   ops/s
[info] ArrayOfDurationsReading.jsoniterScala                      128  thrpt    5    288386.987 ±    1478.457   ops/s
[info] ArrayOfEnumADTsReading.jsoniterScala                       128  thrpt    5    766228.541 ±    6789.961   ops/s
[info] ArrayOfEnumsReading.jsoniterScala                          128  thrpt    5    424391.761 ±    3516.945   ops/s
[info] ArrayOfFloatsReading.jsoniterScala                         128  thrpt    5    528132.925 ±    2932.756   ops/s
[info] ArrayOfInstantsReading.jsoniterScala                       128  thrpt    5    466328.358 ±    3126.353   ops/s
[info] ArrayOfIntsReading.jsoniterScala                           128  thrpt    5   1011803.848 ±    9821.458   ops/s
[info] ArrayOfJavaEnumsReading.jsoniterScala                      128  thrpt    5    834539.523 ±   21107.675   ops/s
[info] ArrayOfLocalDateTimesReading.jsoniterScala                 128  thrpt    5    434741.830 ±    8802.643   ops/s
[info] ArrayOfLocalDatesReading.jsoniterScala                     128  thrpt    5    943373.662 ±   11663.910   ops/s
[info] ArrayOfLocalTimesReading.jsoniterScala                     128  thrpt    5    657836.081 ±    2681.980   ops/s
[info] ArrayOfLongsReading.jsoniterScala                          128  thrpt    5    682729.908 ±   32851.600   ops/s
[info] ArrayOfMonthDaysReading.jsoniterScala                      128  thrpt    5   1214986.487 ±    8279.412   ops/s
[info] ArrayOfOffsetDateTimesReading.jsoniterScala                128  thrpt    5    367528.711 ±   16234.175   ops/s
[info] ArrayOfOffsetTimesReading.jsoniterScala                    128  thrpt    5    518010.347 ±    2624.850   ops/s
[info] ArrayOfPeriodsReading.jsoniterScala                        128  thrpt    5    325227.109 ±    1948.376   ops/s
[info] ArrayOfShortsReading.jsoniterScala                         128  thrpt    5   1362706.002 ±   13229.047   ops/s
[info] ArrayOfUUIDsReading.jsoniterScala                          128  thrpt    5    576527.855 ±   11333.032   ops/s
[info] ArrayOfYearMonthsReading.jsoniterScala                     128  thrpt    5   1376451.613 ±   10282.236   ops/s
[info] ArrayOfYearsReading.jsoniterScala                          128  thrpt    5   1604094.302 ±   34809.483   ops/s
[info] ArrayOfZoneIdsReading.jsoniterScala                        128  thrpt    5    375614.146 ±    5416.154   ops/s
[info] ArrayOfZoneOffsetsReading.jsoniterScala                    128  thrpt    5   1426479.379 ±   15168.046   ops/s
[info] ArrayOfZonedDateTimesReading.jsoniterScala                 128  thrpt    5    152691.150 ±    2945.818   ops/s
[info] ArraySeqOfBooleansReading.jsoniterScala                    128  thrpt    5   2830168.756 ±  160647.816   ops/s
[info] Base16Reading.jsoniterScala                                128  thrpt    5   8743571.240 ±  451788.631   ops/s
[info] Base64Reading.jsoniterScala                                128  thrpt    5   6559664.823 ±  110559.086   ops/s
[info] BigDecimalReading.jsoniterScala                            128  thrpt    5   6905781.135 ±  528764.541   ops/s
[info] BigIntReading.jsoniterScala                                128  thrpt    5   6866695.413 ±   57573.454   ops/s
[info] BitSetReading.jsoniterScala                                128  thrpt    5   1559740.732 ±   97987.778   ops/s
[info] ExtractFieldsReading.jsoniterScala                         128  thrpt    5    252758.557 ±     561.015   ops/s
[info] GeoJSONReading.jsoniterScala                               N/A  thrpt    5     70181.014 ±    1199.698   ops/s
[info] GitHubActionsAPIReading.jsoniterScala                      N/A  thrpt    5    833443.474 ±    1456.829   ops/s
[info] GoogleMapsAPIReading.jsoniterScala                         N/A  thrpt    5     36712.374 ±     137.620   ops/s
[info] IntMapOfBooleansReading.jsoniterScala                      128  thrpt    5    271422.336 ±   13163.982   ops/s
[info] IntReading.jsoniterScala                                   N/A  thrpt    5  83922855.833 ± 2553163.618   ops/s
[info] ListOfBooleansReading.jsoniterScala                        128  thrpt    5   2211277.292 ±   12813.047   ops/s
[info] MapOfIntsToBooleansReading.jsoniterScala                   128  thrpt    5    217285.484 ±    1226.142   ops/s
[info] MissingRequiredFieldsReading.jsoniterScala                 N/A  thrpt    5   6177488.618 ±  186589.687   ops/s
[info] MissingRequiredFieldsReading.jsoniterScalaWithStacktrace   N/A  thrpt    5    965627.660 ±   71012.325   ops/s
[info] MissingRequiredFieldsReading.jsoniterScalaWithoutDump      N/A  thrpt    5  12181174.260 ±  325438.146   ops/s
[info] MutableBitSetReading.jsoniterScala                         128  thrpt    5   1892618.441 ±   13638.911   ops/s
[info] MutableLongMapOfBooleansReading.jsoniterScala              128  thrpt    5    421703.115 ±    1274.617   ops/s
[info] MutableMapOfIntsToBooleansReading.jsoniterScala            128  thrpt    5    475510.513 ±   23248.362   ops/s
[info] MutableSetOfIntsReading.jsoniterScala                      128  thrpt    5    572593.860 ±   10135.111   ops/s
[info] NestedStructsReading.jsoniterScala                         128  thrpt    5    526446.788 ±    6066.700   ops/s
[info] OpenRTBReading.jsoniterScala                               N/A  thrpt    5    354609.378 ±    2045.059   ops/s
[info] PrimitivesReading.jsoniterScala                            N/A  thrpt    5   9408659.991 ±  221388.614   ops/s
[info] SetOfIntsReading.jsoniterScala                             128  thrpt    5    272880.392 ±    1010.124   ops/s
[info] StringOfAsciiCharsReading.jsoniterScala                    128  thrpt    5  15655962.746 ±   83237.013   ops/s
[info] StringOfEscapedCharsReading.jsoniterScala                  128  thrpt    5   3246458.535 ±   17403.505   ops/s
[info] StringOfNonAsciiCharsReading.jsoniterScala                 128  thrpt    5   3555793.098 ±   21413.789   ops/s
[info] TwitterAPIReading.jsoniterScala                            N/A  thrpt    5     57864.902 ±     326.815   ops/s
[info] VectorOfBooleansReading.jsoniterScala                      128  thrpt    5   2298477.021 ±   19594.256   ops/s
```