### PR TITLE
Reproduce DoS for borer-compat-circe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -244,6 +244,7 @@ lazy val `jsoniter-scala-benchmark` = crossProject(JVMPlatform, JSPlatform)
       "dev.zio" %%% "zio-json" % "0.3.0-RC11",
       "com.rallyhealth" %% "weepickle-v1" % "1.7.2",
       "io.bullet" %%% "borer-derivation" % "1.8.0",
+      "io.bullet" %%% "borer-compat-circe" % "1.8.0",
       "pl.iterators" %% "kebs-spray-json" % "1.9.4",
       "io.spray" %% "spray-json" % "1.3.6",
       "com.avsystem.commons" %%% "commons-core" % "2.7.4",

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReadingSpec.scala
@@ -10,6 +10,7 @@ class ExtractFieldsReadingSpec extends BenchmarkSpecBase {
       benchmark.avSystemGenCodec() shouldBe benchmark.obj
       benchmark.borer() shouldBe benchmark.obj
       benchmark.circe() shouldBe benchmark.obj
+      benchmark.circeBorer() shouldBe benchmark.obj
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
@@ -30,6 +31,7 @@ class ExtractFieldsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.avSystemGenCodec())
       intercept[Throwable](b.borer())
       intercept[Throwable](b.circe())
+      intercept[Throwable](b.circeBorer())
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReading.scala
@@ -1,5 +1,6 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
+import io.bullet.borer.Json
 import org.openjdk.jmh.annotations.{Benchmark, Param, Setup}
 
 class ExtractFieldsReading extends CommonParams {
@@ -45,6 +46,14 @@ class ExtractFieldsReading extends CommonParams {
     import java.nio.charset.StandardCharsets.UTF_8
 
     decode[ExtractFields](new String(jsonBytes, UTF_8)).fold(throw _, identity)
+  }
+
+  @Benchmark
+  def circeBorer(): ExtractFields = {
+    import io.bullet.borer.compat.circe._ // the borer codec for the circe AST
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.CirceEncodersDecoders._
+
+    Json.decode(jsonBytes).to[ExtractFields].value
   }
 
   @Benchmark


### PR DESCRIPTION
 _Sub-quadratic_ decreasing of throughput when number of JSON object fields (with keys that have the same hash code) is increasing

On contemporary CPUs parsing of such JSON object (with a sequence of 100000 fields like below that is ~1.6Mb) can took ~60 seconds:

```
{
"!!sjyehe":null,
"!!sjyeiF":null,
"!!sjyej'":null,
"!!sjyfIe":null,
"!!sjyfJF":null,
...
}
``` 

Below are results of the benchmark where `size` is a number of such fields:

```
[info] Benchmark                        (size)   Mode  Cnt        Score   Error  Units
[info] ExtractFieldsReading.circeBorer       1  thrpt       1826943.085          ops/s
[info] ExtractFieldsReading.circeBorer      10  thrpt        284635.079          ops/s
[info] ExtractFieldsReading.circeBorer     100  thrpt         14814.658          ops/s
[info] ExtractFieldsReading.circeBorer    1000  thrpt           506.885          ops/s
[info] ExtractFieldsReading.circeBorer   10000  thrpt             3.822          ops/s
[info] ExtractFieldsReading.circeBorer  100000  thrpt             0.016          ops/s
```

To run that benchmarks on your JDK:
1. [Install latest version of `sbt`](https://www.scala-sbt.org/1.0/docs/Setup.html) and/or ensure that it already installed properly: 
```
sbt about
```

2. Clone `jsoniter-scala` repo: 
```
git clone --depth 1 https://github.com/plokhotnyuk/jsoniter-scala.git
```

3. Enter to the cloned directory and checkout for the specific branch:
```
cd jsoniter-scala
git checkout borer-compat-circe-DoS-by-hashmap-collisions
```

4. Run benchmarks using a path parameter to your JDK:
```
sbt -no-colors 'jsoniter-scala-benchmark/jmh:run -jvm /usr/lib/jvm/jdk-11/bin/java -wi 1 -i 1 ExtractFields.*circeBorer'
```