### PR TITLE
Add json4s benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -229,6 +229,8 @@ lazy val `jsoniter-scala-benchmark` = crossProject(JVMPlatform, JSPlatform)
     crossScalaVersions := Seq("2.13.10"),
     resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
     libraryDependencies ++= Seq(
+      "org.json4s" %% "json4s-jackson" % "4.1.0-M2",
+      "org.json4s" %% "json4s-native" % "4.1.0-M2",
       "com.disneystreaming.smithy4s" %%% "smithy4s-json" % "0.16.3",
       "dev.zio" %%% "zio-json" % "0.3.0",
       "com.rallyhealth" %% "weepickle-v1" % "1.8.0",

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTReadingSpec.scala
@@ -15,6 +15,10 @@ class ADTReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      //FIXME: json4s.jackson throws org.json4s.MappingException: No constructor for type ADTBase
+      //benchmark.json4sJackson() shouldBe benchmark.obj
+      //FIXME: json4s.native throws org.json4s.MappingException: No constructor for type ADTBase
+      //benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -33,6 +37,10 @@ class ADTReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      //FIXME: json4s.jackson throws org.json4s.MappingException: No constructor for type ADTBase
+      //intercept[Throwable](b.json4sJackson())
+      //FIXME: json4s.native throws org.json4s.MappingException: No constructor for type ADTBase
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTWritingSpec.scala
@@ -13,6 +13,10 @@ class ADTWritingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.jsonString2
       toString(b.circeJsoniter()) shouldBe b.jsonString2
       toString(b.jacksonScala()) shouldBe b.jsonString1
+      //FIXME: json4s.jackson doesn't serialize type hints
+      //toString(b.json4sJackson()) shouldBe b.jsonString1
+      //FIXME: json4s.native doesn't serialize type hints
+      //toString(b.json4sNative()) shouldBe b.jsonString1
       toString(b.jsoniterScala()) shouldBe b.jsonString1
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString1
       toString(b.playJson()) shouldBe b.jsonString1

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsReadingSpec.scala
@@ -17,6 +17,8 @@ class AnyValsReadingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON throws com.dslplatform.json.ParsingException: Expecting '{' to start decoding com.github.plokhotnyuk.jsoniter_scala.benchmark.ByteVal. Found 1 at position: 6, following: `{"b":1`, before: `,"s":2,"i":3,"l":4,"`
       //benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class AnyValsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsWritingSpec.scala
@@ -15,6 +15,8 @@ class AnyValsWritingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON wraps AnyVal values
       //toString(b.dslJsonScala()) shouldBe b.jsonString1
       toString(b.jacksonScala()) shouldBe b.jsonString1
+      toString(b.json4sJackson()) shouldBe b.jsonString1
+      toString(b.json4sNative()) shouldBe b.jsonString1
       toString(b.jsoniterScala()) shouldBe b.jsonString1
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString1
       toString(b.playJson()) shouldBe b.jsonString3

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayBufferOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -33,6 +35,8 @@ class ArrayBufferOfBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayBufferOfBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsReadingSpec.scala
@@ -16,6 +16,10 @@ class ArrayOfBigDecimalsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.sourceObj
       benchmark.dslJsonScala() shouldBe benchmark.sourceObj
       benchmark.jacksonScala() shouldBe benchmark.sourceObj
+      //FIXME: json4s.jackson rounds parsed numbers to double
+      //benchmark.json4sJackson() shouldBe benchmark.sourceObj
+      //FIXME: json4s.native rounds parsed numbers to double
+      //benchmark.json4sNative() shouldBe benchmark.sourceObj
       benchmark.jsoniterScala() shouldBe benchmark.sourceObj
       benchmark.playJson() shouldBe benchmark.sourceObj
       benchmark.playJsonJsoniter() shouldBe benchmark.sourceObj
@@ -35,6 +39,10 @@ class ArrayOfBigDecimalsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      //FIXME: json4s.jackson rounds parsed numbers to double
+      //intercept[Throwable](b.json4sJackson())
+      //FIXME: json4s.native rounds parsed numbers to double
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsWritingSpec.scala
@@ -14,6 +14,9 @@ class ArrayOfBigDecimalsWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      //FIXME: json4s.jackson rounding to double
+      //toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayOfBigIntsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       //FIXME: Play-JSON looses significant digits in BigInt values
       //benchmark.playJson() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class ArrayOfBigIntsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.smithy4sJson())
       intercept[Throwable](b.sprayJson())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayOfBigIntsWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       //FIXME: Play-JSON uses BigDecimal with engineering decimal representation to serialize numbers

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class ArrayOfBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayOfBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReadingSpec.scala
@@ -17,6 +17,8 @@ class ArrayOfBytesReadingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON expects a base64 string for the byte array
       //benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class ArrayOfBytesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesWritingSpec.scala
@@ -15,6 +15,8 @@ class ArrayOfBytesWritingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON serializes a byte array to the base64 string
       //toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsReadingSpec.scala
@@ -15,6 +15,10 @@ class ArrayOfCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      //FIXME: json4s.jackson throws org.json4s.MappingException: Do not know how to convert JString(3) into byte
+      //benchmark.json4sJackson() shouldBe benchmark.obj
+      //FIXME: json4s.native throws org.json4s.MappingException: Do not know how to convert JString(3) into byte
+      //benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -32,6 +36,10 @@ class ArrayOfCharsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      //FIXME: json4s.jackson throws org.json4s.MappingException: Do not know how to convert JString(3) into byte
+      //intercept[Throwable](b.json4sJackson())
+      //FIXME: json4s.native throws org.json4s.MappingException: Do not know how to convert JString(3) into byte
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsWritingSpec.scala
@@ -13,6 +13,8 @@ class ArrayOfCharsWritingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.jsonString
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayOfDoublesReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class ArrayOfDoublesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesWritingSpec.scala
@@ -15,6 +15,8 @@ class ArrayOfDoublesWritingSpec extends BenchmarkSpecBase {
       check(toString(b.dslJsonScala()), b.jsonString)
       check(toString(b.jacksonScala()), b.jsonString)
       check(toString(b.jsoniterScala()), b.jsonString)
+      check(toString(b.json4sJackson()), b.jsonString)
+      check(toString(b.json4sNative()), b.jsonString)
       check(toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()), b.jsonString)
       check(toString(b.playJson()), b.jsonString)
       check(toString(b.playJsonJsoniter()), b.jsonString)

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsReadingSpec.scala
@@ -15,6 +15,8 @@ class ArrayOfDurationsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -32,6 +34,8 @@ class ArrayOfDurationsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsWritingSpec.scala
@@ -13,6 +13,8 @@ class ArrayOfDurationsWritingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.jsonString
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayOfEnumADTsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -34,6 +36,8 @@ class ArrayOfEnumADTsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayOfEnumADTsWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsReadingSpec.scala
@@ -15,6 +15,8 @@ class ArrayOfEnumsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -32,6 +34,8 @@ class ArrayOfEnumsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsWritingSpec.scala
@@ -13,6 +13,8 @@ class ArrayOfEnumsWritingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.jsonString
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReadingSpec.scala
@@ -28,6 +28,10 @@ class ArrayOfFloatsReadingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON parses 1.199999988079071 as 1.2f instead of 1.1999999f
       //benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      //FIXME: json4s.jackson parses 1.199999988079071 as 1.2f instead of 1.1999999f
+      //benchmark.json4sJackson() shouldBe benchmark.obj
+      //FIXME: json4s.native parses 1.199999988079071 as 1.2f instead of 1.1999999f
+      //benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -46,6 +50,10 @@ class ArrayOfFloatsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      //FIXME: json4s.jackson parses 1.199999988079071 as 1.2f instead of 1.1999999f
+      //intercept[Throwable](b.json4sJackson())
+      //FIXME: json4s.native parses 1.199999988079071 as 1.2f instead of 1.1999999f
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayOfFloatsWritingSpec extends BenchmarkSpecBase {
       check(toString(b.circeJsoniter()), b.jsonString)
       check(toString(b.dslJsonScala()), b.jsonString)
       check(toString(b.jacksonScala()), b.jsonString)
+      check(toString(b.json4sJackson()), b.jsonString)
+      check(toString(b.json4sNative()), b.jsonString)
       check(toString(b.jsoniterScala()), b.jsonString)
       check(toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()), b.jsonString)
       check(toString(b.playJson()), b.jsonString)

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReadingSpec.scala
@@ -15,6 +15,8 @@ class ArrayOfInstantsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -33,6 +35,8 @@ class ArrayOfInstantsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsWritingSpec.scala
@@ -13,6 +13,8 @@ class ArrayOfInstantsWritingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.jsonString
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayOfIntsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class ArrayOfIntsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayOfIntsWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.smithy4sJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayOfJavaEnumsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -33,6 +35,8 @@ class ArrayOfJavaEnumsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayOfJavaEnumsWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayOfLocalDateTimesReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -34,6 +36,8 @@ class ArrayOfLocalDateTimesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayOfLocalDateTimesWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayOfLocalDatesReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -34,6 +36,8 @@ class ArrayOfLocalDatesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayOfLocalDatesWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayOfLocalTimesReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -34,6 +36,8 @@ class ArrayOfLocalTimesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayOfLocalTimesWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayOfLongsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class ArrayOfLongsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayOfLongsWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysReadingSpec.scala
@@ -15,6 +15,8 @@ class ArrayOfMonthDaysReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -32,6 +34,8 @@ class ArrayOfMonthDaysReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysWritingSpec.scala
@@ -13,6 +13,8 @@ class ArrayOfMonthDaysWritingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.jsonString
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayOfOffsetDateTimesReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -34,6 +36,8 @@ class ArrayOfOffsetDateTimesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayOfOffsetDateTimesWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayOfOffsetTimesReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -34,6 +36,8 @@ class ArrayOfOffsetTimesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayOfOffsetTimesWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsReadingSpec.scala
@@ -15,6 +15,8 @@ class ArrayOfPeriodsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -32,6 +34,8 @@ class ArrayOfPeriodsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsWritingSpec.scala
@@ -13,6 +13,8 @@ class ArrayOfPeriodsWritingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.jsonString
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayOfShortsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class ArrayOfShortsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayOfShortsWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReadingSpec.scala
@@ -16,6 +16,8 @@ class ArrayOfUUIDsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class ArrayOfUUIDsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsWritingSpec.scala
@@ -14,6 +14,8 @@ class ArrayOfUUIDsWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsReadingSpec.scala
@@ -15,6 +15,8 @@ class ArrayOfYearMonthsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -32,6 +34,8 @@ class ArrayOfYearMonthsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsWritingSpec.scala
@@ -13,6 +13,8 @@ class ArrayOfYearMonthsWritingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.jsonString
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsReadingSpec.scala
@@ -15,6 +15,8 @@ class ArrayOfYearsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -32,6 +34,8 @@ class ArrayOfYearsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsWritingSpec.scala
@@ -13,6 +13,8 @@ class ArrayOfYearsWritingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.jsonString
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsReadingSpec.scala
@@ -15,6 +15,8 @@ class ArrayOfZoneIdsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -32,6 +34,8 @@ class ArrayOfZoneIdsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsWritingSpec.scala
@@ -13,6 +13,8 @@ class ArrayOfZoneIdsWritingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.jsonString
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsReadingSpec.scala
@@ -15,6 +15,8 @@ class ArrayOfZoneOffsetsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -32,6 +34,8 @@ class ArrayOfZoneOffsetsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsWritingSpec.scala
@@ -13,6 +13,8 @@ class ArrayOfZoneOffsetsWritingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.jsonString
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesReadingSpec.scala
@@ -17,6 +17,8 @@ class ArrayOfZonedDateTimesReadingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON does not parse preferred timezone
       //benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -34,6 +36,8 @@ class ArrayOfZonedDateTimesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesWritingSpec.scala
@@ -15,6 +15,8 @@ class ArrayOfZonedDateTimesWritingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON does not serialize preferred timezone
       //toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArraySeqOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArraySeqOfBooleansReadingSpec.scala
@@ -17,6 +17,10 @@ class ArraySeqOfBooleansReadingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON doesn't support parsing of ArraySeq
       //benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      //FIXME json4s.jackson throws org.json4s.MappingException: unknown error
+      //benchmark.json4sJackson() shouldBe benchmark.obj
+      //FIXME json4s.native throws org.json4s.MappingException: unknown error
+      //benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -37,6 +41,10 @@ class ArraySeqOfBooleansReadingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON doesn't support parsing of ArraySeq
       //intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      //FIXME json4s.jackson throws org.json4s.MappingException: unknown error
+      //intercept[Throwable](b.json4sJackson())
+      //FIXME json4s.native throws org.json4s.MappingException: unknown error
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArraySeqOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArraySeqOfBooleansWritingSpec.scala
@@ -15,6 +15,8 @@ class ArraySeqOfBooleansWritingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON doesn't support serialization of ArraySeq
       //toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64ReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64ReadingSpec.scala
@@ -16,6 +16,9 @@ class Base64ReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      //FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+      //benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +38,9 @@ class Base64ReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      //FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64WritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64WritingSpec.scala
@@ -14,6 +14,8 @@ class Base64WritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalReadingSpec.scala
@@ -16,6 +16,9 @@ class BigDecimalReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.sourceObj
       benchmark.dslJsonScala() shouldBe benchmark.sourceObj
       benchmark.jacksonScala() shouldBe benchmark.sourceObj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      //FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+      //benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.sourceObj
       //FIXME: Play-JSON: don't know how to tune precision for parsing of BigDecimal values
       //benchmark.playJson() shouldBe benchmark.sourceObj
@@ -35,6 +38,9 @@ class BigDecimalReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      //FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.sprayJson())
       intercept[Throwable](b.uPickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalWritingSpec.scala
@@ -14,6 +14,9 @@ class BigDecimalWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      //FIXME: json4s.jackson rounding to double
+      //toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       BigDecimal(toString(b.playJson())) shouldBe b.obj

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntReadingSpec.scala
@@ -16,6 +16,9 @@ class BigIntReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      //FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+      //benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       //FIXME: Play-JSON looses significant digits in BigInt values
       //benchmark.playJson() shouldBe benchmark.obj
@@ -34,6 +37,9 @@ class BigIntReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      //FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.smithy4sJson())
       intercept[Throwable](b.sprayJson())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntWritingSpec.scala
@@ -14,6 +14,8 @@ class BigIntWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       //FIXME: Play-JSON serializes BigInt values as floating point numbers with a scientific representation

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReadingSpec.scala
@@ -16,6 +16,8 @@ class ExtractFieldsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class ExtractFieldsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReadingSpec.scala
@@ -15,6 +15,10 @@ class GeoJSONReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      //FIXME: json4s.jackson throws org.json4s.MappingException: No constructor for type GeoJSON
+      //benchmark.json4sJackson() shouldBe benchmark.obj
+      //FIXME: json4s.native throws org.json4s.MappingException: No constructor for type GeoJSON
+      //benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -33,6 +37,10 @@ class GeoJSONReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      //FIXME: json4s.jackson throws org.json4s.MappingException: No constructor for type GeoJSON
+      //intercept[Throwable](b.json4sJackson())
+      //FIXME: json4s.native throws org.json4s.MappingException: No constructor for type GeoJSON
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWritingSpec.scala
@@ -13,6 +13,10 @@ class GeoJSONWritingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.jsonString2
       toString(b.circeJsoniter()) shouldBe b.jsonString2
       toString(b.jacksonScala()) shouldBe b.jsonString1
+      //FIXME: json4s.jackson doesn't type hints
+      //toString(b.json4sJackson()) shouldBe b.jsonString1
+      //FIXME: json4s.native doesn't type hints
+      //toString(b.json4sNative()) shouldBe b.jsonString1
       toString(b.jsoniterScala()) shouldBe b.jsonString1
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString1
       toString(b.playJson()) shouldBe b.jsonString1

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIReadingSpec.scala
@@ -15,6 +15,8 @@ class GitHubActionsAPIReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -33,6 +35,8 @@ class GitHubActionsAPIReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIWritingSpec.scala
@@ -13,6 +13,8 @@ class GitHubActionsAPIWritingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.compactJsonString1
       toString(b.circeJsoniter()) shouldBe b.compactJsonString1
       toString(b.jacksonScala()) shouldBe b.compactJsonString1
+      toString(b.json4sJackson()) shouldBe b.compactJsonString1
+      toString(b.json4sNative()) shouldBe b.compactJsonString1
       toString(b.jsoniterScala()) shouldBe b.compactJsonString1
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.compactJsonString1
       toString(b.playJson()) shouldBe b.compactJsonString1

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrintingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrintingSpec.scala
@@ -12,6 +12,9 @@ class GoogleMapsAPIPrettyPrintingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.jsonString1
       toString(b.circeJsoniter()) shouldBe b.jsonString2
       toString(b.jacksonScala()) shouldBe b.jsonString1
+      //FIXME: json4s.jackson pretty prints array elements in the same line
+      //toString(b.json4sJackson()) shouldBe b.jsonString1
+      toString(b.json4sNative()) shouldBe b.jsonString3
       toString(b.jsoniterScala()) shouldBe b.jsonString2
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString2
       toString(b.playJson()) shouldBe b.jsonString1

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReadingSpec.scala
@@ -16,6 +16,8 @@ class GoogleMapsAPIReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class GoogleMapsAPIReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWritingSpec.scala
@@ -14,6 +14,8 @@ class GoogleMapsAPIWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.compactJsonString1
       toString(b.dslJsonScala()) shouldBe b.compactJsonString1
       toString(b.jacksonScala()) shouldBe b.compactJsonString1
+      toString(b.json4sJackson()) shouldBe b.compactJsonString1
+      toString(b.json4sNative()) shouldBe b.compactJsonString1
       toString(b.jsoniterScala()) shouldBe b.compactJsonString1
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.compactJsonString1
       toString(b.playJson()) shouldBe b.compactJsonString1

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansReadingSpec.scala
@@ -16,6 +16,10 @@ class IntMapOfBooleansReadingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON throws java.lang.IllegalArgumentException: requirement failed: Unable to create decoder for scala.collection.immutable.IntMap[Boolean]
       //benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      //FIXME: json4s.jackson throws org.json4s.MappingException: unknown error
+      //benchmark.json4sJackson() shouldBe benchmark.obj
+      //FIXME: json4s.native throws org.json4s.MappingException: unknown error
+      //benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -30,6 +34,10 @@ class IntMapOfBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      //FIXME: json4s.jackson throws org.json4s.MappingException: unknown error
+      //intercept[Throwable](b.json4sJackson())
+      //FIXME: json4s.native throws org.json4s.MappingException: unknown error
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansWritingSpec.scala
@@ -14,6 +14,8 @@ class IntMapOfBooleansWritingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON throws java.lang.ClassCastException: scala.Tuple2 cannot be cast to java.lang.Boolean
       //toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReadingSpec.scala
@@ -16,6 +16,9 @@ class IntReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      //FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+      //benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +38,9 @@ class IntReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      //FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntWritingSpec.scala
@@ -14,6 +14,8 @@ class IntWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReadingSpec.scala
@@ -16,6 +16,8 @@ class ListOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class ListOfBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansWritingSpec.scala
@@ -14,6 +14,8 @@ class ListOfBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansReadingSpec.scala
@@ -15,6 +15,8 @@ class MapOfIntsToBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class MapOfIntsToBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansWritingSpec.scala
@@ -13,6 +13,8 @@ class MapOfIntsToBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MissingRequiredFieldsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MissingRequiredFieldsReadingSpec.scala
@@ -22,6 +22,12 @@ class MissingRequiredFieldsReadingSpec extends BenchmarkSpecBase {
       b.jacksonScala() shouldBe
         """Missing required creator property 's' (index 0)
           | at [Source: (byte[])"{}"; line: 1, column: 2] (through reference chain: com.github.plokhotnyuk.jsoniter_scala.benchmark.MissingRequiredFields["s"])""".stripMargin
+      b.json4sJackson() shouldBe
+        """No usable value for s
+          |Did not find value which can be converted into java.lang.String""".stripMargin
+      b.json4sNative() shouldBe
+        """No usable value for s
+          |Did not find value which can be converted into java.lang.String""".stripMargin
       b.jsoniterScala() shouldBe
         """missing required field "s", offset: 0x00000001, buf:
           |+----------+-------------------------------------------------+------------------+
@@ -54,6 +60,8 @@ class MissingRequiredFieldsReadingSpec extends BenchmarkSpecBase {
       b.circeJawn() shouldBe "MissingRequiredFields(VVV,1)"
       b.dslJsonScala() shouldBe "MissingRequiredFields(VVV,1)"
       b.jacksonScala() shouldBe "MissingRequiredFields(VVV,1)"
+      b.json4sJackson() shouldBe "MissingRequiredFields(VVV,1)"
+      b.json4sNative() shouldBe "MissingRequiredFields(VVV,1)"
       b.jsoniterScala() shouldBe "MissingRequiredFields(VVV,1)"
       b.jsoniterScalaWithoutDump() shouldBe "MissingRequiredFields(VVV,1)"
       b.jsoniterScalaWithStacktrace() shouldBe "MissingRequiredFields(VVV,1)"

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansReadingSpec.scala
@@ -16,6 +16,10 @@ class MutableLongMapOfBooleansReadingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON doesn't support mutable.LongMap
       //benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      //FIXME: json4s.jackson throws org.json4s.MappingException: unknown error
+      //benchmark.json4sJackson() shouldBe benchmark.obj
+      //FIXME: json4s.native throws org.json4s.MappingException: unknown error
+      //benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -28,6 +32,10 @@ class MutableLongMapOfBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      //FIXME: json4s.jackson throws org.json4s.MappingException: unknown error
+      //intercept[Throwable](b.json4sJackson())
+      //FIXME: json4s.native throws org.json4s.MappingException: unknown error
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansWritingSpec.scala
@@ -14,6 +14,8 @@ class MutableLongMapOfBooleansWritingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON doesn't support mutable.LongMap
       //toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansReadingSpec.scala
@@ -15,6 +15,8 @@ class MutableMapOfIntsToBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -29,6 +31,8 @@ class MutableMapOfIntsToBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansWritingSpec.scala
@@ -13,6 +13,8 @@ class MutableMapOfIntsToBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsReadingSpec.scala
@@ -16,6 +16,8 @@ class MutableSetOfIntsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -32,6 +34,8 @@ class MutableSetOfIntsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsWritingSpec.scala
@@ -14,6 +14,8 @@ class MutableSetOfIntsWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReadingSpec.scala
@@ -17,6 +17,8 @@ class NestedStructsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,10 @@ class NestedStructsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      b.jsonBytes = "x".getBytes(UTF_8)
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
+      b.jsonBytes = "[]".getBytes(UTF_8)
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsWritingSpec.scala
@@ -16,6 +16,8 @@ class NestedStructsWritingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON serializes null value for Option.None
       //toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/OpenRTBReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/OpenRTBReadingSpec.scala
@@ -15,6 +15,8 @@ class OpenRTBReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJawn() shouldBe benchmark.obj
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       //FIXME: Play-JSON requires fields for lists with default values
       //benchmark.playJson() shouldBe benchmark.obj
@@ -34,6 +36,8 @@ class OpenRTBReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJawn())
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.smithy4sJson())
       intercept[Throwable](b.uPickle())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/OpenRTBWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/OpenRTBWritingSpec.scala
@@ -15,6 +15,10 @@ class OpenRTBWritingSpec extends BenchmarkSpecBase {
       //toString(b.circeJsoniter()) shouldBe b.jsonString
       //FIXME: Jackson serializes fields with default values
       //toString(b.jacksonScala()) shouldBe b.jsonString
+      //FIXME: json4s.jackson serializes fields with default values
+      //toString(b.json4sJackson()) shouldBe b.jsonString
+      //FIXME: json4s.native serializes fields with default values
+      //toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       //FIXME: Play-JSON serializes lists with default values

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReadingSpec.scala
@@ -16,6 +16,8 @@ class PrimitivesReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class PrimitivesReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesWritingSpec.scala
@@ -14,6 +14,8 @@ class PrimitivesWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString1
       toString(b.dslJsonScala()) shouldBe b.jsonString1
       toString(b.jacksonScala()) shouldBe b.jsonString1
+      toString(b.json4sJackson()) shouldBe b.jsonString1
+      toString(b.json4sNative()) shouldBe b.jsonString1
       toString(b.jsoniterScala()) shouldBe b.jsonString1
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString1
       toString(b.playJson()) shouldBe b.jsonString3

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReadingSpec.scala
@@ -16,6 +16,8 @@ class SetOfIntsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class SetOfIntsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsWritingSpec.scala
@@ -18,6 +18,8 @@ class SetOfIntsWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReadingSpec.scala
@@ -16,6 +16,9 @@ class StringOfAsciiCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      //FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+      //benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +38,9 @@ class StringOfAsciiCharsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      //FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsWritingSpec.scala
@@ -14,6 +14,8 @@ class StringOfAsciiCharsWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReadingSpec.scala
@@ -16,6 +16,9 @@ class StringOfEscapedCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      //FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+      //benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +38,9 @@ class StringOfEscapedCharsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      //FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsWritingSpec.scala
@@ -12,6 +12,10 @@ class StringOfEscapedCharsWritingSpec extends BenchmarkSpecBase {
       toString(b.circe()) shouldBe b.jsonString1
       toString(b.circeJsoniter()) shouldBe b.jsonString1
       toString(b.jacksonScala()) shouldBe b.jsonString2
+      //FIXME: json4s.jackson doesn't escape unicode
+      //toString(b.json4sJackson()) shouldBe b.jsonString1
+      //FIXME: json4s.native doesn't escape unicode
+      //toString(b.json4sNative()) shouldBe b.jsonString1
       toString(b.jsoniterScala()) shouldBe b.jsonString1
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString1
       toString(b.playJson()) shouldBe b.jsonString2

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReadingSpec.scala
@@ -16,6 +16,9 @@ class StringOfNonAsciiCharsReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      //FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+      //benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +38,9 @@ class StringOfNonAsciiCharsReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      //FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+      //intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsWritingSpec.scala
@@ -14,6 +14,9 @@ class StringOfNonAsciiCharsWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      //FIXME: json4s.native writes escaped codes instead of UTF-8 bytes
+      //toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIReadingSpec.scala
@@ -16,6 +16,8 @@ class TwitterAPIReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class TwitterAPIReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIWritingSpec.scala
@@ -15,6 +15,10 @@ class TwitterAPIWritingSpec extends BenchmarkSpecBase {
       //FIXME: DSL-JSON serializes empty collections
       //toString(b.dslJsonScala()) shouldBe b.compactJsonString
       toString(b.jacksonScala()) shouldBe b.compactJsonString
+      //FIXME: json4s.jackson serializes empty collections
+      //toString(b.json4sJackson()) shouldBe b.compactJsonString
+      //FIXME: json4s.native serializes empty collections
+      //toString(b.json4sNative()) shouldBe b.compactJsonString
       toString(b.jsoniterScala()) shouldBe b.compactJsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.compactJsonString
       //FIXME: Play-JSON serializes empty collections

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReadingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReadingSpec.scala
@@ -16,6 +16,8 @@ class VectorOfBooleansReadingSpec extends BenchmarkSpecBase {
       benchmark.circeJsoniter() shouldBe benchmark.obj
       benchmark.dslJsonScala() shouldBe benchmark.obj
       benchmark.jacksonScala() shouldBe benchmark.obj
+      benchmark.json4sJackson() shouldBe benchmark.obj
+      benchmark.json4sNative() shouldBe benchmark.obj
       benchmark.jsoniterScala() shouldBe benchmark.obj
       benchmark.playJson() shouldBe benchmark.obj
       benchmark.playJsonJsoniter() shouldBe benchmark.obj
@@ -35,6 +37,8 @@ class VectorOfBooleansReadingSpec extends BenchmarkSpecBase {
       intercept[Throwable](b.circeJsoniter())
       intercept[Throwable](b.dslJsonScala())
       intercept[Throwable](b.jacksonScala())
+      intercept[Throwable](b.json4sJackson())
+      intercept[Throwable](b.json4sNative())
       intercept[Throwable](b.jsoniterScala())
       intercept[Throwable](b.playJson())
       intercept[Throwable](b.playJsonJsoniter())

--- a/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansWritingSpec.scala
+++ b/jsoniter-scala-benchmark/jvm/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansWritingSpec.scala
@@ -14,6 +14,8 @@ class VectorOfBooleansWritingSpec extends BenchmarkSpecBase {
       toString(b.circeJsoniter()) shouldBe b.jsonString
       toString(b.dslJsonScala()) shouldBe b.jsonString
       toString(b.jacksonScala()) shouldBe b.jsonString
+      toString(b.json4sJackson()) shouldBe b.jsonString
+      toString(b.json4sNative()) shouldBe b.jsonString
       toString(b.jsoniterScala()) shouldBe b.jsonString
       toString(b.preallocatedBuf, 64, b.jsoniterScalaPrealloc()) shouldBe b.jsonString
       toString(b.playJson()) shouldBe b.jsonString

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTReading.scala
@@ -53,7 +53,28 @@ class ADTReading extends ADTBenchmark {
 
     jacksonMapper.readValue[ADTBase](jsonBytes)
   }
+/* FIXME: json4s.jackson throws org.json4s.MappingException: No constructor for type ADTBase
+  @Benchmark
+  def json4sJackson(): ADTBase = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
 
+    parse(new String(jsonBytes, UTF_8)).extract[ADTBase]
+  }
+*/
+/* FIXME: json4s.native throws org.json4s.MappingException: No constructor for type ADTBase
+  @Benchmark
+  def json4sNative(): ADTBase = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[ADTBase]
+  }
+*/
   @Benchmark
   def jsoniterScala(): ADTBase = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ADTWriting.scala
@@ -45,7 +45,26 @@ class ADTWriting extends ADTBenchmark {
 
     jacksonMapper.writeValueAsBytes(obj)
   }
+/* FIXME: json4s.jackson doesn't type hints
+  @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
 
+    write(obj).getBytes(UTF_8)
+  }
+*/
+/*  FIXME: json4s.native doesn't type hints
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+*/
   @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsReading.scala
@@ -62,6 +62,26 @@ class AnyValsReading extends AnyValsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): AnyVals = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[AnyVals]
+  }
+
+  @Benchmark
+  def json4sNative(): AnyVals = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[AnyVals]
+  }
+
+  @Benchmark
   def jsoniterScala(): AnyVals = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/AnyValsWriting.scala
@@ -54,6 +54,24 @@ class AnyValsWriting extends AnyValsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansReading.scala
@@ -61,6 +61,26 @@ class ArrayBufferOfBooleansReading extends ArrayBufferOfBooleansBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): mutable.ArrayBuffer[Boolean] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[mutable.ArrayBuffer[Boolean]]
+  }
+
+  @Benchmark
+  def json4sNative(): mutable.ArrayBuffer[Boolean] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[mutable.ArrayBuffer[Boolean]]
+  }
+
+  @Benchmark
   def jsoniterScala(): mutable.ArrayBuffer[Boolean] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayBufferOfBooleansWriting.scala
@@ -51,6 +51,24 @@ class ArrayBufferOfBooleansWriting extends ArrayBufferOfBooleansBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsReading.scala
@@ -57,7 +57,28 @@ class ArrayOfBigDecimalsReading extends ArrayOfBigDecimalsBenchmark {
 
     jacksonMapper.readValue[Array[BigDecimal]](jsonBytes)
   }
+/* FIXME: json4s.jackson rounds parsed numbers to double
+  @Benchmark
+  def json4sJackson(): Array[BigDecimal] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
 
+    parse(new String(jsonBytes, UTF_8)).extract[Array[BigDecimal]]
+  }
+*/
+/* FIXME: json4s.native rounds parsed numbers to double
+  @Benchmark
+  def json4sNative(): Array[BigDecimal] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[BigDecimal]]
+  }
+*/
   @Benchmark
   def jsoniterScala(): Array[BigDecimal] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigDecimalsWriting.scala
@@ -49,6 +49,24 @@ class ArrayOfBigDecimalsWriting extends ArrayOfBigDecimalsBenchmark {
 
     jacksonMapper.writeValueAsBytes(obj)
   }
+/* FIXME: json4s.jackson rounding to double
+  @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+*/
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
 
   @Benchmark
   def jsoniterScala(): Array[Byte] = {

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsReading.scala
@@ -59,6 +59,26 @@ class ArrayOfBigIntsReading extends ArrayOfBigIntsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[BigInt] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[BigInt]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[BigInt] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[BigInt]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[BigInt] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBigIntsWriting.scala
@@ -52,6 +52,24 @@ class ArrayOfBigIntsWriting extends ArrayOfBigIntsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansReading.scala
@@ -57,6 +57,26 @@ class ArrayOfBooleansReading extends ArrayOfBooleansBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Boolean] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Boolean]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Boolean] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Boolean]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Boolean] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBooleansWriting.scala
@@ -51,6 +51,24 @@ class ArrayOfBooleansWriting extends ArrayOfBooleansBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesReading.scala
@@ -58,6 +58,26 @@ class ArrayOfBytesReading extends ArrayOfBytesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Byte]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Byte]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfBytesWriting.scala
@@ -52,6 +52,24 @@ class ArrayOfBytesWriting extends ArrayOfBytesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsReading.scala
@@ -49,7 +49,28 @@ class ArrayOfCharsReading extends ArrayOfCharsBenchmark {
 
     jacksonMapper.readValue[Array[Char]](jsonBytes)
   }
+/* FIXME: json4s.jackson throws org.json4s.MappingException: Do not know how to convert JString(3) into byte
+  @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
 
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Byte]]
+  }
+*/
+/* FIXME: json4s.native throws org.json4s.MappingException: Do not know how to convert JString(3) into byte
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Byte]]
+  }
+*/
   @Benchmark
   def jsoniterScala(): Array[Char] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfCharsWriting.scala
@@ -45,6 +45,24 @@ class ArrayOfCharsWriting extends ArrayOfCharsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesReading.scala
@@ -57,6 +57,26 @@ class ArrayOfDoublesReading extends ArrayOfDoublesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Double] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Double]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Double] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Double]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Double] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDoublesWriting.scala
@@ -51,6 +51,24 @@ class ArrayOfDoublesWriting extends ArrayOfDoublesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsReading.scala
@@ -54,6 +54,26 @@ class ArrayOfDurationsReading extends ArrayOfDurationsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Duration] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Duration]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Duration] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Duration]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Duration] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfDurationsWriting.scala
@@ -47,6 +47,24 @@ class ArrayOfDurationsWriting extends ArrayOfDurationsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsReading.scala
@@ -62,6 +62,26 @@ class ArrayOfEnumADTsReading extends ArrayOfEnumADTsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[SuitADT] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[SuitADT]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[SuitADT] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[SuitADT]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[SuitADT] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumADTsWriting.scala
@@ -54,6 +54,24 @@ class ArrayOfEnumADTsWriting extends ArrayOfEnumADTsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsReading.scala
@@ -56,6 +56,26 @@ class ArrayOfEnumsReading extends ArrayOfEnumsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[SuitEnum] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[SuitEnum]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[SuitEnum] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[SuitEnum]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[SuitEnum] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfEnumsWriting.scala
@@ -47,6 +47,24 @@ class ArrayOfEnumsWriting extends ArrayOfEnumsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsReading.scala
@@ -54,7 +54,28 @@ class ArrayOfFloatsReading extends ArrayOfFloatsBenchmark {
 
     jacksonMapper.readValue[Array[Float]](jsonBytes)
   }
+/* FIXME: json4s.jackson parses 1.199999988079071 as 1.2f instead of 1.1999999f
+  @Benchmark
+  def json4sJackson(): Array[Float] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
 
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Float]]
+  }
+*/
+/* FIXME: json4s.native parses 1.199999988079071 as 1.2f instead of 1.1999999f
+  @Benchmark
+  def json4sNative(): Array[Float] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Float]]
+  }
+*/
   @Benchmark
   def jsoniterScala(): Array[Float] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfFloatsWriting.scala
@@ -51,6 +51,24 @@ class ArrayOfFloatsWriting extends ArrayOfFloatsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsReading.scala
@@ -54,6 +54,26 @@ class ArrayOfInstantsReading extends ArrayOfInstantsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Instant] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Instant]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Instant] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Instant]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Instant] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfInstantsWriting.scala
@@ -47,6 +47,24 @@ class ArrayOfInstantsWriting extends ArrayOfInstantsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsReading.scala
@@ -57,6 +57,26 @@ class ArrayOfIntsReading extends ArrayOfIntsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Int] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Int]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Int] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Int]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Int] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfIntsWriting.scala
@@ -51,6 +51,24 @@ class ArrayOfIntsWriting extends ArrayOfIntsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsReading.scala
@@ -61,6 +61,26 @@ class ArrayOfJavaEnumsReading extends ArrayOfJavaEnumsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Suit] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Suit]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Suit] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Suit]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Suit] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfJavaEnumsWriting.scala
@@ -53,6 +53,24 @@ class ArrayOfJavaEnumsWriting extends ArrayOfJavaEnumsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesReading.scala
@@ -61,6 +61,26 @@ class ArrayOfLocalDateTimesReading extends ArrayOfLocalDateTimesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[LocalDateTime] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[LocalDateTime]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[LocalDateTime] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[LocalDateTime]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[LocalDateTime] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDateTimesWriting.scala
@@ -54,6 +54,24 @@ class ArrayOfLocalDateTimesWriting extends ArrayOfLocalDateTimesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesReading.scala
@@ -61,6 +61,26 @@ class ArrayOfLocalDatesReading extends ArrayOfLocalDatesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[LocalDate] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[LocalDate]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[LocalDate] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[LocalDate]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[LocalDate] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalDatesWriting.scala
@@ -54,6 +54,24 @@ class ArrayOfLocalDatesWriting extends ArrayOfLocalDatesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesReading.scala
@@ -62,6 +62,26 @@ class ArrayOfLocalTimesReading extends ArrayOfLocalTimesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[LocalTime] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[LocalTime]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[LocalTime] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[LocalTime]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[LocalTime] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLocalTimesWriting.scala
@@ -54,6 +54,24 @@ class ArrayOfLocalTimesWriting extends ArrayOfLocalTimesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsReading.scala
@@ -57,6 +57,26 @@ class ArrayOfLongsReading extends ArrayOfLongsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Long] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Long]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Long] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Long]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Long] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfLongsWriting.scala
@@ -51,6 +51,24 @@ class ArrayOfLongsWriting extends ArrayOfLongsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysReading.scala
@@ -54,6 +54,26 @@ class ArrayOfMonthDaysReading extends ArrayOfMonthDaysBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[MonthDay] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[MonthDay]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[MonthDay] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[MonthDay]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[MonthDay] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfMonthDaysWriting.scala
@@ -47,6 +47,24 @@ class ArrayOfMonthDaysWriting extends ArrayOfMonthDaysBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesReading.scala
@@ -61,6 +61,26 @@ class ArrayOfOffsetDateTimesReading extends ArrayOfOffsetDateTimesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[OffsetDateTime] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[OffsetDateTime]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[OffsetDateTime] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[OffsetDateTime]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[OffsetDateTime] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetDateTimesWriting.scala
@@ -54,6 +54,24 @@ class ArrayOfOffsetDateTimesWriting extends ArrayOfOffsetDateTimesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesReading.scala
@@ -61,6 +61,26 @@ class ArrayOfOffsetTimesReading extends ArrayOfOffsetTimesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[OffsetTime] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[OffsetTime]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[OffsetTime] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[OffsetTime]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[OffsetTime] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfOffsetTimesWriting.scala
@@ -54,6 +54,24 @@ class ArrayOfOffsetTimesWriting extends ArrayOfOffsetTimesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsReading.scala
@@ -54,6 +54,26 @@ class ArrayOfPeriodsReading extends ArrayOfPeriodsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Period] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Period]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Period] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Period]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Period] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfPeriodsWriting.scala
@@ -47,6 +47,24 @@ class ArrayOfPeriodsWriting extends ArrayOfPeriodsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsReading.scala
@@ -57,6 +57,26 @@ class ArrayOfShortsReading extends ArrayOfShortsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Short] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Short]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Short] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Short]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Short] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfShortsWriting.scala
@@ -51,6 +51,24 @@ class ArrayOfShortsWriting extends ArrayOfShortsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsReading.scala
@@ -60,6 +60,26 @@ class ArrayOfUUIDsReading extends ArrayOfUUIDsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[UUID] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[UUID]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[UUID] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[UUID]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[UUID] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfUUIDsWriting.scala
@@ -53,6 +53,24 @@ class ArrayOfUUIDsWriting extends ArrayOfUUIDsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsReading.scala
@@ -54,6 +54,26 @@ class ArrayOfYearMonthsReading extends ArrayOfYearMonthsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[YearMonth] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[YearMonth]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[YearMonth] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[YearMonth]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[YearMonth] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearMonthsWriting.scala
@@ -46,6 +46,24 @@ class ArrayOfYearMonthsWriting extends ArrayOfYearMonthsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsReading.scala
@@ -54,6 +54,26 @@ class ArrayOfYearsReading extends ArrayOfYearsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Year] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Year]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Year] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Year]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Year] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfYearsWriting.scala
@@ -47,6 +47,24 @@ class ArrayOfYearsWriting extends ArrayOfYearsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsReading.scala
@@ -53,6 +53,26 @@ class ArrayOfZoneIdsReading extends ArrayOfZoneIdsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[ZoneId] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[ZoneId]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[ZoneId] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[ZoneId]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[ZoneId] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneIdsWriting.scala
@@ -46,6 +46,24 @@ class ArrayOfZoneIdsWriting extends ArrayOfZoneIdsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsReading.scala
@@ -53,6 +53,26 @@ class ArrayOfZoneOffsetsReading extends ArrayOfZoneOffsetsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[ZoneOffset] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[ZoneOffset]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[ZoneOffset] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[ZoneOffset]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[ZoneOffset] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZoneOffsetsWriting.scala
@@ -46,6 +46,24 @@ class ArrayOfZoneOffsetsWriting extends ArrayOfZoneOffsetsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesReading.scala
@@ -59,6 +59,26 @@ class ArrayOfZonedDateTimesReading extends ArrayOfZonedDateTimesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[ZonedDateTime] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[ZonedDateTime]]
+  }
+
+  @Benchmark
+  def json4sNative(): Array[ZonedDateTime] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[ZonedDateTime]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[ZonedDateTime] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArrayOfZonedDateTimesWriting.scala
@@ -53,6 +53,24 @@ class ArrayOfZonedDateTimesWriting extends ArrayOfZonedDateTimesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArraySeqOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArraySeqOfBooleansReading.scala
@@ -56,6 +56,28 @@ class ArraySeqOfBooleansReading extends ArraySeqOfBooleansBenchmark {
 
     jacksonMapper.readValue[ArraySeq[Boolean]](jsonBytes)
   }
+/* FIXME json4s.jackson throws org.json4s.MappingException: unknown error
+  @Benchmark
+  def json4sJackson(): ArraySeq[Boolean] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[ArraySeq[Boolean]]
+  }
+*/
+/* FIXME json4s.native throws org.json4s.MappingException: unknown error
+  @Benchmark
+  def json4sNative(): ArraySeq[Boolean] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[ArraySeq[Boolean]]
+  }
+*/
   @Benchmark
   def jsoniterScala(): ArraySeq[Boolean] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArraySeqOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ArraySeqOfBooleansWriting.scala
@@ -51,6 +51,24 @@ class ArraySeqOfBooleansWriting extends ArraySeqOfBooleansBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64Reading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64Reading.scala
@@ -61,6 +61,26 @@ class Base64Reading extends Base64Benchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Base64Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Byte]]
+  }
+/* FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Base64Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Array[Byte]]
+  }
+*/
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64Writing.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Base64Writing.scala
@@ -53,6 +53,24 @@ class Base64Writing extends Base64Benchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Base64Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Base64Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalReading.scala
@@ -59,6 +59,26 @@ class BigDecimalReading extends BigDecimalBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): BigDecimal = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[BigDecimal]
+  }
+/* FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+  @Benchmark
+  def json4sNative(): BigDecimal = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[BigDecimal]
+  }
+*/
+  @Benchmark
   def jsoniterScala(): BigDecimal = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigDecimalWriting.scala
@@ -49,6 +49,24 @@ class BigDecimalWriting extends BigDecimalBenchmark {
 
     jacksonMapper.writeValueAsBytes(obj)
   }
+/* FIXME: json4s.jackson rounding to double
+  @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+*/
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
 
   @Benchmark
   def jsoniterScala(): Array[Byte] = {

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntReading.scala
@@ -59,6 +59,26 @@ class BigIntReading extends BigIntBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): BigInt = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[BigInt]
+  }
+/* FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+  @Benchmark
+  def json4sNative(): BigInt = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[BigInt]
+  }
+*/
+  @Benchmark
   def jsoniterScala(): BigInt = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/BigIntWriting.scala
@@ -51,6 +51,24 @@ class BigIntWriting extends BigIntBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ExtractFieldsReading.scala
@@ -62,6 +62,26 @@ class ExtractFieldsReading extends ExtractFieldsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): ExtractFields = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[ExtractFields]
+  }
+
+  @Benchmark
+  def json4sNative(): ExtractFields = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[ExtractFields]
+  }
+
+  @Benchmark
   def jsoniterScala(): ExtractFields = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONReading.scala
@@ -53,7 +53,28 @@ class GeoJSONReading extends GeoJSONBenchmark {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
     jacksonMapper.readValue[GeoJSON](jsonBytes)
   }
+/* FIXME: json4s.jackson throws org.json4s.MappingException: No constructor for type GeoJSON
+  @Benchmark
+  def json4sJackson(): GeoJSON = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.GitHubActionsAPIJson4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
 
+    parse(new String(jsonBytes, UTF_8)).extract[GeoJSON]
+  }
+*/
+/* FIXME: json4s.native throws org.json4s.MappingException: No constructor for type GeoJSON
+  @Benchmark
+  def json4sNative(): GeoJSON = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.GitHubActionsAPIJson4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[GeoJSON]
+  }
+*/
   @Benchmark
   def jsoniterScala(): GeoJSON = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GeoJSONWriting.scala
@@ -45,7 +45,26 @@ class GeoJSONWriting extends GeoJSONBenchmark {
 
     jacksonMapper.writeValueAsBytes(obj)
   }
+/* FIXME: json4s.jackson doesn't type hints
+  @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.GitHubActionsAPIJson4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
 
+    write(obj).getBytes(UTF_8)
+  }
+*/
+/* FIXME: json4s.native doesn't type hints
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.GitHubActionsAPIJson4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+*/
   @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIReading.scala
@@ -1,5 +1,6 @@
 package com.github.plokhotnyuk.jsoniter_scala.benchmark
 
+import com.github.plokhotnyuk.jsoniter_scala.benchmark.GoogleMapsAPI.DistanceMatrix
 import org.openjdk.jmh.annotations.Benchmark
 
 class GitHubActionsAPIReading extends GitHubActionsAPIBenchmark {
@@ -52,6 +53,26 @@ class GitHubActionsAPIReading extends GitHubActionsAPIBenchmark {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JacksonSerDesers._
 
     jacksonMapper.readValue[GitHubActionsAPI.Response](jsonBytes)
+  }
+
+  @Benchmark
+  def json4sJackson(): GitHubActionsAPI.Response = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.GitHubActionsAPIJson4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[GitHubActionsAPI.Response]
+  }
+
+  @Benchmark
+  def json4sNative(): GitHubActionsAPI.Response = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.GitHubActionsAPIJson4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[GitHubActionsAPI.Response]
   }
 
   @Benchmark

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GitHubActionsAPIWriting.scala
@@ -47,6 +47,24 @@ class GitHubActionsAPIWriting extends GitHubActionsAPIBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.GitHubActionsAPIJson4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.GitHubActionsAPIJson4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIBenchmark.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIBenchmark.scala
@@ -2351,6 +2351,1176 @@ abstract class GoogleMapsAPIBenchmark extends CommonParams {
       |  ],
       |  "status": "OK"
       |}""".stripMargin
+  var jsonString3: String =
+    """{
+      |  "destination_addresses":[
+      |    "New York, NY, USA",
+      |    "Los Angeles, CA, USA",
+      |    "Chicago, IL, USA",
+      |    "Houston, TX, USA",
+      |    "Phoenix, AZ, USA",
+      |    "Philadelphia, PA, USA",
+      |    "San Antonio, TX, USA",
+      |    "San Diego, CA, USA",
+      |    "Dallas, TX, USA",
+      |    "San Jose, CA, USA"
+      |  ],
+      |  "origin_addresses":[
+      |    "New York, NY, USA",
+      |    "Los Angeles, CA, USA",
+      |    "Chicago, IL, USA",
+      |    "Houston, TX, USA",
+      |    "Phoenix, AZ, USA",
+      |    "Philadelphia, PA, USA",
+      |    "San Antonio, TX, USA",
+      |    "San Diego, CA, USA",
+      |    "Dallas, TX, USA",
+      |    "San Jose, CA, USA"
+      |  ],
+      |  "rows":[
+      |    {
+      |      "elements":[
+      |        {
+      |          "distance":{
+      |            "text":"1 m",
+      |            "value":0
+      |          },
+      |          "duration":{
+      |            "text":"1 min",
+      |            "value":0
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"4,490 km",
+      |            "value":4489862
+      |          },
+      |          "duration":{
+      |            "text":"1 day 16 hours",
+      |            "value":145589
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,270 km",
+      |            "value":1270445
+      |          },
+      |          "duration":{
+      |            "text":"12 hours 10 mins",
+      |            "value":43773
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,621 km",
+      |            "value":2620658
+      |          },
+      |          "duration":{
+      |            "text":"23 hours 55 mins",
+      |            "value":86073
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"3,876 km",
+      |            "value":3875676
+      |          },
+      |          "duration":{
+      |            "text":"1 day 12 hours",
+      |            "value":129040
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"158 km",
+      |            "value":158242
+      |          },
+      |          "duration":{
+      |            "text":"1 hour 55 mins",
+      |            "value":6885
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,935 km",
+      |            "value":2934803
+      |          },
+      |          "duration":{
+      |            "text":"1 day 3 hours",
+      |            "value":96322
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"4,443 km",
+      |            "value":4443412
+      |          },
+      |          "duration":{
+      |            "text":"1 day 17 hours",
+      |            "value":147406
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,492 km",
+      |            "value":2492302
+      |          },
+      |          "duration":{
+      |            "text":"22 hours 53 mins",
+      |            "value":82371
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"4,728 km",
+      |            "value":4728294
+      |          },
+      |          "duration":{
+      |            "text":"1 day 19 hours",
+      |            "value":154228
+      |          },
+      |          "status":"OK"
+      |        }
+      |      ]
+      |    },
+      |    {
+      |      "elements":[
+      |        {
+      |          "distance":{
+      |            "text":"4,501 km",
+      |            "value":4501326
+      |          },
+      |          "duration":{
+      |            "text":"1 day 16 hours",
+      |            "value":145282
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1 m",
+      |            "value":0
+      |          },
+      |          "duration":{
+      |            "text":"1 min",
+      |            "value":0
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"3,244 km",
+      |            "value":3243718
+      |          },
+      |          "duration":{
+      |            "text":"1 day 5 hours",
+      |            "value":103355
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,491 km",
+      |            "value":2491140
+      |          },
+      |          "duration":{
+      |            "text":"21 hours 48 mins",
+      |            "value":78485
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"600 km",
+      |            "value":600314
+      |          },
+      |          "duration":{
+      |            "text":"5 hours 29 mins",
+      |            "value":19738
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"4,368 km",
+      |            "value":4368094
+      |          },
+      |          "duration":{
+      |            "text":"1 day 15 hours",
+      |            "value":141933
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,177 km",
+      |            "value":2176782
+      |          },
+      |          "duration":{
+      |            "text":"19 hours 3 mins",
+      |            "value":68584
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"194 km",
+      |            "value":193646
+      |          },
+      |          "duration":{
+      |            "text":"1 hour 57 mins",
+      |            "value":7042
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,312 km",
+      |            "value":2311734
+      |          },
+      |          "duration":{
+      |            "text":"20 hours 25 mins",
+      |            "value":73503
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"547 km",
+      |            "value":546932
+      |          },
+      |          "duration":{
+      |            "text":"5 hours 11 mins",
+      |            "value":18651
+      |          },
+      |          "status":"OK"
+      |        }
+      |      ]
+      |    },
+      |    {
+      |      "elements":[
+      |        {
+      |          "distance":{
+      |            "text":"1,282 km",
+      |            "value":1281616
+      |          },
+      |          "duration":{
+      |            "text":"12 hours 8 mins",
+      |            "value":43678
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"3,243 km",
+      |            "value":3242543
+      |          },
+      |          "duration":{
+      |            "text":"1 day 5 hours",
+      |            "value":103349
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1 m",
+      |            "value":0
+      |          },
+      |          "duration":{
+      |            "text":"1 min",
+      |            "value":0
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,742 km",
+      |            "value":1741571
+      |          },
+      |          "duration":{
+      |            "text":"16 hours 11 mins",
+      |            "value":58255
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,821 km",
+      |            "value":2821137
+      |          },
+      |          "duration":{
+      |            "text":"1 day 2 hours",
+      |            "value":92449
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,220 km",
+      |            "value":1219825
+      |          },
+      |          "duration":{
+      |            "text":"11 hours 27 mins",
+      |            "value":41212
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,997 km",
+      |            "value":1996514
+      |          },
+      |          "duration":{
+      |            "text":"18 hours 4 mins",
+      |            "value":65059
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"3,342 km",
+      |            "value":3341754
+      |          },
+      |          "duration":{
+      |            "text":"1 day 6 hours",
+      |            "value":106407
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,490 km",
+      |            "value":1489726
+      |          },
+      |          "duration":{
+      |            "text":"14 hours 2 mins",
+      |            "value":50540
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"3,481 km",
+      |            "value":3480975
+      |          },
+      |          "duration":{
+      |            "text":"1 day 7 hours",
+      |            "value":111989
+      |          },
+      |          "status":"OK"
+      |        }
+      |      ]
+      |    },
+      |    {
+      |      "elements":[
+      |        {
+      |          "distance":{
+      |            "text":"2,624 km",
+      |            "value":2623641
+      |          },
+      |          "duration":{
+      |            "text":"23 hours 58 mins",
+      |            "value":86258
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,488 km",
+      |            "value":2488117
+      |          },
+      |          "duration":{
+      |            "text":"21 hours 49 mins",
+      |            "value":78547
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,742 km",
+      |            "value":1741761
+      |          },
+      |          "duration":{
+      |            "text":"16 hours 13 mins",
+      |            "value":58360
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1 m",
+      |            "value":0
+      |          },
+      |          "duration":{
+      |            "text":"1 min",
+      |            "value":0
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,890 km",
+      |            "value":1889580
+      |          },
+      |          "duration":{
+      |            "text":"16 hours 28 mins",
+      |            "value":59289
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,489 km",
+      |            "value":2489250
+      |          },
+      |          "duration":{
+      |            "text":"22 hours 42 mins",
+      |            "value":81704
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"317 km",
+      |            "value":317168
+      |          },
+      |          "duration":{
+      |            "text":"2 hours 55 mins",
+      |            "value":10481
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,363 km",
+      |            "value":2362972
+      |          },
+      |          "duration":{
+      |            "text":"20 hours 36 mins",
+      |            "value":74158
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"385 km",
+      |            "value":384812
+      |          },
+      |          "duration":{
+      |            "text":"3 hours 26 mins",
+      |            "value":12385
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"3,033 km",
+      |            "value":3033431
+      |          },
+      |          "duration":{
+      |            "text":"1 day 3 hours",
+      |            "value":96387
+      |          },
+      |          "status":"OK"
+      |        }
+      |      ]
+      |    },
+      |    {
+      |      "elements":[
+      |        {
+      |          "distance":{
+      |            "text":"3,885 km",
+      |            "value":3884549
+      |          },
+      |          "duration":{
+      |            "text":"1 day 12 hours",
+      |            "value":128892
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"599 km",
+      |            "value":598636
+      |          },
+      |          "duration":{
+      |            "text":"5 hours 32 mins",
+      |            "value":19898
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,829 km",
+      |            "value":2828868
+      |          },
+      |          "duration":{
+      |            "text":"1 day 2 hours",
+      |            "value":92370
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,893 km",
+      |            "value":1892718
+      |          },
+      |          "duration":{
+      |            "text":"16 hours 31 mins",
+      |            "value":59432
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1 m",
+      |            "value":0
+      |          },
+      |          "duration":{
+      |            "text":"1 min",
+      |            "value":0
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"3,776 km",
+      |            "value":3776390
+      |          },
+      |          "duration":{
+      |            "text":"1 day 11 hours",
+      |            "value":124555
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,578 km",
+      |            "value":1578360
+      |          },
+      |          "duration":{
+      |            "text":"13 hours 46 mins",
+      |            "value":49532
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"571 km",
+      |            "value":570657
+      |          },
+      |          "duration":{
+      |            "text":"5 hours 17 mins",
+      |            "value":19041
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,713 km",
+      |            "value":1713312
+      |          },
+      |          "duration":{
+      |            "text":"15 hours 8 mins",
+      |            "value":54450
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,144 km",
+      |            "value":1143951
+      |          },
+      |          "duration":{
+      |            "text":"10 hours 29 mins",
+      |            "value":37738
+      |          },
+      |          "status":"OK"
+      |        }
+      |      ]
+      |    },
+      |    {
+      |      "elements":[
+      |        {
+      |          "distance":{
+      |            "text":"159 km",
+      |            "value":158684
+      |          },
+      |          "duration":{
+      |            "text":"1 hour 53 mins",
+      |            "value":6753
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"4,363 km",
+      |            "value":4362509
+      |          },
+      |          "duration":{
+      |            "text":"1 day 16 hours",
+      |            "value":142324
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,221 km",
+      |            "value":1220728
+      |          },
+      |          "duration":{
+      |            "text":"11 hours 30 mins",
+      |            "value":41424
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,488 km",
+      |            "value":2487984
+      |          },
+      |          "duration":{
+      |            "text":"22 hours 37 mins",
+      |            "value":81429
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"3,769 km",
+      |            "value":3769346
+      |          },
+      |          "duration":{
+      |            "text":"1 day 11 hours",
+      |            "value":124752
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1 m",
+      |            "value":0
+      |          },
+      |          "duration":{
+      |            "text":"1 min",
+      |            "value":0
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,802 km",
+      |            "value":2802129
+      |          },
+      |          "duration":{
+      |            "text":"1 day 1 hour",
+      |            "value":91677
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"4,337 km",
+      |            "value":4337082
+      |          },
+      |          "duration":{
+      |            "text":"1 day 16 hours",
+      |            "value":143118
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,360 km",
+      |            "value":2359628
+      |          },
+      |          "duration":{
+      |            "text":"21 hours 35 mins",
+      |            "value":77726
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"4,679 km",
+      |            "value":4678576
+      |          },
+      |          "duration":{
+      |            "text":"1 day 18 hours",
+      |            "value":151879
+      |          },
+      |          "status":"OK"
+      |        }
+      |      ]
+      |    },
+      |    {
+      |      "elements":[
+      |        {
+      |          "distance":{
+      |            "text":"2,939 km",
+      |            "value":2938513
+      |          },
+      |          "duration":{
+      |            "text":"1 day 3 hours",
+      |            "value":96477
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,178 km",
+      |            "value":2178117
+      |          },
+      |          "duration":{
+      |            "text":"19 hours 6 mins",
+      |            "value":68773
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,996 km",
+      |            "value":1996414
+      |          },
+      |          "duration":{
+      |            "text":"18 hours 3 mins",
+      |            "value":64959
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"318 km",
+      |            "value":317558
+      |          },
+      |          "duration":{
+      |            "text":"2 hours 54 mins",
+      |            "value":10436
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,580 km",
+      |            "value":1579581
+      |          },
+      |          "duration":{
+      |            "text":"13 hours 45 mins",
+      |            "value":49515
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,804 km",
+      |            "value":2804123
+      |          },
+      |          "duration":{
+      |            "text":"1 day 2 hours",
+      |            "value":91923
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1 m",
+      |            "value":0
+      |          },
+      |          "duration":{
+      |            "text":"1 min",
+      |            "value":0
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,053 km",
+      |            "value":2052972
+      |          },
+      |          "duration":{
+      |            "text":"17 hours 53 mins",
+      |            "value":64384
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"440 km",
+      |            "value":440485
+      |          },
+      |          "duration":{
+      |            "text":"4 hours 7 mins",
+      |            "value":14809
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,723 km",
+      |            "value":2723432
+      |          },
+      |          "duration":{
+      |            "text":"1 day 0 hours",
+      |            "value":86613
+      |          },
+      |          "status":"OK"
+      |        }
+      |      ]
+      |    },
+      |    {
+      |      "elements":[
+      |        {
+      |          "distance":{
+      |            "text":"4,450 km",
+      |            "value":4449804
+      |          },
+      |          "duration":{
+      |            "text":"1 day 17 hours",
+      |            "value":147307
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"193 km",
+      |            "value":193391
+      |          },
+      |          "duration":{
+      |            "text":"2 hours 1 min",
+      |            "value":7257
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"3,343 km",
+      |            "value":3342861
+      |          },
+      |          "duration":{
+      |            "text":"1 day 6 hours",
+      |            "value":106618
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,365 km",
+      |            "value":2365196
+      |          },
+      |          "duration":{
+      |            "text":"20 hours 39 mins",
+      |            "value":74342
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"571 km",
+      |            "value":571299
+      |          },
+      |          "duration":{
+      |            "text":"5 hours 20 mins",
+      |            "value":19183
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"4,342 km",
+      |            "value":4341645
+      |          },
+      |          "duration":{
+      |            "text":"1 day 16 hours",
+      |            "value":142971
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,051 km",
+      |            "value":2050838
+      |          },
+      |          "duration":{
+      |            "text":"17 hours 54 mins",
+      |            "value":64441
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1 m",
+      |            "value":0
+      |          },
+      |          "duration":{
+      |            "text":"1 min",
+      |            "value":0
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,186 km",
+      |            "value":2185790
+      |          },
+      |          "duration":{
+      |            "text":"19 hours 16 mins",
+      |            "value":69360
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"740 km",
+      |            "value":740005
+      |          },
+      |          "duration":{
+      |            "text":"7 hours 6 mins",
+      |            "value":25541
+      |          },
+      |          "status":"OK"
+      |        }
+      |      ]
+      |    },
+      |    {
+      |      "elements":[
+      |        {
+      |          "distance":{
+      |            "text":"2,493 km",
+      |            "value":2492688
+      |          },
+      |          "duration":{
+      |            "text":"22 hours 52 mins",
+      |            "value":82333
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,311 km",
+      |            "value":2310974
+      |          },
+      |          "duration":{
+      |            "text":"20 hours 27 mins",
+      |            "value":73596
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,557 km",
+      |            "value":1556570
+      |          },
+      |          "duration":{
+      |            "text":"14 hours 3 mins",
+      |            "value":50581
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"385 km",
+      |            "value":385037
+      |          },
+      |          "duration":{
+      |            "text":"3 hours 28 mins",
+      |            "value":12495
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,712 km",
+      |            "value":1712438
+      |          },
+      |          "duration":{
+      |            "text":"15 hours 6 mins",
+      |            "value":54339
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,358 km",
+      |            "value":2358297
+      |          },
+      |          "duration":{
+      |            "text":"21 hours 36 mins",
+      |            "value":77780
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"441 km",
+      |            "value":440702
+      |          },
+      |          "duration":{
+      |            "text":"4 hours 7 mins",
+      |            "value":14800
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,186 km",
+      |            "value":2185829
+      |          },
+      |          "duration":{
+      |            "text":"19 hours 13 mins",
+      |            "value":69208
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1 m",
+      |            "value":0
+      |          },
+      |          "duration":{
+      |            "text":"1 min",
+      |            "value":0
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,716 km",
+      |            "value":2715614
+      |          },
+      |          "duration":{
+      |            "text":"1 day 1 hour",
+      |            "value":89296
+      |          },
+      |          "status":"OK"
+      |        }
+      |      ]
+      |    },
+      |    {
+      |      "elements":[
+      |        {
+      |          "distance":{
+      |            "text":"4,741 km",
+      |            "value":4740819
+      |          },
+      |          "duration":{
+      |            "text":"1 day 19 hours",
+      |            "value":153881
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"549 km",
+      |            "value":549030
+      |          },
+      |          "duration":{
+      |            "text":"5 hours 11 mins",
+      |            "value":18643
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"3,483 km",
+      |            "value":3483210
+      |          },
+      |          "duration":{
+      |            "text":"1 day 7 hours",
+      |            "value":111954
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"3,037 km",
+      |            "value":3036563
+      |          },
+      |          "duration":{
+      |            "text":"1 day 3 hours",
+      |            "value":96326
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1,146 km",
+      |            "value":1145736
+      |          },
+      |          "duration":{
+      |            "text":"10 hours 26 mins",
+      |            "value":37580
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"4,679 km",
+      |            "value":4679027
+      |          },
+      |          "duration":{
+      |            "text":"1 day 18 hours",
+      |            "value":151414
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,722 km",
+      |            "value":2722204
+      |          },
+      |          "duration":{
+      |            "text":"1 day 0 hours",
+      |            "value":86426
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"740 km",
+      |            "value":739719
+      |          },
+      |          "duration":{
+      |            "text":"7 hours 2 mins",
+      |            "value":25298
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"2,717 km",
+      |            "value":2717009
+      |          },
+      |          "duration":{
+      |            "text":"1 day 1 hour",
+      |            "value":89209
+      |          },
+      |          "status":"OK"
+      |        },
+      |        {
+      |          "distance":{
+      |            "text":"1 m",
+      |            "value":0
+      |          },
+      |          "duration":{
+      |            "text":"1 min",
+      |            "value":0
+      |          },
+      |          "status":"OK"
+      |        }
+      |      ]
+      |    }
+      |  ],
+      |  "status":"OK"
+      |}""".stripMargin
   var compactJsonString1: String = """{"destination_addresses":["New York, NY, USA","Los Angeles, CA, USA","Chicago, IL, USA","Houston, TX, USA","Phoenix, AZ, USA","Philadelphia, PA, USA","San Antonio, TX, USA","San Diego, CA, USA","Dallas, TX, USA","San Jose, CA, USA"],"origin_addresses":["New York, NY, USA","Los Angeles, CA, USA","Chicago, IL, USA","Houston, TX, USA","Phoenix, AZ, USA","Philadelphia, PA, USA","San Antonio, TX, USA","San Diego, CA, USA","Dallas, TX, USA","San Jose, CA, USA"],"rows":[{"elements":[{"distance":{"text":"1 m","value":0},"duration":{"text":"1 min","value":0},"status":"OK"},{"distance":{"text":"4,490 km","value":4489862},"duration":{"text":"1 day 16 hours","value":145589},"status":"OK"},{"distance":{"text":"1,270 km","value":1270445},"duration":{"text":"12 hours 10 mins","value":43773},"status":"OK"},{"distance":{"text":"2,621 km","value":2620658},"duration":{"text":"23 hours 55 mins","value":86073},"status":"OK"},{"distance":{"text":"3,876 km","value":3875676},"duration":{"text":"1 day 12 hours","value":129040},"status":"OK"},{"distance":{"text":"158 km","value":158242},"duration":{"text":"1 hour 55 mins","value":6885},"status":"OK"},{"distance":{"text":"2,935 km","value":2934803},"duration":{"text":"1 day 3 hours","value":96322},"status":"OK"},{"distance":{"text":"4,443 km","value":4443412},"duration":{"text":"1 day 17 hours","value":147406},"status":"OK"},{"distance":{"text":"2,492 km","value":2492302},"duration":{"text":"22 hours 53 mins","value":82371},"status":"OK"},{"distance":{"text":"4,728 km","value":4728294},"duration":{"text":"1 day 19 hours","value":154228},"status":"OK"}]},{"elements":[{"distance":{"text":"4,501 km","value":4501326},"duration":{"text":"1 day 16 hours","value":145282},"status":"OK"},{"distance":{"text":"1 m","value":0},"duration":{"text":"1 min","value":0},"status":"OK"},{"distance":{"text":"3,244 km","value":3243718},"duration":{"text":"1 day 5 hours","value":103355},"status":"OK"},{"distance":{"text":"2,491 km","value":2491140},"duration":{"text":"21 hours 48 mins","value":78485},"status":"OK"},{"distance":{"text":"600 km","value":600314},"duration":{"text":"5 hours 29 mins","value":19738},"status":"OK"},{"distance":{"text":"4,368 km","value":4368094},"duration":{"text":"1 day 15 hours","value":141933},"status":"OK"},{"distance":{"text":"2,177 km","value":2176782},"duration":{"text":"19 hours 3 mins","value":68584},"status":"OK"},{"distance":{"text":"194 km","value":193646},"duration":{"text":"1 hour 57 mins","value":7042},"status":"OK"},{"distance":{"text":"2,312 km","value":2311734},"duration":{"text":"20 hours 25 mins","value":73503},"status":"OK"},{"distance":{"text":"547 km","value":546932},"duration":{"text":"5 hours 11 mins","value":18651},"status":"OK"}]},{"elements":[{"distance":{"text":"1,282 km","value":1281616},"duration":{"text":"12 hours 8 mins","value":43678},"status":"OK"},{"distance":{"text":"3,243 km","value":3242543},"duration":{"text":"1 day 5 hours","value":103349},"status":"OK"},{"distance":{"text":"1 m","value":0},"duration":{"text":"1 min","value":0},"status":"OK"},{"distance":{"text":"1,742 km","value":1741571},"duration":{"text":"16 hours 11 mins","value":58255},"status":"OK"},{"distance":{"text":"2,821 km","value":2821137},"duration":{"text":"1 day 2 hours","value":92449},"status":"OK"},{"distance":{"text":"1,220 km","value":1219825},"duration":{"text":"11 hours 27 mins","value":41212},"status":"OK"},{"distance":{"text":"1,997 km","value":1996514},"duration":{"text":"18 hours 4 mins","value":65059},"status":"OK"},{"distance":{"text":"3,342 km","value":3341754},"duration":{"text":"1 day 6 hours","value":106407},"status":"OK"},{"distance":{"text":"1,490 km","value":1489726},"duration":{"text":"14 hours 2 mins","value":50540},"status":"OK"},{"distance":{"text":"3,481 km","value":3480975},"duration":{"text":"1 day 7 hours","value":111989},"status":"OK"}]},{"elements":[{"distance":{"text":"2,624 km","value":2623641},"duration":{"text":"23 hours 58 mins","value":86258},"status":"OK"},{"distance":{"text":"2,488 km","value":2488117},"duration":{"text":"21 hours 49 mins","value":78547},"status":"OK"},{"distance":{"text":"1,742 km","value":1741761},"duration":{"text":"16 hours 13 mins","value":58360},"status":"OK"},{"distance":{"text":"1 m","value":0},"duration":{"text":"1 min","value":0},"status":"OK"},{"distance":{"text":"1,890 km","value":1889580},"duration":{"text":"16 hours 28 mins","value":59289},"status":"OK"},{"distance":{"text":"2,489 km","value":2489250},"duration":{"text":"22 hours 42 mins","value":81704},"status":"OK"},{"distance":{"text":"317 km","value":317168},"duration":{"text":"2 hours 55 mins","value":10481},"status":"OK"},{"distance":{"text":"2,363 km","value":2362972},"duration":{"text":"20 hours 36 mins","value":74158},"status":"OK"},{"distance":{"text":"385 km","value":384812},"duration":{"text":"3 hours 26 mins","value":12385},"status":"OK"},{"distance":{"text":"3,033 km","value":3033431},"duration":{"text":"1 day 3 hours","value":96387},"status":"OK"}]},{"elements":[{"distance":{"text":"3,885 km","value":3884549},"duration":{"text":"1 day 12 hours","value":128892},"status":"OK"},{"distance":{"text":"599 km","value":598636},"duration":{"text":"5 hours 32 mins","value":19898},"status":"OK"},{"distance":{"text":"2,829 km","value":2828868},"duration":{"text":"1 day 2 hours","value":92370},"status":"OK"},{"distance":{"text":"1,893 km","value":1892718},"duration":{"text":"16 hours 31 mins","value":59432},"status":"OK"},{"distance":{"text":"1 m","value":0},"duration":{"text":"1 min","value":0},"status":"OK"},{"distance":{"text":"3,776 km","value":3776390},"duration":{"text":"1 day 11 hours","value":124555},"status":"OK"},{"distance":{"text":"1,578 km","value":1578360},"duration":{"text":"13 hours 46 mins","value":49532},"status":"OK"},{"distance":{"text":"571 km","value":570657},"duration":{"text":"5 hours 17 mins","value":19041},"status":"OK"},{"distance":{"text":"1,713 km","value":1713312},"duration":{"text":"15 hours 8 mins","value":54450},"status":"OK"},{"distance":{"text":"1,144 km","value":1143951},"duration":{"text":"10 hours 29 mins","value":37738},"status":"OK"}]},{"elements":[{"distance":{"text":"159 km","value":158684},"duration":{"text":"1 hour 53 mins","value":6753},"status":"OK"},{"distance":{"text":"4,363 km","value":4362509},"duration":{"text":"1 day 16 hours","value":142324},"status":"OK"},{"distance":{"text":"1,221 km","value":1220728},"duration":{"text":"11 hours 30 mins","value":41424},"status":"OK"},{"distance":{"text":"2,488 km","value":2487984},"duration":{"text":"22 hours 37 mins","value":81429},"status":"OK"},{"distance":{"text":"3,769 km","value":3769346},"duration":{"text":"1 day 11 hours","value":124752},"status":"OK"},{"distance":{"text":"1 m","value":0},"duration":{"text":"1 min","value":0},"status":"OK"},{"distance":{"text":"2,802 km","value":2802129},"duration":{"text":"1 day 1 hour","value":91677},"status":"OK"},{"distance":{"text":"4,337 km","value":4337082},"duration":{"text":"1 day 16 hours","value":143118},"status":"OK"},{"distance":{"text":"2,360 km","value":2359628},"duration":{"text":"21 hours 35 mins","value":77726},"status":"OK"},{"distance":{"text":"4,679 km","value":4678576},"duration":{"text":"1 day 18 hours","value":151879},"status":"OK"}]},{"elements":[{"distance":{"text":"2,939 km","value":2938513},"duration":{"text":"1 day 3 hours","value":96477},"status":"OK"},{"distance":{"text":"2,178 km","value":2178117},"duration":{"text":"19 hours 6 mins","value":68773},"status":"OK"},{"distance":{"text":"1,996 km","value":1996414},"duration":{"text":"18 hours 3 mins","value":64959},"status":"OK"},{"distance":{"text":"318 km","value":317558},"duration":{"text":"2 hours 54 mins","value":10436},"status":"OK"},{"distance":{"text":"1,580 km","value":1579581},"duration":{"text":"13 hours 45 mins","value":49515},"status":"OK"},{"distance":{"text":"2,804 km","value":2804123},"duration":{"text":"1 day 2 hours","value":91923},"status":"OK"},{"distance":{"text":"1 m","value":0},"duration":{"text":"1 min","value":0},"status":"OK"},{"distance":{"text":"2,053 km","value":2052972},"duration":{"text":"17 hours 53 mins","value":64384},"status":"OK"},{"distance":{"text":"440 km","value":440485},"duration":{"text":"4 hours 7 mins","value":14809},"status":"OK"},{"distance":{"text":"2,723 km","value":2723432},"duration":{"text":"1 day 0 hours","value":86613},"status":"OK"}]},{"elements":[{"distance":{"text":"4,450 km","value":4449804},"duration":{"text":"1 day 17 hours","value":147307},"status":"OK"},{"distance":{"text":"193 km","value":193391},"duration":{"text":"2 hours 1 min","value":7257},"status":"OK"},{"distance":{"text":"3,343 km","value":3342861},"duration":{"text":"1 day 6 hours","value":106618},"status":"OK"},{"distance":{"text":"2,365 km","value":2365196},"duration":{"text":"20 hours 39 mins","value":74342},"status":"OK"},{"distance":{"text":"571 km","value":571299},"duration":{"text":"5 hours 20 mins","value":19183},"status":"OK"},{"distance":{"text":"4,342 km","value":4341645},"duration":{"text":"1 day 16 hours","value":142971},"status":"OK"},{"distance":{"text":"2,051 km","value":2050838},"duration":{"text":"17 hours 54 mins","value":64441},"status":"OK"},{"distance":{"text":"1 m","value":0},"duration":{"text":"1 min","value":0},"status":"OK"},{"distance":{"text":"2,186 km","value":2185790},"duration":{"text":"19 hours 16 mins","value":69360},"status":"OK"},{"distance":{"text":"740 km","value":740005},"duration":{"text":"7 hours 6 mins","value":25541},"status":"OK"}]},{"elements":[{"distance":{"text":"2,493 km","value":2492688},"duration":{"text":"22 hours 52 mins","value":82333},"status":"OK"},{"distance":{"text":"2,311 km","value":2310974},"duration":{"text":"20 hours 27 mins","value":73596},"status":"OK"},{"distance":{"text":"1,557 km","value":1556570},"duration":{"text":"14 hours 3 mins","value":50581},"status":"OK"},{"distance":{"text":"385 km","value":385037},"duration":{"text":"3 hours 28 mins","value":12495},"status":"OK"},{"distance":{"text":"1,712 km","value":1712438},"duration":{"text":"15 hours 6 mins","value":54339},"status":"OK"},{"distance":{"text":"2,358 km","value":2358297},"duration":{"text":"21 hours 36 mins","value":77780},"status":"OK"},{"distance":{"text":"441 km","value":440702},"duration":{"text":"4 hours 7 mins","value":14800},"status":"OK"},{"distance":{"text":"2,186 km","value":2185829},"duration":{"text":"19 hours 13 mins","value":69208},"status":"OK"},{"distance":{"text":"1 m","value":0},"duration":{"text":"1 min","value":0},"status":"OK"},{"distance":{"text":"2,716 km","value":2715614},"duration":{"text":"1 day 1 hour","value":89296},"status":"OK"}]},{"elements":[{"distance":{"text":"4,741 km","value":4740819},"duration":{"text":"1 day 19 hours","value":153881},"status":"OK"},{"distance":{"text":"549 km","value":549030},"duration":{"text":"5 hours 11 mins","value":18643},"status":"OK"},{"distance":{"text":"3,483 km","value":3483210},"duration":{"text":"1 day 7 hours","value":111954},"status":"OK"},{"distance":{"text":"3,037 km","value":3036563},"duration":{"text":"1 day 3 hours","value":96326},"status":"OK"},{"distance":{"text":"1,146 km","value":1145736},"duration":{"text":"10 hours 26 mins","value":37580},"status":"OK"},{"distance":{"text":"4,679 km","value":4679027},"duration":{"text":"1 day 18 hours","value":151414},"status":"OK"},{"distance":{"text":"2,722 km","value":2722204},"duration":{"text":"1 day 0 hours","value":86426},"status":"OK"},{"distance":{"text":"740 km","value":739719},"duration":{"text":"7 hours 2 mins","value":25298},"status":"OK"},{"distance":{"text":"2,717 km","value":2717009},"duration":{"text":"1 day 1 hour","value":89209},"status":"OK"},{"distance":{"text":"1 m","value":0},"duration":{"text":"1 min","value":0},"status":"OK"}]}],"status":"OK"}"""
   var compactJsonString2: String = """{"status":"OK","rows":[{"elements":[{"status":"OK","duration":{"value":0,"text":"1 min"},"distance":{"value":0,"text":"1 m"}},{"status":"OK","duration":{"value":145589,"text":"1 day 16 hours"},"distance":{"value":4489862,"text":"4,490 km"}},{"status":"OK","duration":{"value":43773,"text":"12 hours 10 mins"},"distance":{"value":1270445,"text":"1,270 km"}},{"status":"OK","duration":{"value":86073,"text":"23 hours 55 mins"},"distance":{"value":2620658,"text":"2,621 km"}},{"status":"OK","duration":{"value":129040,"text":"1 day 12 hours"},"distance":{"value":3875676,"text":"3,876 km"}},{"status":"OK","duration":{"value":6885,"text":"1 hour 55 mins"},"distance":{"value":158242,"text":"158 km"}},{"status":"OK","duration":{"value":96322,"text":"1 day 3 hours"},"distance":{"value":2934803,"text":"2,935 km"}},{"status":"OK","duration":{"value":147406,"text":"1 day 17 hours"},"distance":{"value":4443412,"text":"4,443 km"}},{"status":"OK","duration":{"value":82371,"text":"22 hours 53 mins"},"distance":{"value":2492302,"text":"2,492 km"}},{"status":"OK","duration":{"value":154228,"text":"1 day 19 hours"},"distance":{"value":4728294,"text":"4,728 km"}}]},{"elements":[{"status":"OK","duration":{"value":145282,"text":"1 day 16 hours"},"distance":{"value":4501326,"text":"4,501 km"}},{"status":"OK","duration":{"value":0,"text":"1 min"},"distance":{"value":0,"text":"1 m"}},{"status":"OK","duration":{"value":103355,"text":"1 day 5 hours"},"distance":{"value":3243718,"text":"3,244 km"}},{"status":"OK","duration":{"value":78485,"text":"21 hours 48 mins"},"distance":{"value":2491140,"text":"2,491 km"}},{"status":"OK","duration":{"value":19738,"text":"5 hours 29 mins"},"distance":{"value":600314,"text":"600 km"}},{"status":"OK","duration":{"value":141933,"text":"1 day 15 hours"},"distance":{"value":4368094,"text":"4,368 km"}},{"status":"OK","duration":{"value":68584,"text":"19 hours 3 mins"},"distance":{"value":2176782,"text":"2,177 km"}},{"status":"OK","duration":{"value":7042,"text":"1 hour 57 mins"},"distance":{"value":193646,"text":"194 km"}},{"status":"OK","duration":{"value":73503,"text":"20 hours 25 mins"},"distance":{"value":2311734,"text":"2,312 km"}},{"status":"OK","duration":{"value":18651,"text":"5 hours 11 mins"},"distance":{"value":546932,"text":"547 km"}}]},{"elements":[{"status":"OK","duration":{"value":43678,"text":"12 hours 8 mins"},"distance":{"value":1281616,"text":"1,282 km"}},{"status":"OK","duration":{"value":103349,"text":"1 day 5 hours"},"distance":{"value":3242543,"text":"3,243 km"}},{"status":"OK","duration":{"value":0,"text":"1 min"},"distance":{"value":0,"text":"1 m"}},{"status":"OK","duration":{"value":58255,"text":"16 hours 11 mins"},"distance":{"value":1741571,"text":"1,742 km"}},{"status":"OK","duration":{"value":92449,"text":"1 day 2 hours"},"distance":{"value":2821137,"text":"2,821 km"}},{"status":"OK","duration":{"value":41212,"text":"11 hours 27 mins"},"distance":{"value":1219825,"text":"1,220 km"}},{"status":"OK","duration":{"value":65059,"text":"18 hours 4 mins"},"distance":{"value":1996514,"text":"1,997 km"}},{"status":"OK","duration":{"value":106407,"text":"1 day 6 hours"},"distance":{"value":3341754,"text":"3,342 km"}},{"status":"OK","duration":{"value":50540,"text":"14 hours 2 mins"},"distance":{"value":1489726,"text":"1,490 km"}},{"status":"OK","duration":{"value":111989,"text":"1 day 7 hours"},"distance":{"value":3480975,"text":"3,481 km"}}]},{"elements":[{"status":"OK","duration":{"value":86258,"text":"23 hours 58 mins"},"distance":{"value":2623641,"text":"2,624 km"}},{"status":"OK","duration":{"value":78547,"text":"21 hours 49 mins"},"distance":{"value":2488117,"text":"2,488 km"}},{"status":"OK","duration":{"value":58360,"text":"16 hours 13 mins"},"distance":{"value":1741761,"text":"1,742 km"}},{"status":"OK","duration":{"value":0,"text":"1 min"},"distance":{"value":0,"text":"1 m"}},{"status":"OK","duration":{"value":59289,"text":"16 hours 28 mins"},"distance":{"value":1889580,"text":"1,890 km"}},{"status":"OK","duration":{"value":81704,"text":"22 hours 42 mins"},"distance":{"value":2489250,"text":"2,489 km"}},{"status":"OK","duration":{"value":10481,"text":"2 hours 55 mins"},"distance":{"value":317168,"text":"317 km"}},{"status":"OK","duration":{"value":74158,"text":"20 hours 36 mins"},"distance":{"value":2362972,"text":"2,363 km"}},{"status":"OK","duration":{"value":12385,"text":"3 hours 26 mins"},"distance":{"value":384812,"text":"385 km"}},{"status":"OK","duration":{"value":96387,"text":"1 day 3 hours"},"distance":{"value":3033431,"text":"3,033 km"}}]},{"elements":[{"status":"OK","duration":{"value":128892,"text":"1 day 12 hours"},"distance":{"value":3884549,"text":"3,885 km"}},{"status":"OK","duration":{"value":19898,"text":"5 hours 32 mins"},"distance":{"value":598636,"text":"599 km"}},{"status":"OK","duration":{"value":92370,"text":"1 day 2 hours"},"distance":{"value":2828868,"text":"2,829 km"}},{"status":"OK","duration":{"value":59432,"text":"16 hours 31 mins"},"distance":{"value":1892718,"text":"1,893 km"}},{"status":"OK","duration":{"value":0,"text":"1 min"},"distance":{"value":0,"text":"1 m"}},{"status":"OK","duration":{"value":124555,"text":"1 day 11 hours"},"distance":{"value":3776390,"text":"3,776 km"}},{"status":"OK","duration":{"value":49532,"text":"13 hours 46 mins"},"distance":{"value":1578360,"text":"1,578 km"}},{"status":"OK","duration":{"value":19041,"text":"5 hours 17 mins"},"distance":{"value":570657,"text":"571 km"}},{"status":"OK","duration":{"value":54450,"text":"15 hours 8 mins"},"distance":{"value":1713312,"text":"1,713 km"}},{"status":"OK","duration":{"value":37738,"text":"10 hours 29 mins"},"distance":{"value":1143951,"text":"1,144 km"}}]},{"elements":[{"status":"OK","duration":{"value":6753,"text":"1 hour 53 mins"},"distance":{"value":158684,"text":"159 km"}},{"status":"OK","duration":{"value":142324,"text":"1 day 16 hours"},"distance":{"value":4362509,"text":"4,363 km"}},{"status":"OK","duration":{"value":41424,"text":"11 hours 30 mins"},"distance":{"value":1220728,"text":"1,221 km"}},{"status":"OK","duration":{"value":81429,"text":"22 hours 37 mins"},"distance":{"value":2487984,"text":"2,488 km"}},{"status":"OK","duration":{"value":124752,"text":"1 day 11 hours"},"distance":{"value":3769346,"text":"3,769 km"}},{"status":"OK","duration":{"value":0,"text":"1 min"},"distance":{"value":0,"text":"1 m"}},{"status":"OK","duration":{"value":91677,"text":"1 day 1 hour"},"distance":{"value":2802129,"text":"2,802 km"}},{"status":"OK","duration":{"value":143118,"text":"1 day 16 hours"},"distance":{"value":4337082,"text":"4,337 km"}},{"status":"OK","duration":{"value":77726,"text":"21 hours 35 mins"},"distance":{"value":2359628,"text":"2,360 km"}},{"status":"OK","duration":{"value":151879,"text":"1 day 18 hours"},"distance":{"value":4678576,"text":"4,679 km"}}]},{"elements":[{"status":"OK","duration":{"value":96477,"text":"1 day 3 hours"},"distance":{"value":2938513,"text":"2,939 km"}},{"status":"OK","duration":{"value":68773,"text":"19 hours 6 mins"},"distance":{"value":2178117,"text":"2,178 km"}},{"status":"OK","duration":{"value":64959,"text":"18 hours 3 mins"},"distance":{"value":1996414,"text":"1,996 km"}},{"status":"OK","duration":{"value":10436,"text":"2 hours 54 mins"},"distance":{"value":317558,"text":"318 km"}},{"status":"OK","duration":{"value":49515,"text":"13 hours 45 mins"},"distance":{"value":1579581,"text":"1,580 km"}},{"status":"OK","duration":{"value":91923,"text":"1 day 2 hours"},"distance":{"value":2804123,"text":"2,804 km"}},{"status":"OK","duration":{"value":0,"text":"1 min"},"distance":{"value":0,"text":"1 m"}},{"status":"OK","duration":{"value":64384,"text":"17 hours 53 mins"},"distance":{"value":2052972,"text":"2,053 km"}},{"status":"OK","duration":{"value":14809,"text":"4 hours 7 mins"},"distance":{"value":440485,"text":"440 km"}},{"status":"OK","duration":{"value":86613,"text":"1 day 0 hours"},"distance":{"value":2723432,"text":"2,723 km"}}]},{"elements":[{"status":"OK","duration":{"value":147307,"text":"1 day 17 hours"},"distance":{"value":4449804,"text":"4,450 km"}},{"status":"OK","duration":{"value":7257,"text":"2 hours 1 min"},"distance":{"value":193391,"text":"193 km"}},{"status":"OK","duration":{"value":106618,"text":"1 day 6 hours"},"distance":{"value":3342861,"text":"3,343 km"}},{"status":"OK","duration":{"value":74342,"text":"20 hours 39 mins"},"distance":{"value":2365196,"text":"2,365 km"}},{"status":"OK","duration":{"value":19183,"text":"5 hours 20 mins"},"distance":{"value":571299,"text":"571 km"}},{"status":"OK","duration":{"value":142971,"text":"1 day 16 hours"},"distance":{"value":4341645,"text":"4,342 km"}},{"status":"OK","duration":{"value":64441,"text":"17 hours 54 mins"},"distance":{"value":2050838,"text":"2,051 km"}},{"status":"OK","duration":{"value":0,"text":"1 min"},"distance":{"value":0,"text":"1 m"}},{"status":"OK","duration":{"value":69360,"text":"19 hours 16 mins"},"distance":{"value":2185790,"text":"2,186 km"}},{"status":"OK","duration":{"value":25541,"text":"7 hours 6 mins"},"distance":{"value":740005,"text":"740 km"}}]},{"elements":[{"status":"OK","duration":{"value":82333,"text":"22 hours 52 mins"},"distance":{"value":2492688,"text":"2,493 km"}},{"status":"OK","duration":{"value":73596,"text":"20 hours 27 mins"},"distance":{"value":2310974,"text":"2,311 km"}},{"status":"OK","duration":{"value":50581,"text":"14 hours 3 mins"},"distance":{"value":1556570,"text":"1,557 km"}},{"status":"OK","duration":{"value":12495,"text":"3 hours 28 mins"},"distance":{"value":385037,"text":"385 km"}},{"status":"OK","duration":{"value":54339,"text":"15 hours 6 mins"},"distance":{"value":1712438,"text":"1,712 km"}},{"status":"OK","duration":{"value":77780,"text":"21 hours 36 mins"},"distance":{"value":2358297,"text":"2,358 km"}},{"status":"OK","duration":{"value":14800,"text":"4 hours 7 mins"},"distance":{"value":440702,"text":"441 km"}},{"status":"OK","duration":{"value":69208,"text":"19 hours 13 mins"},"distance":{"value":2185829,"text":"2,186 km"}},{"status":"OK","duration":{"value":0,"text":"1 min"},"distance":{"value":0,"text":"1 m"}},{"status":"OK","duration":{"value":89296,"text":"1 day 1 hour"},"distance":{"value":2715614,"text":"2,716 km"}}]},{"elements":[{"status":"OK","duration":{"value":153881,"text":"1 day 19 hours"},"distance":{"value":4740819,"text":"4,741 km"}},{"status":"OK","duration":{"value":18643,"text":"5 hours 11 mins"},"distance":{"value":549030,"text":"549 km"}},{"status":"OK","duration":{"value":111954,"text":"1 day 7 hours"},"distance":{"value":3483210,"text":"3,483 km"}},{"status":"OK","duration":{"value":96326,"text":"1 day 3 hours"},"distance":{"value":3036563,"text":"3,037 km"}},{"status":"OK","duration":{"value":37580,"text":"10 hours 26 mins"},"distance":{"value":1145736,"text":"1,146 km"}},{"status":"OK","duration":{"value":151414,"text":"1 day 18 hours"},"distance":{"value":4679027,"text":"4,679 km"}},{"status":"OK","duration":{"value":86426,"text":"1 day 0 hours"},"distance":{"value":2722204,"text":"2,722 km"}},{"status":"OK","duration":{"value":25298,"text":"7 hours 2 mins"},"distance":{"value":739719,"text":"740 km"}},{"status":"OK","duration":{"value":89209,"text":"1 day 1 hour"},"distance":{"value":2717009,"text":"2,717 km"}},{"status":"OK","duration":{"value":0,"text":"1 min"},"distance":{"value":0,"text":"1 m"}}]}],"origin_addresses":["New York, NY, USA","Los Angeles, CA, USA","Chicago, IL, USA","Houston, TX, USA","Phoenix, AZ, USA","Philadelphia, PA, USA","San Antonio, TX, USA","San Diego, CA, USA","Dallas, TX, USA","San Jose, CA, USA"],"destination_addresses":["New York, NY, USA","Los Angeles, CA, USA","Chicago, IL, USA","Houston, TX, USA","Phoenix, AZ, USA","Philadelphia, PA, USA","San Antonio, TX, USA","San Diego, CA, USA","Dallas, TX, USA","San Jose, CA, USA"]}"""
 

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrinting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIPrettyPrinting.scala
@@ -37,6 +37,24 @@ class GoogleMapsAPIPrettyPrinting extends GoogleMapsAPIBenchmark {
 
     jacksonPrettyMapper.writeValueAsBytes(obj)
   }
+/* FIXME: json4s.jackson pretty prints array elements in the same line
+  @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    writePretty(obj).getBytes(UTF_8)
+  }
+*/
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    writePretty(obj).getBytes(UTF_8)
+  }
 
   @Benchmark
   def jsoniterScala(): Array[Byte] = {

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIReading.scala
@@ -63,6 +63,26 @@ class GoogleMapsAPIReading extends GoogleMapsAPIBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): DistanceMatrix = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[DistanceMatrix]
+  }
+
+  @Benchmark
+  def json4sNative(): DistanceMatrix = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[DistanceMatrix]
+  }
+
+  @Benchmark
   def jsoniterScala(): DistanceMatrix = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/GoogleMapsAPIWriting.scala
@@ -53,6 +53,24 @@ class GoogleMapsAPIWriting extends GoogleMapsAPIBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansReading.scala
@@ -53,7 +53,28 @@ class IntMapOfBooleansReading extends IntMapOfBooleansBenchmark {
 
     jacksonMapper.readValue[IntMap[Boolean]](jsonBytes)
   }
+/* FIXME: json4s.jackson throws org.json4s.MappingException: unknown error
+  @Benchmark
+  def json4sJackson(): IntMap[Boolean] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
 
+    parse(new String(jsonBytes, UTF_8)).extract[IntMap[Boolean]]
+  }
+*/
+/* FIXME: json4s.jackson throws org.json4s.MappingException: unknown error
+  @Benchmark
+  def json4sNative(): IntMap[Boolean] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[IntMap[Boolean]]
+  }
+*/
   @Benchmark
   def jsoniterScala(): IntMap[Boolean] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntMapOfBooleansWriting.scala
@@ -46,6 +46,24 @@ class IntMapOfBooleansWriting extends IntMapOfBooleansBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntReading.scala
@@ -53,6 +53,26 @@ class IntReading extends IntBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Int = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Int]
+  }
+/* FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+  @Benchmark
+  def json4sNative(): Int = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Int]
+  }
+*/
+  @Benchmark
   def jsoniterScala(): Int = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/IntWriting.scala
@@ -51,6 +51,24 @@ class IntWriting extends IntBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(Int.box(obj)).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Json4sFormats.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/Json4sFormats.scala
@@ -1,0 +1,107 @@
+package com.github.plokhotnyuk.jsoniter_scala.benchmark
+
+import com.github.plokhotnyuk.jsoniter_scala.benchmark.SuitEnum.SuitEnum
+import org.json4s._
+import java.time._
+import java.util.{Base64, UUID}
+import java.util.concurrent.ConcurrentHashMap
+import scala.reflect.ClassTag
+
+object Json4sFormats {
+  implicit val customFormats: Formats =
+    new DefaultFormats  {
+      override val typeHints: TypeHints =
+        ShortTypeHints(List(classOf[ADTBase], classOf[GeoJSON.GeoJSON], classOf[GeoJSON.SimpleGeoJSON]), "type")
+    }.skippingEmptyValues +
+    StringifiedFormats.stringified[Char](x => if (x.length == 1) x.charAt(0) else sys.error("char")) +
+    StringifiedFormats.stringified[Duration](Duration.parse) +
+    StringifiedFormats.stringified[Instant](Instant.parse) +
+    StringifiedFormats.stringified[LocalDate](LocalDate.parse) +
+    StringifiedFormats.stringified[LocalDateTime](LocalDateTime.parse) +
+    StringifiedFormats.stringified[LocalTime](LocalTime.parse) +
+    StringifiedFormats.stringified[MonthDay](MonthDay.parse) +
+    StringifiedFormats.stringified[OffsetDateTime](OffsetDateTime.parse) +
+    StringifiedFormats.stringified[OffsetTime](OffsetTime.parse) +
+    StringifiedFormats.stringified[Period](Period.parse) +
+    StringifiedFormats.stringified[UUID](UUID.fromString) +
+    StringifiedFormats.stringified[Year](Year.parse) +
+    StringifiedFormats.stringified[YearMonth](YearMonth.parse) +
+    StringifiedFormats.stringified[ZonedDateTime](ZonedDateTime.parse) +
+    StringifiedFormats.stringified[ZoneId](ZoneId.of) +
+    StringifiedFormats.stringified[ZoneOffset](ZoneOffset.of) +
+    StringifiedFormats.stringified[Suit](Suit.valueOf) +
+    StringifiedFormats.stringified[SuitADT] {
+      val suite = Map(
+        "Hearts" -> Hearts,
+        "Spades" -> Spades,
+        "Diamonds" -> Diamonds,
+        "Clubs" -> Clubs)
+      x => suite(x)
+    } +
+    StringifiedFormats.stringified[SuitEnum] {
+      val ec = new ConcurrentHashMap[String, SuitEnum]
+      x => {
+        var v = ec.get(x)
+        if (v eq null) {
+          v = SuitEnum.values.iterator.find(_.toString == x).getOrElse(sys.error("SuitEnum"))
+          ec.put(x, v)
+        }
+        v
+      }
+    } + new CustomSerializer[Tuple2[Double, Double]](_ => ({
+      case JArray(JDouble(x) :: JDouble(y) :: Nil) => new Tuple2[Double, Double](x, y)
+    }, {
+      case x: Tuple2[Double, Double] => JArray(JDouble(x._1) :: JDouble(x._2) :: Nil)
+    })) + new CustomSerializer[ByteVal](_ => ({
+      case JInt(x) if x.isValidByte => new ByteVal(x.toByte)
+    }, {
+      case x: ByteVal => JInt(x.a)
+    })) + new CustomSerializer[ShortVal](_ => ({
+      case JInt(x) if x.isValidShort => new ShortVal(x.toShort)
+    }, {
+      case x: ShortVal => JInt(x.a)
+    })) + new CustomSerializer[IntVal](_ => ({
+      case JInt(x) if x.isValidInt => new IntVal(x.toInt)
+    }, {
+      case x: IntVal => JInt(x.a)
+    })) + new CustomSerializer[LongVal](_ => ({
+      case JInt(x) if x.isValidLong => new LongVal(x.toInt)
+    }, {
+      case x: LongVal => JInt(x.a)
+    })) + new CustomSerializer[FloatVal](_ => ({
+      case JDecimal(x) => new FloatVal(x.toFloat)
+    }, {
+      case x: FloatVal => JDecimal(x.a)
+    })) + new CustomSerializer[DoubleVal](_ => ({
+      case JDouble(x) => new DoubleVal(x.toFloat)
+    }, {
+      case x: DoubleVal => JDecimal(x.a)
+    })) + new CustomSerializer[CharVal](_ => ({
+      case JString(x) if x.length == 1 => new CharVal(x.charAt(0))
+    }, {
+      case x: CharVal => JString(x.a.toString)
+    }))
+}
+
+object GitHubActionsAPIJson4sFormats {
+  implicit val gitHubActionsAPIFormats: Formats = Json4sFormats.customFormats +
+    StringifiedFormats.stringified[Boolean](java.lang.Boolean.parseBoolean)
+}
+
+object Base64Json4sFormats {
+  implicit val base64Formats: Formats = DefaultFormats +
+    StringifiedFormats.stringified[Array[Byte]](Base64.getDecoder.decode, Base64.getEncoder.encodeToString)
+}
+
+object EscapeUnicodeJson4sFormats {
+  implicit val escapeUnicodeFormats: Formats = DefaultFormats.withEscapeUnicode
+}
+
+object StringifiedFormats {
+  def stringified[A: ClassTag](f: String => A, g: A => String = (x: A) => x.toString): CustomSerializer[A] =
+    new CustomSerializer[A](_ => ({
+      case JString(s) => f(s)
+    }, {
+      case x: A => JString(g(x))
+    }))
+}

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansReading.scala
@@ -55,6 +55,26 @@ class ListOfBooleansReading extends ListOfBooleansBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): List[Boolean] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[List[Boolean]]
+  }
+
+  @Benchmark
+  def json4sNative(): List[Boolean] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[List[Boolean]]
+  }
+
+  @Benchmark
   def jsoniterScala(): List[Boolean] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/ListOfBooleansWriting.scala
@@ -51,6 +51,24 @@ class ListOfBooleansWriting extends ListOfBooleansBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansReading.scala
@@ -50,6 +50,26 @@ class MapOfIntsToBooleansReading extends MapOfIntsToBooleansBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Map[Int, Boolean] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Map[Int, Boolean]]
+  }
+
+  @Benchmark
+  def json4sNative(): Map[Int, Boolean] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Map[Int, Boolean]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Map[Int, Boolean] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MapOfIntsToBooleansWriting.scala
@@ -44,6 +44,24 @@ class MapOfIntsToBooleansWriting extends MapOfIntsToBooleansBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MissingRequiredFieldsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MissingRequiredFieldsReading.scala
@@ -82,6 +82,34 @@ class MissingRequiredFieldsReading extends MissingRequiredFieldsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): String = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    try {
+      parse(new String(jsonBytes, UTF_8)).extract[MissingRequiredFields].toString// toString shouldn't be called
+    } catch {
+      case ex: MappingException => ex.getMessage
+    }
+  }
+
+  @Benchmark
+  def json4sNative(): String = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    try {
+      parse(new String(jsonBytes, UTF_8)).extract[MissingRequiredFields].toString// toString shouldn't be called
+    } catch {
+      case ex: MappingException => ex.getMessage
+    }
+  }
+
+  @Benchmark
   def jsoniterScala(): String = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansReading.scala
@@ -53,7 +53,28 @@ class MutableLongMapOfBooleansReading extends MutableLongMapOfBooleansBenchmark 
 
     jacksonMapper.readValue[mutable.LongMap[Boolean]](jsonBytes)
   }
+/* FIXME: json4s.jackson throws org.json4s.MappingException: unknown error
+  @Benchmark
+  def json4sJackson(): mutable.LongMap[Boolean] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
 
+    parse(new String(jsonBytes, UTF_8)).extract[mutable.LongMap[Boolean]]
+  }
+*/
+/* FIXME: json4s.jackson throws org.json4s.MappingException: unknown error
+  @Benchmark
+  def json4sNative(): mutable.LongMap[Boolean] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[mutable.LongMap[Boolean]]
+  }
+*/
   @Benchmark
   def jsoniterScala(): mutable.LongMap[Boolean] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableLongMapOfBooleansWriting.scala
@@ -46,6 +46,24 @@ class MutableLongMapOfBooleansWriting extends MutableLongMapOfBooleansBenchmark 
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansReading.scala
@@ -50,6 +50,26 @@ class MutableMapOfIntsToBooleansReading extends MutableMapOfIntsToBooleansBenchm
   }
 
   @Benchmark
+  def json4sJackson(): mutable.Map[Int, Boolean] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[mutable.Map[Int, Boolean]]
+  }
+
+  @Benchmark
+  def json4sNative(): mutable.Map[Int, Boolean] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[mutable.Map[Int, Boolean]]
+  }
+
+  @Benchmark
   def jsoniterScala(): mutable.Map[Int, Boolean] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableMapOfIntsToBooleansWriting.scala
@@ -44,6 +44,24 @@ class MutableMapOfIntsToBooleansWriting extends MutableMapOfIntsToBooleansBenchm
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsReading.scala
@@ -58,6 +58,26 @@ class MutableSetOfIntsReading extends MutableSetOfIntsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): mutable.Set[Int] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[mutable.Set[Int]]
+  }
+
+  @Benchmark
+  def json4sNative(): mutable.Set[Int] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[mutable.Set[Int]]
+  }
+
+  @Benchmark
   def jsoniterScala(): mutable.Set[Int] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/MutableSetOfIntsWriting.scala
@@ -51,6 +51,24 @@ class MutableSetOfIntsWriting extends MutableSetOfIntsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsReading.scala
@@ -62,6 +62,26 @@ class NestedStructsReading extends NestedStructsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): NestedStructs = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[NestedStructs]
+  }
+
+  @Benchmark
+  def json4sNative(): NestedStructs = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[NestedStructs]
+  }
+
+  @Benchmark
   def jsoniterScala(): NestedStructs = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/NestedStructsWriting.scala
@@ -54,6 +54,24 @@ class NestedStructsWriting extends NestedStructsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/OpenRTBReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/OpenRTBReading.scala
@@ -56,6 +56,26 @@ class OpenRTBReading extends OpenRTBBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): BidRequest = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[BidRequest]
+  }
+
+  @Benchmark
+  def json4sNative(): BidRequest = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[BidRequest]
+  }
+
+  @Benchmark
   def jsoniterScala(): BidRequest = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/OpenRTBWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/OpenRTBWriting.scala
@@ -36,6 +36,26 @@ class OpenRTBWriting extends OpenRTBBenchmark {
     jacksonMapper.writeValueAsBytes(obj)
   }
 */
+/* FIXME: json4s.jackson serializes fields with default values
+  @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+*/
+/* FIXME: json4s.native serializes fields with default values
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+*/
   @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesReading.scala
@@ -62,6 +62,26 @@ class PrimitivesReading extends PrimitivesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Primitives = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Primitives]
+  }
+
+  @Benchmark
+  def json4sNative(): Primitives = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Primitives]
+  }
+
+  @Benchmark
   def jsoniterScala(): Primitives = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/PrimitivesWriting.scala
@@ -54,6 +54,24 @@ class PrimitivesWriting extends PrimitivesBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsReading.scala
@@ -57,6 +57,26 @@ class SetOfIntsReading extends SetOfIntsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Set[Int] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Set[Int]]
+  }
+
+  @Benchmark
+  def json4sNative(): Set[Int] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Set[Int]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Set[Int] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/SetOfIntsWriting.scala
@@ -51,6 +51,24 @@ class SetOfIntsWriting extends SetOfIntsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsReading.scala
@@ -57,6 +57,26 @@ class StringOfAsciiCharsReading extends StringOfAsciiCharsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): String = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[String]
+  }
+/* FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+  @Benchmark
+  def json4sNative(): String = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[String]
+  }
+*/
+  @Benchmark
   def jsoniterScala(): String = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfAsciiCharsWriting.scala
@@ -51,6 +51,24 @@ class StringOfAsciiCharsWriting extends StringOfAsciiCharsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsReading.scala
@@ -55,6 +55,26 @@ class StringOfEscapedCharsReading extends StringOfEscapedCharsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): String = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[String]
+  }
+/* FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+  @Benchmark
+  def json4sNative(): String = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[String]
+  }
+*/
+  @Benchmark
   def jsoniterScala(): String = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfEscapedCharsWriting.scala
@@ -34,7 +34,26 @@ class StringOfEscapedCharsWriting extends StringOfEscapedCharsBenchmark {
 
     jacksonEscapeNonAsciiMapper.writeValueAsBytes(obj)
   }
+/* FIXME: json4s.jackson doesn't escape unicode
+  @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.EscapeUnicodeJson4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
 
+    write(obj).getBytes(UTF_8)
+  }
+*/
+/*  FIXME: json4s.native doesn't escape unicode
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.EscapeUnicodeJson4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+*/
   @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsReading.scala
@@ -57,6 +57,26 @@ class StringOfNonAsciiCharsReading extends StringOfNonAsciiCharsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): String = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[String]
+  }
+/* FIXME: json4s.native throws org.json4s.ParserUtil$ParseException: expected field or array
+  @Benchmark
+  def json4sNative(): String = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[String]
+  }
+*/
+  @Benchmark
   def jsoniterScala(): String = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/StringOfNonAsciiCharsWriting.scala
@@ -49,6 +49,24 @@ class StringOfNonAsciiCharsWriting extends StringOfNonAsciiCharsBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+/* FIXME: json4s.native writes escaped codes instead of UTF-8 bytes
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+*/
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIReading.scala
@@ -63,6 +63,26 @@ class TwitterAPIReading extends TwitterAPIBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Seq[Tweet] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Seq[Tweet]]
+  }
+
+  @Benchmark
+  def json4sNative(): Seq[Tweet] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Seq[Tweet]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Seq[Tweet] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/TwitterAPIWriting.scala
@@ -54,7 +54,26 @@ class TwitterAPIWriting extends TwitterAPIBenchmark {
 
     jacksonMapper.writeValueAsBytes(obj)
   }
+/* FIXME: json4s.jackson serializes empty collections
+  @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
 
+    write(obj).getBytes(UTF_8)
+  }
+*/
+/* FIXME: json4s.native serializes empty collections
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+*/
   @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReading.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansReading.scala
@@ -57,6 +57,26 @@ class VectorOfBooleansReading extends VectorOfBooleansBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Vector[Boolean] = {
+    import org.json4s._
+    import org.json4s.jackson.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Vector[Boolean]]
+  }
+
+  @Benchmark
+  def json4sNative(): Vector[Boolean] = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    parse(new String(jsonBytes, UTF_8)).extract[Vector[Boolean]]
+  }
+
+  @Benchmark
   def jsoniterScala(): Vector[Boolean] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._

--- a/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansWriting.scala
+++ b/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark/VectorOfBooleansWriting.scala
@@ -51,6 +51,24 @@ class VectorOfBooleansWriting extends VectorOfBooleansBenchmark {
   }
 
   @Benchmark
+  def json4sJackson(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.jackson.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
+  def json4sNative(): Array[Byte] = {
+    import com.github.plokhotnyuk.jsoniter_scala.benchmark.Json4sFormats._
+    import org.json4s.native.Serialization._
+    import java.nio.charset.StandardCharsets.UTF_8
+
+    write(obj).getBytes(UTF_8)
+  }
+
+  @Benchmark
   def jsoniterScala(): Array[Byte] = {
     import com.github.plokhotnyuk.jsoniter_scala.benchmark.JsoniterScalaCodecs._
     import com.github.plokhotnyuk.jsoniter_scala.core._


### PR DESCRIPTION
It looks that json4s is the slowest JSON parser and serializer tested by this benchmark suite

<details>
<summary><b>Results from JDK 17</b> (Intel® Core™ i9-11900H CPU @ 2.5GHz (max 4.9GHz), RAM 32Gb DDR4-3200, Ubuntu 22.04)</summary>

```
[info] Benchmark                                                                         (size)   Mode  Cnt        Score         Error   Units
[info] AnyValsReading.json4sJackson                                                         N/A  thrpt    5   420903.211 ±    4599.407   ops/s
[info] AnyValsReading.json4sJackson:·gc.alloc.rate                                          N/A  thrpt    5     2459.236 ±      26.976  MB/sec
[info] AnyValsReading.json4sJackson:·gc.alloc.rate.norm                                     N/A  thrpt    5     6128.218 ±       0.157    B/op
[info] AnyValsReading.json4sJackson:·gc.churn.PS_Eden_Space                                 N/A  thrpt    5     2456.459 ±    1322.145  MB/sec
[info] AnyValsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                            N/A  thrpt    5     6121.716 ±    3310.718    B/op
[info] AnyValsReading.json4sJackson:·gc.churn.PS_Survivor_Space                             N/A  thrpt    5        1.638 ±      13.368  MB/sec
[info] AnyValsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                        N/A  thrpt    5        4.101 ±      33.467    B/op
[info] AnyValsReading.json4sJackson:·gc.count                                               N/A  thrpt    5       16.000                counts
[info] AnyValsReading.json4sJackson:·gc.time                                                N/A  thrpt    5       11.000                    ms
[info] AnyValsReading.json4sNative                                                          N/A  thrpt    5   362757.048 ±    3251.188   ops/s
[info] AnyValsReading.json4sNative:·gc.alloc.rate                                           N/A  thrpt    5     2830.621 ±      25.175  MB/sec
[info] AnyValsReading.json4sNative:·gc.alloc.rate.norm                                      N/A  thrpt    5     8184.265 ±       0.157    B/op
[info] AnyValsReading.json4sNative:·gc.churn.PS_Eden_Space                                  N/A  thrpt    5     2763.597 ±    1619.112  MB/sec
[info] AnyValsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                             N/A  thrpt    5     7991.393 ±    4708.310    B/op
[info] AnyValsReading.json4sNative:·gc.churn.PS_Survivor_Space                              N/A  thrpt    5        0.075 ±       0.219  MB/sec
[info] AnyValsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                         N/A  thrpt    5        0.217 ±       0.632    B/op
[info] AnyValsReading.json4sNative:·gc.count                                                N/A  thrpt    5       18.000                counts
[info] AnyValsReading.json4sNative:·gc.time                                                 N/A  thrpt    5        9.000                    ms
[info] AnyValsWriting.json4sJackson                                                         N/A  thrpt    5   209519.863 ±    3979.438   ops/s
[info] AnyValsWriting.json4sJackson:·gc.alloc.rate                                          N/A  thrpt    5     4369.305 ±      83.110  MB/sec
[info] AnyValsWriting.json4sJackson:·gc.alloc.rate.norm                                     N/A  thrpt    5    21872.709 ±       0.276    B/op
[info] AnyValsWriting.json4sJackson:·gc.churn.PS_Eden_Space                                 N/A  thrpt    5     4298.720 ±    1618.512  MB/sec
[info] AnyValsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                            N/A  thrpt    5    21523.049 ±    8267.288    B/op
[info] AnyValsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                             N/A  thrpt    5        0.125 ±       0.190  MB/sec
[info] AnyValsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                        N/A  thrpt    5        0.625 ±       0.945    B/op
[info] AnyValsWriting.json4sJackson:·gc.count                                               N/A  thrpt    5       28.000                counts
[info] AnyValsWriting.json4sJackson:·gc.time                                                N/A  thrpt    5       14.000                    ms
[info] AnyValsWriting.json4sNative                                                          N/A  thrpt    5   202683.783 ±    1255.990   ops/s
[info] AnyValsWriting.json4sNative:·gc.alloc.rate                                           N/A  thrpt    5     4004.195 ±      24.862  MB/sec
[info] AnyValsWriting.json4sNative:·gc.alloc.rate.norm                                      N/A  thrpt    5    20720.707 ±       0.270    B/op
[info] AnyValsWriting.json4sNative:·gc.churn.PS_Eden_Space                                  N/A  thrpt    5     4145.366 ±    1618.637  MB/sec
[info] AnyValsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                             N/A  thrpt    5    21451.427 ±    8384.603    B/op
[info] AnyValsWriting.json4sNative:·gc.churn.PS_Survivor_Space                              N/A  thrpt    5        0.081 ±       0.201  MB/sec
[info] AnyValsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                         N/A  thrpt    5        0.420 ±       1.042    B/op
[info] AnyValsWriting.json4sNative:·gc.count                                                N/A  thrpt    5       27.000                counts
[info] AnyValsWriting.json4sNative:·gc.time                                                 N/A  thrpt    5       15.000                    ms
[info] ArrayBufferOfBooleansReading.json4sJackson                                           128  thrpt    5    98079.688 ±    2308.920   ops/s
[info] ArrayBufferOfBooleansReading.json4sJackson:·gc.alloc.rate                            128  thrpt    5     1442.371 ±      33.964  MB/sec
[info] ArrayBufferOfBooleansReading.json4sJackson:·gc.alloc.rate.norm                       128  thrpt    5    15424.559 ±       0.840    B/op
[info] ArrayBufferOfBooleansReading.json4sJackson:·gc.churn.PS_Eden_Space                   128  thrpt    5     1381.732 ±    1321.904  MB/sec
[info] ArrayBufferOfBooleansReading.json4sJackson:·gc.churn.PS_Eden_Space.norm              128  thrpt    5    14758.982 ±   13910.416    B/op
[info] ArrayBufferOfBooleansReading.json4sJackson:·gc.churn.PS_Survivor_Space               128  thrpt    5        1.599 ±      13.310  MB/sec
[info] ArrayBufferOfBooleansReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm          128  thrpt    5       17.031 ±     141.753    B/op
[info] ArrayBufferOfBooleansReading.json4sJackson:·gc.count                                 128  thrpt    5        9.000                counts
[info] ArrayBufferOfBooleansReading.json4sJackson:·gc.time                                  128  thrpt    5       14.000                    ms
[info] ArrayBufferOfBooleansReading.json4sNative                                            128  thrpt    5    88143.770 ±    2222.799   ops/s
[info] ArrayBufferOfBooleansReading.json4sNative:·gc.alloc.rate                             128  thrpt    5     2140.092 ±      53.898  MB/sec
[info] ArrayBufferOfBooleansReading.json4sNative:·gc.alloc.rate.norm                        128  thrpt    5    25464.932 ±       0.959    B/op
[info] ArrayBufferOfBooleansReading.json4sNative:·gc.churn.PS_Eden_Space                    128  thrpt    5     2149.501 ±    1322.020  MB/sec
[info] ArrayBufferOfBooleansReading.json4sNative:·gc.churn.PS_Eden_Space.norm               128  thrpt    5    25584.799 ±   15911.020    B/op
[info] ArrayBufferOfBooleansReading.json4sNative:·gc.churn.PS_Survivor_Space                128  thrpt    5        1.369 ±      10.846  MB/sec
[info] ArrayBufferOfBooleansReading.json4sNative:·gc.churn.PS_Survivor_Space.norm           128  thrpt    5       16.355 ±     129.695    B/op
[info] ArrayBufferOfBooleansReading.json4sNative:·gc.count                                  128  thrpt    5       14.000                counts
[info] ArrayBufferOfBooleansReading.json4sNative:·gc.time                                   128  thrpt    5        9.000                    ms
[info] ArrayBufferOfBooleansWriting.json4sJackson                                           128  thrpt    5    24320.059 ±     676.762   ops/s
[info] ArrayBufferOfBooleansWriting.json4sJackson:·gc.alloc.rate                            128  thrpt    5     5145.643 ±     144.021  MB/sec
[info] ArrayBufferOfBooleansWriting.json4sJackson:·gc.alloc.rate.norm                       128  thrpt    5   221911.411 ±       1.925    B/op
[info] ArrayBufferOfBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space                   128  thrpt    5     5219.992 ±    1321.922  MB/sec
[info] ArrayBufferOfBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm              128  thrpt    5   225129.923 ±   57550.484    B/op
[info] ArrayBufferOfBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space               128  thrpt    5        0.244 ±       0.693  MB/sec
[info] ArrayBufferOfBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm          128  thrpt    5       10.505 ±      29.821    B/op
[info] ArrayBufferOfBooleansWriting.json4sJackson:·gc.count                                 128  thrpt    5       34.000                counts
[info] ArrayBufferOfBooleansWriting.json4sJackson:·gc.time                                  128  thrpt    5       15.000                    ms
[info] ArrayBufferOfBooleansWriting.json4sNative                                            128  thrpt    5    23369.647 ±     416.611   ops/s
[info] ArrayBufferOfBooleansWriting.json4sNative:·gc.alloc.rate                             128  thrpt    5     4920.053 ±      87.247  MB/sec
[info] ArrayBufferOfBooleansWriting.json4sNative:·gc.alloc.rate.norm                        128  thrpt    5   220799.486 ±       2.491    B/op
[info] ArrayBufferOfBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space                    128  thrpt    5     5065.970 ±    1616.886  MB/sec
[info] ArrayBufferOfBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space.norm               128  thrpt    5   227385.456 ±   74542.677    B/op
[info] ArrayBufferOfBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space                128  thrpt    5        0.244 ±       0.365  MB/sec
[info] ArrayBufferOfBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm           128  thrpt    5       10.929 ±      16.298    B/op
[info] ArrayBufferOfBooleansWriting.json4sNative:·gc.count                                  128  thrpt    5       33.000                counts
[info] ArrayBufferOfBooleansWriting.json4sNative:·gc.time                                   128  thrpt    5       17.000                    ms
[info] ArrayOfBigDecimalsWriting.json4sNative                                               128  thrpt    5    15318.990 ±     427.960   ops/s
[info] ArrayOfBigDecimalsWriting.json4sNative:·gc.alloc.rate                                128  thrpt    5     4576.525 ±     127.738  MB/sec
[info] ArrayOfBigDecimalsWriting.json4sNative:·gc.alloc.rate.norm                           128  thrpt    5   313322.389 ±       0.293    B/op
[info] ArrayOfBigDecimalsWriting.json4sNative:·gc.churn.PS_Eden_Space                       128  thrpt    5     4606.123 ±       0.909  MB/sec
[info] ArrayOfBigDecimalsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                  128  thrpt    5   315361.997 ±    8762.247    B/op
[info] ArrayOfBigDecimalsWriting.json4sNative:·gc.churn.PS_Survivor_Space                   128  thrpt    5        0.231 ±       0.470  MB/sec
[info] ArrayOfBigDecimalsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm              128  thrpt    5       15.861 ±      32.369    B/op
[info] ArrayOfBigDecimalsWriting.json4sNative:·gc.count                                     128  thrpt    5       30.000                counts
[info] ArrayOfBigDecimalsWriting.json4sNative:·gc.time                                      128  thrpt    5       14.000                    ms
[info] ArrayOfBigIntsReading.json4sJackson                                                  128  thrpt    5    28443.430 ±     435.878   ops/s
[info] ArrayOfBigIntsReading.json4sJackson:·gc.alloc.rate                                   128  thrpt    5     1745.934 ±      26.774  MB/sec
[info] ArrayOfBigIntsReading.json4sJackson:·gc.alloc.rate.norm                              128  thrpt    5    64378.300 ±       2.278    B/op
[info] ArrayOfBigIntsReading.json4sJackson:·gc.churn.PS_Eden_Space                          128  thrpt    5     1688.946 ±    1321.841  MB/sec
[info] ArrayOfBigIntsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5    62258.920 ±   48179.768    B/op
[info] ArrayOfBigIntsReading.json4sJackson:·gc.churn.PS_Survivor_Space                      128  thrpt    5        1.586 ±      13.284  MB/sec
[info] ArrayOfBigIntsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5       58.481 ±     489.860    B/op
[info] ArrayOfBigIntsReading.json4sJackson:·gc.count                                        128  thrpt    5       11.000                counts
[info] ArrayOfBigIntsReading.json4sJackson:·gc.time                                         128  thrpt    5       11.000                    ms
[info] ArrayOfBigIntsReading.json4sNative                                                   128  thrpt    5    25047.002 ±     394.171   ops/s
[info] ArrayOfBigIntsReading.json4sNative:·gc.alloc.rate                                    128  thrpt    5     1891.311 ±      29.623  MB/sec
[info] ArrayOfBigIntsReading.json4sNative:·gc.alloc.rate.norm                               128  thrpt    5    79194.844 ±       4.186    B/op
[info] ArrayOfBigIntsReading.json4sNative:·gc.churn.PS_Eden_Space                           128  thrpt    5     1842.408 ±    1619.113  MB/sec
[info] ArrayOfBigIntsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5    77176.736 ±   68460.254    B/op
[info] ArrayOfBigIntsReading.json4sNative:·gc.churn.PS_Survivor_Space                       128  thrpt    5        1.344 ±      10.897  MB/sec
[info] ArrayOfBigIntsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5       56.615 ±     459.103    B/op
[info] ArrayOfBigIntsReading.json4sNative:·gc.count                                         128  thrpt    5       12.000                counts
[info] ArrayOfBigIntsReading.json4sNative:·gc.time                                          128  thrpt    5       10.000                    ms
[info] ArrayOfBigIntsWriting.json4sJackson                                                  128  thrpt    5    16401.981 ±      31.018   ops/s
[info] ArrayOfBigIntsWriting.json4sJackson:·gc.alloc.rate                                   128  thrpt    5     4853.911 ±       8.778  MB/sec
[info] ArrayOfBigIntsWriting.json4sJackson:·gc.alloc.rate.norm                              128  thrpt    5   310386.023 ±       2.851    B/op
[info] ArrayOfBigIntsWriting.json4sJackson:·gc.churn.PS_Eden_Space                          128  thrpt    5     4759.326 ±    1322.222  MB/sec
[info] ArrayOfBigIntsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5   304338.597 ±   84610.874    B/op
[info] ArrayOfBigIntsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                      128  thrpt    5        0.187 ±       0.307  MB/sec
[info] ArrayOfBigIntsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5       11.983 ±      19.602    B/op
[info] ArrayOfBigIntsWriting.json4sJackson:·gc.count                                        128  thrpt    5       31.000                counts
[info] ArrayOfBigIntsWriting.json4sJackson:·gc.time                                         128  thrpt    5       14.000                    ms
[info] ArrayOfBigIntsWriting.json4sNative                                                   128  thrpt    5    16138.790 ±     696.199   ops/s
[info] ArrayOfBigIntsWriting.json4sNative:·gc.alloc.rate                                    128  thrpt    5     4477.250 ±     193.100  MB/sec
[info] ArrayOfBigIntsWriting.json4sNative:·gc.alloc.rate.norm                               128  thrpt    5   290937.535 ±       2.961    B/op
[info] ArrayOfBigIntsWriting.json4sNative:·gc.churn.PS_Eden_Space                           128  thrpt    5     4452.255 ±    1320.184  MB/sec
[info] ArrayOfBigIntsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5   289382.742 ±   88953.054    B/op
[info] ArrayOfBigIntsWriting.json4sNative:·gc.churn.PS_Survivor_Space                       128  thrpt    5        0.169 ±       0.404  MB/sec
[info] ArrayOfBigIntsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5       11.005 ±      26.649    B/op
[info] ArrayOfBigIntsWriting.json4sNative:·gc.count                                         128  thrpt    5       29.000                counts
[info] ArrayOfBigIntsWriting.json4sNative:·gc.time                                          128  thrpt    5       14.000                    ms
[info] ArrayOfBooleansReading.json4sJackson                                                 128  thrpt    5    80733.115 ±    1220.151   ops/s
[info] ArrayOfBooleansReading.json4sJackson:·gc.alloc.rate                                  128  thrpt    5     1330.708 ±      19.577  MB/sec
[info] ArrayOfBooleansReading.json4sJackson:·gc.alloc.rate.norm                             128  thrpt    5    17288.616 ±       0.635    B/op
[info] ArrayOfBooleansReading.json4sJackson:·gc.churn.PS_Eden_Space                         128  thrpt    5     1228.179 ±    1619.136  MB/sec
[info] ArrayOfBooleansReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5    15964.576 ±   21133.300    B/op
[info] ArrayOfBooleansReading.json4sJackson:·gc.churn.PS_Survivor_Space                     128  thrpt    5        1.555 ±      13.073  MB/sec
[info] ArrayOfBooleansReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5       20.245 ±     170.178    B/op
[info] ArrayOfBooleansReading.json4sJackson:·gc.count                                       128  thrpt    5        8.000                counts
[info] ArrayOfBooleansReading.json4sJackson:·gc.time                                        128  thrpt    5       13.000                    ms
[info] ArrayOfBooleansReading.json4sNative                                                  128  thrpt    5    73036.163 ±     650.292   ops/s
[info] ArrayOfBooleansReading.json4sNative:·gc.alloc.rate                                   128  thrpt    5     1905.190 ±      16.796  MB/sec
[info] ArrayOfBooleansReading.json4sNative:·gc.alloc.rate.norm                              128  thrpt    5    27360.975 ±       1.423    B/op
[info] ArrayOfBooleansReading.json4sNative:·gc.churn.PS_Eden_Space                          128  thrpt    5     1842.235 ±    1618.423  MB/sec
[info] ArrayOfBooleansReading.json4sNative:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5    26462.452 ±   23368.512    B/op
[info] ArrayOfBooleansReading.json4sNative:·gc.churn.PS_Survivor_Space                      128  thrpt    5        1.345 ±      10.900  MB/sec
[info] ArrayOfBooleansReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5       19.324 ±     156.642    B/op
[info] ArrayOfBooleansReading.json4sNative:·gc.count                                        128  thrpt    5       12.000                counts
[info] ArrayOfBooleansReading.json4sNative:·gc.time                                         128  thrpt    5       11.000                    ms
[info] ArrayOfBooleansWriting.json4sJackson                                                 128  thrpt    5    23959.363 ±     139.772   ops/s
[info] ArrayOfBooleansWriting.json4sJackson:·gc.alloc.rate                                  128  thrpt    5     5068.505 ±      29.667  MB/sec
[info] ArrayOfBooleansWriting.json4sJackson:·gc.alloc.rate.norm                             128  thrpt    5   221871.300 ±       2.337    B/op
[info] ArrayOfBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space                         128  thrpt    5     5066.734 ±    1619.057  MB/sec
[info] ArrayOfBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5   221781.400 ±   70164.192    B/op
[info] ArrayOfBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space                     128  thrpt    5        0.125 ±       0.147  MB/sec
[info] ArrayOfBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5        5.470 ±       6.453    B/op
[info] ArrayOfBooleansWriting.json4sJackson:·gc.count                                       128  thrpt    5       33.000                counts
[info] ArrayOfBooleansWriting.json4sJackson:·gc.time                                        128  thrpt    5       17.000                    ms
[info] ArrayOfBooleansWriting.json4sNative                                                  128  thrpt    5    23458.613 ±     618.093   ops/s
[info] ArrayOfBooleansWriting.json4sNative:·gc.alloc.rate                                   128  thrpt    5     4937.661 ±     130.404  MB/sec
[info] ArrayOfBooleansWriting.json4sNative:·gc.alloc.rate.norm                              128  thrpt    5   220759.455 ±       2.382    B/op
[info] ArrayOfBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space                          128  thrpt    5     5066.386 ±    1619.487  MB/sec
[info] ArrayOfBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5   226497.573 ±   71218.621    B/op
[info] ArrayOfBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space                      128  thrpt    5        0.144 ±       0.486  MB/sec
[info] ArrayOfBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5        6.403 ±      21.537    B/op
[info] ArrayOfBooleansWriting.json4sNative:·gc.count                                        128  thrpt    5       33.000                counts
[info] ArrayOfBooleansWriting.json4sNative:·gc.time                                         128  thrpt    5       16.000                    ms
[info] ArrayOfBytesReading.json4sJackson                                                    128  thrpt    5    61517.950 ±     886.813   ops/s
[info] ArrayOfBytesReading.json4sJackson:·gc.alloc.rate                                     128  thrpt    5     1962.022 ±      28.469  MB/sec
[info] ArrayOfBytesReading.json4sJackson:·gc.alloc.rate.norm                                128  thrpt    5    33449.236 ±       1.562    B/op
[info] ArrayOfBytesReading.json4sJackson:·gc.churn.PS_Eden_Space                            128  thrpt    5     1996.048 ±    1619.187  MB/sec
[info] ArrayOfBytesReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5    34025.872 ±   27528.819    B/op
[info] ArrayOfBytesReading.json4sJackson:·gc.churn.PS_Survivor_Space                        128  thrpt    5        1.587 ±      13.179  MB/sec
[info] ArrayOfBytesReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5       26.974 ±     223.948    B/op
[info] ArrayOfBytesReading.json4sJackson:·gc.count                                          128  thrpt    5       13.000                counts
[info] ArrayOfBytesReading.json4sJackson:·gc.time                                           128  thrpt    5       13.000                    ms
[info] ArrayOfBytesReading.json4sNative                                                     128  thrpt    5    50997.492 ±    1706.948   ops/s
[info] ArrayOfBytesReading.json4sNative:·gc.alloc.rate                                      128  thrpt    5     2463.268 ±      82.112  MB/sec
[info] ArrayOfBytesReading.json4sNative:·gc.alloc.rate.norm                                 128  thrpt    5    50657.813 ±       2.038    B/op
[info] ArrayOfBytesReading.json4sNative:·gc.churn.PS_Eden_Space                             128  thrpt    5     2456.688 ±    1322.008  MB/sec
[info] ArrayOfBytesReading.json4sNative:·gc.churn.PS_Eden_Space.norm                        128  thrpt    5    50511.025 ±   26638.348    B/op
[info] ArrayOfBytesReading.json4sNative:·gc.churn.PS_Survivor_Space                         128  thrpt    5        1.417 ±      10.925  MB/sec
[info] ArrayOfBytesReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                    128  thrpt    5       29.029 ±     223.626    B/op
[info] ArrayOfBytesReading.json4sNative:·gc.count                                           128  thrpt    5       16.000                counts
[info] ArrayOfBytesReading.json4sNative:·gc.time                                            128  thrpt    5       10.000                    ms
[info] ArrayOfBytesWriting.json4sJackson                                                    128  thrpt    5    21357.895 ±     373.839   ops/s
[info] ArrayOfBytesWriting.json4sJackson:·gc.alloc.rate                                     128  thrpt    5     5090.471 ±      89.227  MB/sec
[info] ArrayOfBytesWriting.json4sJackson:·gc.alloc.rate.norm                                128  thrpt    5   249976.187 ±       2.656    B/op
[info] ArrayOfBytesWriting.json4sJackson:·gc.churn.PS_Eden_Space                            128  thrpt    5     5066.526 ±    1619.004  MB/sec
[info] ArrayOfBytesWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5   248855.340 ±   82422.834    B/op
[info] ArrayOfBytesWriting.json4sJackson:·gc.churn.PS_Survivor_Space                        128  thrpt    5        0.194 ±       0.198  MB/sec
[info] ArrayOfBytesWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5        9.516 ±       9.832    B/op
[info] ArrayOfBytesWriting.json4sJackson:·gc.count                                          128  thrpt    5       33.000                counts
[info] ArrayOfBytesWriting.json4sJackson:·gc.time                                           128  thrpt    5       16.000                    ms
[info] ArrayOfBytesWriting.json4sNative                                                     128  thrpt    5    23862.735 ±     113.242   ops/s
[info] ArrayOfBytesWriting.json4sNative:·gc.alloc.rate                                      128  thrpt    5     5052.329 ±      23.736  MB/sec
[info] ArrayOfBytesWriting.json4sNative:·gc.alloc.rate.norm                                 128  thrpt    5   222055.326 ±       2.322    B/op
[info] ArrayOfBytesWriting.json4sNative:·gc.churn.PS_Eden_Space                             128  thrpt    5     5066.469 ±    1619.342  MB/sec
[info] ArrayOfBytesWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                        128  thrpt    5   222694.740 ±   72166.245    B/op
[info] ArrayOfBytesWriting.json4sNative:·gc.churn.PS_Survivor_Space                         128  thrpt    5        0.194 ±       0.287  MB/sec
[info] ArrayOfBytesWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                    128  thrpt    5        8.510 ±      12.605    B/op
[info] ArrayOfBytesWriting.json4sNative:·gc.count                                           128  thrpt    5       33.000                counts
[info] ArrayOfBytesWriting.json4sNative:·gc.time                                            128  thrpt    5       14.000                    ms
[info] ArrayOfCharsWriting.json4sJackson                                                    128  thrpt    5    22895.298 ±     107.966   ops/s
[info] ArrayOfCharsWriting.json4sJackson:·gc.alloc.rate                                     128  thrpt    5     5484.365 ±      25.847  MB/sec
[info] ArrayOfCharsWriting.json4sJackson:·gc.alloc.rate.norm                                128  thrpt    5   251224.335 ±       1.924    B/op
[info] ArrayOfCharsWriting.json4sJackson:·gc.churn.PS_Eden_Space                            128  thrpt    5     5527.238 ±    1322.575  MB/sec
[info] ArrayOfCharsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5   253178.638 ±   59759.000    B/op
[info] ArrayOfCharsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                        128  thrpt    5        0.269 ±       0.357  MB/sec
[info] ArrayOfCharsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5       12.304 ±      16.325    B/op
[info] ArrayOfCharsWriting.json4sJackson:·gc.count                                          128  thrpt    5       36.000                counts
[info] ArrayOfCharsWriting.json4sJackson:·gc.time                                           128  thrpt    5       15.000                    ms
[info] ArrayOfCharsWriting.json4sNative                                                     128  thrpt    5    20948.453 ±     264.327   ops/s
[info] ArrayOfCharsWriting.json4sNative:·gc.alloc.rate                                      128  thrpt    5     4972.492 ±      61.827  MB/sec
[info] ArrayOfCharsWriting.json4sNative:·gc.alloc.rate.norm                                 128  thrpt    5   248944.350 ±       2.708    B/op
[info] ArrayOfCharsWriting.json4sNative:·gc.churn.PS_Eden_Space                             128  thrpt    5     5066.569 ±    1618.959  MB/sec
[info] ArrayOfCharsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                        128  thrpt    5   253656.028 ±   81102.470    B/op
[info] ArrayOfCharsWriting.json4sNative:·gc.churn.PS_Survivor_Space                         128  thrpt    5        0.256 ±       0.261  MB/sec
[info] ArrayOfCharsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                    128  thrpt    5       12.820 ±      12.987    B/op
[info] ArrayOfCharsWriting.json4sNative:·gc.count                                           128  thrpt    5       33.000                counts
[info] ArrayOfCharsWriting.json4sNative:·gc.time                                            128  thrpt    5       16.000                    ms
[info] ArrayOfDoublesReading.json4sJackson                                                  128  thrpt    5    40774.915 ±     487.427   ops/s
[info] ArrayOfDoublesReading.json4sJackson:·gc.alloc.rate                                   128  thrpt    5     2123.684 ±      25.328  MB/sec
[info] ArrayOfDoublesReading.json4sJackson:·gc.alloc.rate.norm                              128  thrpt    5    54625.994 ±       2.059    B/op
[info] ArrayOfDoublesReading.json4sJackson:·gc.churn.PS_Eden_Space                          128  thrpt    5     2149.498 ±    1321.732  MB/sec
[info] ArrayOfDoublesReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5    55292.143 ±   34047.080    B/op
[info] ArrayOfDoublesReading.json4sJackson:·gc.churn.PS_Survivor_Space                      128  thrpt    5        1.599 ±      13.233  MB/sec
[info] ArrayOfDoublesReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5       41.272 ±     341.575    B/op
[info] ArrayOfDoublesReading.json4sJackson:·gc.count                                        128  thrpt    5       14.000                counts
[info] ArrayOfDoublesReading.json4sJackson:·gc.time                                         128  thrpt    5       11.000                    ms
[info] ArrayOfDoublesReading.json4sNative                                                   128  thrpt    5    26581.425 ±    1306.243   ops/s
[info] ArrayOfDoublesReading.json4sNative:·gc.alloc.rate                                    128  thrpt    5     2339.625 ±     114.953  MB/sec
[info] ArrayOfDoublesReading.json4sNative:·gc.alloc.rate.norm                               128  thrpt    5    92315.276 ±       2.133    B/op
[info] ArrayOfDoublesReading.json4sNative:·gc.churn.PS_Eden_Space                           128  thrpt    5     2302.990 ±       0.563  MB/sec
[info] ArrayOfDoublesReading.json4sNative:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5    90881.638 ±    4472.632    B/op
[info] ArrayOfDoublesReading.json4sNative:·gc.churn.PS_Survivor_Space                       128  thrpt    5        1.380 ±      11.144  MB/sec
[info] ArrayOfDoublesReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5       53.861 ±     434.465    B/op
[info] ArrayOfDoublesReading.json4sNative:·gc.count                                         128  thrpt    5       15.000                counts
[info] ArrayOfDoublesReading.json4sNative:·gc.time                                          128  thrpt    5        8.000                    ms
[info] ArrayOfDoublesWriting.json4sJackson                                                  128  thrpt    5    12210.425 ±     113.743   ops/s
[info] ArrayOfDoublesWriting.json4sJackson:·gc.alloc.rate                                   128  thrpt    5     3033.613 ±      28.639  MB/sec
[info] ArrayOfDoublesWriting.json4sJackson:·gc.alloc.rate.norm                              128  thrpt    5   260576.696 ±       0.083    B/op
[info] ArrayOfDoublesWriting.json4sJackson:·gc.churn.PS_Eden_Space                          128  thrpt    5     3070.500 ±       0.703  MB/sec
[info] ArrayOfDoublesWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5   263746.405 ±    2442.484    B/op
[info] ArrayOfDoublesWriting.json4sJackson:·gc.churn.PS_Survivor_Space                      128  thrpt    5        0.150 ±       0.411  MB/sec
[info] ArrayOfDoublesWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5       12.885 ±      35.357    B/op
[info] ArrayOfDoublesWriting.json4sJackson:·gc.count                                        128  thrpt    5       20.000                counts
[info] ArrayOfDoublesWriting.json4sJackson:·gc.time                                         128  thrpt    5       10.000                    ms
[info] ArrayOfDoublesWriting.json4sNative                                                   128  thrpt    5    12445.101 ±     331.362   ops/s
[info] ArrayOfDoublesWriting.json4sNative:·gc.alloc.rate                                    128  thrpt    5     3069.875 ±      81.619  MB/sec
[info] ArrayOfDoublesWriting.json4sNative:·gc.alloc.rate.norm                               128  thrpt    5   258712.545 ±       0.280    B/op
[info] ArrayOfDoublesWriting.json4sNative:·gc.churn.PS_Eden_Space                           128  thrpt    5     3070.611 ±       0.807  MB/sec
[info] ArrayOfDoublesWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5   258784.392 ±    6866.421    B/op
[info] ArrayOfDoublesWriting.json4sNative:·gc.churn.PS_Survivor_Space                       128  thrpt    5        0.112 ±       0.347  MB/sec
[info] ArrayOfDoublesWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5        9.503 ±      29.441    B/op
[info] ArrayOfDoublesWriting.json4sNative:·gc.count                                         128  thrpt    5       20.000                counts
[info] ArrayOfDoublesWriting.json4sNative:·gc.time                                          128  thrpt    5       12.000                    ms
[info] ArrayOfDurationsReading.json4sJackson                                                128  thrpt    5    15726.894 ±     172.618   ops/s
[info] ArrayOfDurationsReading.json4sJackson:·gc.alloc.rate                                 128  thrpt    5     1322.473 ±      14.730  MB/sec
[info] ArrayOfDurationsReading.json4sJackson:·gc.alloc.rate.norm                            128  thrpt    5    88195.489 ±       5.255    B/op
[info] ArrayOfDurationsReading.json4sJackson:·gc.churn.PS_Eden_Space                        128  thrpt    5     1381.784 ±    1321.964  MB/sec
[info] ArrayOfDurationsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5    92110.231 ±   87631.555    B/op
[info] ArrayOfDurationsReading.json4sJackson:·gc.churn.PS_Survivor_Space                    128  thrpt    5        1.582 ±      13.282  MB/sec
[info] ArrayOfDurationsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5      105.137 ±     882.565    B/op
[info] ArrayOfDurationsReading.json4sJackson:·gc.count                                      128  thrpt    5        9.000                counts
[info] ArrayOfDurationsReading.json4sJackson:·gc.time                                       128  thrpt    5       15.000                    ms
[info] ArrayOfDurationsReading.json4sNative                                                 128  thrpt    5    14882.525 ±     156.528   ops/s
[info] ArrayOfDurationsReading.json4sNative:·gc.alloc.rate                                  128  thrpt    5     1406.053 ±      14.645  MB/sec
[info] ArrayOfDurationsReading.json4sNative:·gc.alloc.rate.norm                             128  thrpt    5    99083.715 ±       5.642    B/op
[info] ArrayOfDurationsReading.json4sNative:·gc.churn.PS_Eden_Space                         128  thrpt    5     1381.838 ±    1322.090  MB/sec
[info] ArrayOfDurationsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5    97428.119 ±   93816.461    B/op
[info] ArrayOfDurationsReading.json4sNative:·gc.churn.PS_Survivor_Space                     128  thrpt    5        1.316 ±      11.012  MB/sec
[info] ArrayOfDurationsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5       92.952 ±     777.972    B/op
[info] ArrayOfDurationsReading.json4sNative:·gc.count                                       128  thrpt    5        9.000                counts
[info] ArrayOfDurationsReading.json4sNative:·gc.time                                        128  thrpt    5       11.000                    ms
[info] ArrayOfDurationsWriting.json4sJackson                                                128  thrpt    5    17475.477 ±     479.710   ops/s
[info] ArrayOfDurationsWriting.json4sJackson:·gc.alloc.rate                                 128  thrpt    5     4389.054 ±     120.326  MB/sec
[info] ArrayOfDurationsWriting.json4sJackson:·gc.alloc.rate.norm                            128  thrpt    5   263408.520 ±       3.313    B/op
[info] ArrayOfDurationsWriting.json4sJackson:·gc.churn.PS_Eden_Space                        128  thrpt    5     4299.114 ±    1619.274  MB/sec
[info] ArrayOfDurationsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5   258050.629 ±   98814.048    B/op
[info] ArrayOfDurationsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                    128  thrpt    5        0.087 ±       0.178  MB/sec
[info] ArrayOfDurationsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5        5.264 ±      10.849    B/op
[info] ArrayOfDurationsWriting.json4sJackson:·gc.count                                      128  thrpt    5       28.000                counts
[info] ArrayOfDurationsWriting.json4sJackson:·gc.time                                       128  thrpt    5       13.000                    ms
[info] ArrayOfDurationsWriting.json4sNative                                                 128  thrpt    5    10230.721 ±     122.148   ops/s
[info] ArrayOfDurationsWriting.json4sNative:·gc.alloc.rate                                  128  thrpt    5     2596.353 ±      31.070  MB/sec
[info] ArrayOfDurationsWriting.json4sNative:·gc.alloc.rate.norm                             128  thrpt    5   266168.829 ±       5.325    B/op
[info] ArrayOfDurationsWriting.json4sNative:·gc.churn.PS_Eden_Space                         128  thrpt    5     2609.973 ±    1619.163  MB/sec
[info] ArrayOfDurationsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5   267499.463 ±  163866.779    B/op
[info] ArrayOfDurationsWriting.json4sNative:·gc.churn.PS_Survivor_Space                     128  thrpt    5        0.162 ±       0.299  MB/sec
[info] ArrayOfDurationsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5       16.642 ±      30.577    B/op
[info] ArrayOfDurationsWriting.json4sNative:·gc.count                                       128  thrpt    5       17.000                counts
[info] ArrayOfDurationsWriting.json4sNative:·gc.time                                        128  thrpt    5        8.000                    ms
[info] ArrayOfEnumADTsReading.json4sJackson                                                 128  thrpt    5    55501.040 ±    1931.720   ops/s
[info] ArrayOfEnumADTsReading.json4sJackson:·gc.alloc.rate                                  128  thrpt    5     2597.809 ±      90.223  MB/sec
[info] ArrayOfEnumADTsReading.json4sJackson:·gc.alloc.rate.norm                             128  thrpt    5    49089.627 ±       0.967    B/op
[info] ArrayOfEnumADTsReading.json4sJackson:·gc.churn.PS_Eden_Space                         128  thrpt    5     2610.251 ±    1619.024  MB/sec
[info] ArrayOfEnumADTsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5    49297.190 ±   29668.639    B/op
[info] ArrayOfEnumADTsReading.json4sJackson:·gc.churn.PS_Survivor_Space                     128  thrpt    5        0.125 ±       0.255  MB/sec
[info] ArrayOfEnumADTsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5        2.357 ±       4.785    B/op
[info] ArrayOfEnumADTsReading.json4sJackson:·gc.count                                       128  thrpt    5       17.000                counts
[info] ArrayOfEnumADTsReading.json4sJackson:·gc.time                                        128  thrpt    5        9.000                    ms
[info] ArrayOfEnumADTsReading.json4sNative                                                  128  thrpt    5    52121.627 ±     895.688   ops/s
[info] ArrayOfEnumADTsReading.json4sNative:·gc.alloc.rate                                   128  thrpt    5     2938.320 ±      50.181  MB/sec
[info] ArrayOfEnumADTsReading.json4sNative:·gc.alloc.rate.norm                              128  thrpt    5    59121.949 ±       0.861    B/op
[info] ArrayOfEnumADTsReading.json4sNative:·gc.churn.PS_Eden_Space                          128  thrpt    5     2917.473 ±    1321.583  MB/sec
[info] ArrayOfEnumADTsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5    58683.460 ±   25912.165    B/op
[info] ArrayOfEnumADTsReading.json4sNative:·gc.churn.PS_Survivor_Space                      128  thrpt    5        0.100 ±       0.054  MB/sec
[info] ArrayOfEnumADTsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5        2.011 ±       1.065    B/op
[info] ArrayOfEnumADTsReading.json4sNative:·gc.count                                        128  thrpt    5       19.000                counts
[info] ArrayOfEnumADTsReading.json4sNative:·gc.time                                         128  thrpt    5       10.000                    ms
[info] ArrayOfEnumADTsWriting.json4sJackson                                                 128  thrpt    5    52071.718 ±    1246.398   ops/s
[info] ArrayOfEnumADTsWriting.json4sJackson:·gc.alloc.rate                                  128  thrpt    5     5218.208 ±     124.573  MB/sec
[info] ArrayOfEnumADTsWriting.json4sJackson:·gc.alloc.rate.norm                             128  thrpt    5   105099.460 ±       0.947    B/op
[info] ArrayOfEnumADTsWriting.json4sJackson:·gc.churn.PS_Eden_Space                         128  thrpt    5     5220.460 ±    1322.349  MB/sec
[info] ArrayOfEnumADTsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5   105178.538 ±   28692.936    B/op
[info] ArrayOfEnumADTsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                     128  thrpt    5        0.200 ±       0.357  MB/sec
[info] ArrayOfEnumADTsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5        4.020 ±       7.119    B/op
[info] ArrayOfEnumADTsWriting.json4sJackson:·gc.count                                       128  thrpt    5       34.000                counts
[info] ArrayOfEnumADTsWriting.json4sJackson:·gc.time                                        128  thrpt    5       16.000                    ms
[info] ArrayOfEnumADTsWriting.json4sNative                                                  128  thrpt    5    29767.271 ±    1067.874   ops/s
[info] ArrayOfEnumADTsWriting.json4sNative:·gc.alloc.rate                                   128  thrpt    5     3017.175 ±     108.272  MB/sec
[info] ArrayOfEnumADTsWriting.json4sNative:·gc.alloc.rate.norm                              128  thrpt    5   106307.567 ±       0.125    B/op
[info] ArrayOfEnumADTsWriting.json4sNative:·gc.churn.PS_Eden_Space                          128  thrpt    5     3070.662 ±       0.481  MB/sec
[info] ArrayOfEnumADTsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5   108199.708 ±    3916.486    B/op
[info] ArrayOfEnumADTsWriting.json4sNative:·gc.churn.PS_Survivor_Space                      128  thrpt    5        0.169 ±       0.249  MB/sec
[info] ArrayOfEnumADTsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5        5.952 ±       8.864    B/op
[info] ArrayOfEnumADTsWriting.json4sNative:·gc.count                                        128  thrpt    5       20.000                counts
[info] ArrayOfEnumADTsWriting.json4sNative:·gc.time                                         128  thrpt    5       11.000                    ms
[info] ArrayOfEnumsReading.json4sJackson                                                    128  thrpt    5    55293.202 ±    2101.883   ops/s
[info] ArrayOfEnumsReading.json4sJackson:·gc.alloc.rate                                     128  thrpt    5     2587.952 ±      98.437  MB/sec
[info] ArrayOfEnumsReading.json4sJackson:·gc.alloc.rate.norm                                128  thrpt    5    49089.633 ±       1.002    B/op
[info] ArrayOfEnumsReading.json4sJackson:·gc.churn.PS_Eden_Space                            128  thrpt    5     2609.990 ±    1618.741  MB/sec
[info] ArrayOfEnumsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5    49495.272 ±   30254.513    B/op
[info] ArrayOfEnumsReading.json4sJackson:·gc.churn.PS_Survivor_Space                        128  thrpt    5        0.137 ±       0.290  MB/sec
[info] ArrayOfEnumsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5        2.604 ±       5.490    B/op
[info] ArrayOfEnumsReading.json4sJackson:·gc.count                                          128  thrpt    5       17.000                counts
[info] ArrayOfEnumsReading.json4sJackson:·gc.time                                           128  thrpt    5        8.000                    ms
[info] ArrayOfEnumsReading.json4sNative                                                     128  thrpt    5    50816.358 ±    1237.536   ops/s
[info] ArrayOfEnumsReading.json4sNative:·gc.alloc.rate                                      128  thrpt    5     2864.575 ±      69.727  MB/sec
[info] ArrayOfEnumsReading.json4sNative:·gc.alloc.rate.norm                                 128  thrpt    5    59122.000 ±       0.882    B/op
[info] ArrayOfEnumsReading.json4sNative:·gc.churn.PS_Eden_Space                             128  thrpt    5     2917.142 ±    1322.291  MB/sec
[info] ArrayOfEnumsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                        128  thrpt    5    60209.302 ±   27350.371    B/op
[info] ArrayOfEnumsReading.json4sNative:·gc.churn.PS_Survivor_Space                         128  thrpt    5        0.119 ±       0.132  MB/sec
[info] ArrayOfEnumsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                    128  thrpt    5        2.449 ±       2.698    B/op
[info] ArrayOfEnumsReading.json4sNative:·gc.count                                           128  thrpt    5       19.000                counts
[info] ArrayOfEnumsReading.json4sNative:·gc.time                                            128  thrpt    5       10.000                    ms
[info] ArrayOfEnumsWriting.json4sJackson                                                    128  thrpt    5    61154.410 ±     828.025   ops/s
[info] ArrayOfEnumsWriting.json4sJackson:·gc.alloc.rate                                     128  thrpt    5     5650.334 ±      76.403  MB/sec
[info] ArrayOfEnumsWriting.json4sJackson:·gc.alloc.rate.norm                                128  thrpt    5    96907.207 ±       0.964    B/op
[info] ArrayOfEnumsWriting.json4sJackson:·gc.churn.PS_Eden_Space                            128  thrpt    5     5680.578 ±    1619.238  MB/sec
[info] ArrayOfEnumsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5    97438.114 ±   28545.260    B/op
[info] ArrayOfEnumsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                        128  thrpt    5        0.262 ±       0.455  MB/sec
[info] ArrayOfEnumsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5        4.498 ±       7.754    B/op
[info] ArrayOfEnumsWriting.json4sJackson:·gc.count                                          128  thrpt    5       37.000                counts
[info] ArrayOfEnumsWriting.json4sJackson:·gc.time                                           128  thrpt    5       16.000                    ms
[info] ArrayOfEnumsWriting.json4sNative                                                     128  thrpt    5    32110.776 ±     390.167   ops/s
[info] ArrayOfEnumsWriting.json4sNative:·gc.alloc.rate                                      128  thrpt    5     3003.929 ±      36.575  MB/sec
[info] ArrayOfEnumsWriting.json4sNative:·gc.alloc.rate.norm                                 128  thrpt    5    98115.306 ±       0.036    B/op
[info] ArrayOfEnumsWriting.json4sNative:·gc.churn.PS_Eden_Space                             128  thrpt    5     3070.673 ±       0.331  MB/sec
[info] ArrayOfEnumsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                        128  thrpt    5   100296.138 ±    1219.301    B/op
[info] ArrayOfEnumsWriting.json4sNative:·gc.churn.PS_Survivor_Space                         128  thrpt    5        0.206 ±       0.395  MB/sec
[info] ArrayOfEnumsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                    128  thrpt    5        6.731 ±      12.886    B/op
[info] ArrayOfEnumsWriting.json4sNative:·gc.count                                           128  thrpt    5       20.000                counts
[info] ArrayOfEnumsWriting.json4sNative:·gc.time                                            128  thrpt    5       11.000                    ms
[info] ArrayOfFloatsWriting.json4sJackson                                                   128  thrpt    5    15334.241 ±      76.505   ops/s
[info] ArrayOfFloatsWriting.json4sJackson:·gc.alloc.rate                                    128  thrpt    5     3562.301 ±      17.896  MB/sec
[info] ArrayOfFloatsWriting.json4sJackson:·gc.alloc.rate.norm                               128  thrpt    5   243655.967 ±       3.548    B/op
[info] ArrayOfFloatsWriting.json4sJackson:·gc.churn.PS_Eden_Space                           128  thrpt    5     3531.099 ±    1619.145  MB/sec
[info] ArrayOfFloatsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5   241501.623 ±  109957.713    B/op
[info] ArrayOfFloatsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                       128  thrpt    5        0.187 ±       0.558  MB/sec
[info] ArrayOfFloatsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5       12.817 ±      38.161    B/op
[info] ArrayOfFloatsWriting.json4sJackson:·gc.count                                         128  thrpt    5       23.000                counts
[info] ArrayOfFloatsWriting.json4sJackson:·gc.time                                          128  thrpt    5       10.000                    ms
[info] ArrayOfFloatsWriting.json4sNative                                                    128  thrpt    5    17495.234 ±     736.459   ops/s
[info] ArrayOfFloatsWriting.json4sNative:·gc.alloc.rate                                     128  thrpt    5     3898.047 ±     164.404  MB/sec
[info] ArrayOfFloatsWriting.json4sNative:·gc.alloc.rate.norm                                128  thrpt    5   233687.605 ±       0.390    B/op
[info] ArrayOfFloatsWriting.json4sNative:·gc.churn.PS_Eden_Space                            128  thrpt    5     3838.127 ±       1.147  MB/sec
[info] ArrayOfFloatsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5   230117.384 ±    9644.765    B/op
[info] ArrayOfFloatsWriting.json4sNative:·gc.churn.PS_Survivor_Space                        128  thrpt    5        0.181 ±       0.429  MB/sec
[info] ArrayOfFloatsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5       10.850 ±      25.608    B/op
[info] ArrayOfFloatsWriting.json4sNative:·gc.count                                          128  thrpt    5       25.000                counts
[info] ArrayOfFloatsWriting.json4sNative:·gc.time                                           128  thrpt    5       12.000                    ms
[info] ArrayOfInstantsReading.json4sJackson                                                 128  thrpt    5    10362.266 ±      43.232   ops/s
[info] ArrayOfInstantsReading.json4sJackson:·gc.alloc.rate                                  128  thrpt    5     2862.739 ±      11.493  MB/sec
[info] ArrayOfInstantsReading.json4sJackson:·gc.alloc.rate.norm                             128  thrpt    5   289737.752 ±       4.466    B/op
[info] ArrayOfInstantsReading.json4sJackson:·gc.churn.PS_Eden_Space                         128  thrpt    5     2917.176 ±    1322.476  MB/sec
[info] ArrayOfInstantsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5   295262.902 ±  134379.957    B/op
[info] ArrayOfInstantsReading.json4sJackson:·gc.churn.PS_Survivor_Space                     128  thrpt    5        0.100 ±       0.231  MB/sec
[info] ArrayOfInstantsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5       10.112 ±      23.397    B/op
[info] ArrayOfInstantsReading.json4sJackson:·gc.count                                       128  thrpt    5       19.000                counts
[info] ArrayOfInstantsReading.json4sJackson:·gc.time                                        128  thrpt    5       10.000                    ms
[info] ArrayOfInstantsReading.json4sNative                                                  128  thrpt    5    10095.911 ±     303.049   ops/s
[info] ArrayOfInstantsReading.json4sNative:·gc.alloc.rate                                   128  thrpt    5     2893.721 ±      86.848  MB/sec
[info] ArrayOfInstantsReading.json4sNative:·gc.alloc.rate.norm                              128  thrpt    5   300610.095 ±       4.225    B/op
[info] ArrayOfInstantsReading.json4sNative:·gc.churn.PS_Eden_Space                          128  thrpt    5     2916.938 ±    1321.657  MB/sec
[info] ArrayOfInstantsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5   302986.068 ±  135881.233    B/op
[info] ArrayOfInstantsReading.json4sNative:·gc.churn.PS_Survivor_Space                      128  thrpt    5        0.137 ±       0.108  MB/sec
[info] ArrayOfInstantsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5       14.271 ±      11.055    B/op
[info] ArrayOfInstantsReading.json4sNative:·gc.count                                        128  thrpt    5       19.000                counts
[info] ArrayOfInstantsReading.json4sNative:·gc.time                                         128  thrpt    5        9.000                    ms
[info] ArrayOfInstantsWriting.json4sJackson                                                 128  thrpt    5    14235.064 ±     259.469   ops/s
[info] ArrayOfInstantsWriting.json4sJackson:·gc.alloc.rate                                  128  thrpt    5     4165.659 ±      75.940  MB/sec
[info] ArrayOfInstantsWriting.json4sJackson:·gc.alloc.rate.norm                             128  thrpt    5   306898.067 ±       3.869    B/op
[info] ArrayOfInstantsWriting.json4sJackson:·gc.churn.PS_Eden_Space                         128  thrpt    5     4145.505 ±    1619.261  MB/sec
[info] ArrayOfInstantsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5   305401.276 ±  118570.713    B/op
[info] ArrayOfInstantsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                     128  thrpt    5        0.175 ±       0.599  MB/sec
[info] ArrayOfInstantsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5       12.925 ±      44.329    B/op
[info] ArrayOfInstantsWriting.json4sJackson:·gc.count                                       128  thrpt    5       27.000                counts
[info] ArrayOfInstantsWriting.json4sJackson:·gc.time                                        128  thrpt    5       13.000                    ms
[info] ArrayOfInstantsWriting.json4sNative                                                  128  thrpt    5     8649.961 ±      36.900   ops/s
[info] ArrayOfInstantsWriting.json4sNative:·gc.alloc.rate                                   128  thrpt    5     2579.210 ±      10.811  MB/sec
[info] ArrayOfInstantsWriting.json4sNative:·gc.alloc.rate.norm                              128  thrpt    5   312730.442 ±       6.412    B/op
[info] ArrayOfInstantsWriting.json4sNative:·gc.churn.PS_Eden_Space                          128  thrpt    5     2609.931 ±    1618.785  MB/sec
[info] ArrayOfInstantsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5   316459.481 ±  196405.275    B/op
[info] ArrayOfInstantsWriting.json4sNative:·gc.churn.PS_Survivor_Space                      128  thrpt    5        0.087 ±       0.157  MB/sec
[info] ArrayOfInstantsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5       10.605 ±      19.017    B/op
[info] ArrayOfInstantsWriting.json4sNative:·gc.count                                        128  thrpt    5       17.000                counts
[info] ArrayOfInstantsWriting.json4sNative:·gc.time                                         128  thrpt    5        9.000                    ms
[info] ArrayOfIntsReading.json4sJackson                                                     128  thrpt    5    52630.868 ±    1248.654   ops/s
[info] ArrayOfIntsReading.json4sJackson:·gc.alloc.rate                                      128  thrpt    5     2094.834 ±      49.524  MB/sec
[info] ArrayOfIntsReading.json4sJackson:·gc.alloc.rate.norm                                 128  thrpt    5    41745.444 ±       1.849    B/op
[info] ArrayOfIntsReading.json4sJackson:·gc.churn.PS_Eden_Space                             128  thrpt    5     1995.970 ±    1618.933  MB/sec
[info] ArrayOfIntsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                        128  thrpt    5    39774.237 ±   32227.526    B/op
[info] ArrayOfIntsReading.json4sJackson:·gc.churn.PS_Survivor_Space                         128  thrpt    5        1.591 ±      13.429  MB/sec
[info] ArrayOfIntsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                    128  thrpt    5       31.831 ±     268.741    B/op
[info] ArrayOfIntsReading.json4sJackson:·gc.count                                           128  thrpt    5       13.000                counts
[info] ArrayOfIntsReading.json4sJackson:·gc.time                                            128  thrpt    5       10.000                    ms
[info] ArrayOfIntsReading.json4sNative                                                      128  thrpt    5    46380.122 ±     157.898   ops/s
[info] ArrayOfIntsReading.json4sNative:·gc.alloc.rate                                       128  thrpt    5     2603.943 ±       8.623  MB/sec
[info] ArrayOfIntsReading.json4sNative:·gc.alloc.rate.norm                                  128  thrpt    5    58889.961 ±       1.204    B/op
[info] ArrayOfIntsReading.json4sNative:·gc.churn.PS_Eden_Space                              128  thrpt    5     2609.730 ±    1617.648  MB/sec
[info] ArrayOfIntsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                         128  thrpt    5    59023.994 ±   36683.304    B/op
[info] ArrayOfIntsReading.json4sNative:·gc.churn.PS_Survivor_Space                          128  thrpt    5        0.106 ±       0.325  MB/sec
[info] ArrayOfIntsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                     128  thrpt    5        2.401 ±       7.345    B/op
[info] ArrayOfIntsReading.json4sNative:·gc.count                                            128  thrpt    5       17.000                counts
[info] ArrayOfIntsReading.json4sNative:·gc.time                                             128  thrpt    5        9.000                    ms
[info] ArrayOfIntsWriting.json4sJackson                                                     128  thrpt    5    20654.239 ±     784.179   ops/s
[info] ArrayOfIntsWriting.json4sJackson:·gc.alloc.rate                                      128  thrpt    5     5150.862 ±     195.016  MB/sec
[info] ArrayOfIntsWriting.json4sJackson:·gc.alloc.rate.norm                                 128  thrpt    5   261552.463 ±       2.607    B/op
[info] ArrayOfIntsWriting.json4sJackson:·gc.churn.PS_Eden_Space                             128  thrpt    5     5066.753 ±    1619.191  MB/sec
[info] ArrayOfIntsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                        128  thrpt    5   257231.497 ±   78710.789    B/op
[info] ArrayOfIntsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                         128  thrpt    5        0.231 ±       0.357  MB/sec
[info] ArrayOfIntsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                    128  thrpt    5       11.759 ±      18.310    B/op
[info] ArrayOfIntsWriting.json4sJackson:·gc.count                                           128  thrpt    5       33.000                counts
[info] ArrayOfIntsWriting.json4sJackson:·gc.time                                            128  thrpt    5       14.000                    ms
[info] ArrayOfIntsWriting.json4sNative                                                      128  thrpt    5    22403.984 ±     175.298   ops/s
[info] ArrayOfIntsWriting.json4sNative:·gc.alloc.rate                                       128  thrpt    5     4824.758 ±      37.922  MB/sec
[info] ArrayOfIntsWriting.json4sNative:·gc.alloc.rate.norm                                  128  thrpt    5   225855.337 ±       2.158    B/op
[info] ArrayOfIntsWriting.json4sNative:·gc.churn.PS_Eden_Space                              128  thrpt    5     4759.567 ±    1321.782  MB/sec
[info] ArrayOfIntsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                         128  thrpt    5   222830.395 ±   63777.222    B/op
[info] ArrayOfIntsWriting.json4sNative:·gc.churn.PS_Survivor_Space                          128  thrpt    5        0.225 ±       0.453  MB/sec
[info] ArrayOfIntsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                     128  thrpt    5       10.529 ±      21.204    B/op
[info] ArrayOfIntsWriting.json4sNative:·gc.count                                            128  thrpt    5       31.000                counts
[info] ArrayOfIntsWriting.json4sNative:·gc.time                                             128  thrpt    5       13.000                    ms
[info] ArrayOfJavaEnumsReading.json4sJackson                                                128  thrpt    5    54595.410 ±     236.614   ops/s
[info] ArrayOfJavaEnumsReading.json4sJackson:·gc.alloc.rate                                 128  thrpt    5     2555.297 ±      11.108  MB/sec
[info] ArrayOfJavaEnumsReading.json4sJackson:·gc.alloc.rate.norm                            128  thrpt    5    49089.781 ±       1.886    B/op
[info] ArrayOfJavaEnumsReading.json4sJackson:·gc.churn.PS_Eden_Space                        128  thrpt    5     2610.051 ±    1619.185  MB/sec
[info] ArrayOfJavaEnumsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5    50142.418 ±   31129.094    B/op
[info] ArrayOfJavaEnumsReading.json4sJackson:·gc.churn.PS_Survivor_Space                    128  thrpt    5        1.631 ±      13.705  MB/sec
[info] ArrayOfJavaEnumsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5       31.306 ±     263.097    B/op
[info] ArrayOfJavaEnumsReading.json4sJackson:·gc.count                                      128  thrpt    5       17.000                counts
[info] ArrayOfJavaEnumsReading.json4sJackson:·gc.time                                       128  thrpt    5       10.000                    ms
[info] ArrayOfJavaEnumsReading.json4sNative                                                 128  thrpt    5    49087.680 ±     918.647   ops/s
[info] ArrayOfJavaEnumsReading.json4sNative:·gc.alloc.rate                                  128  thrpt    5     2767.093 ±      52.103  MB/sec
[info] ArrayOfJavaEnumsReading.json4sNative:·gc.alloc.rate.norm                             128  thrpt    5    59121.961 ±       1.140    B/op
[info] ArrayOfJavaEnumsReading.json4sNative:·gc.churn.PS_Eden_Space                         128  thrpt    5     2763.616 ±    1619.964  MB/sec
[info] ArrayOfJavaEnumsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5    59036.169 ±   34255.379    B/op
[info] ArrayOfJavaEnumsReading.json4sNative:·gc.churn.PS_Survivor_Space                     128  thrpt    5        0.137 ±       0.219  MB/sec
[info] ArrayOfJavaEnumsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5        2.938 ±       4.690    B/op
[info] ArrayOfJavaEnumsReading.json4sNative:·gc.count                                       128  thrpt    5       18.000                counts
[info] ArrayOfJavaEnumsReading.json4sNative:·gc.time                                        128  thrpt    5        9.000                    ms
[info] ArrayOfJavaEnumsWriting.json4sJackson                                                128  thrpt    5    47407.707 ±     457.056   ops/s
[info] ArrayOfJavaEnumsWriting.json4sJackson:·gc.alloc.rate                                 128  thrpt    5     5120.894 ±      49.571  MB/sec
[info] ArrayOfJavaEnumsWriting.json4sJackson:·gc.alloc.rate.norm                            128  thrpt    5   113291.801 ±       0.957    B/op
[info] ArrayOfJavaEnumsWriting.json4sJackson:·gc.churn.PS_Eden_Space                        128  thrpt    5     5219.697 ±    1320.789  MB/sec
[info] ArrayOfJavaEnumsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5   115472.498 ±   28856.650    B/op
[info] ArrayOfJavaEnumsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                    128  thrpt    5        0.212 ±       0.334  MB/sec
[info] ArrayOfJavaEnumsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5        4.699 ±       7.388    B/op
[info] ArrayOfJavaEnumsWriting.json4sJackson:·gc.count                                      128  thrpt    5       34.000                counts
[info] ArrayOfJavaEnumsWriting.json4sJackson:·gc.time                                       128  thrpt    5       17.000                    ms
[info] ArrayOfJavaEnumsWriting.json4sNative                                                 128  thrpt    5    27816.919 ±     903.161   ops/s
[info] ArrayOfJavaEnumsWriting.json4sNative:·gc.alloc.rate                                  128  thrpt    5     3091.181 ±     100.748  MB/sec
[info] ArrayOfJavaEnumsWriting.json4sNative:·gc.alloc.rate.norm                             128  thrpt    5   116547.823 ±       0.160    B/op
[info] ArrayOfJavaEnumsWriting.json4sNative:·gc.churn.PS_Eden_Space                         128  thrpt    5     3070.722 ±       0.708  MB/sec
[info] ArrayOfJavaEnumsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5   115783.038 ±    3758.720    B/op
[info] ArrayOfJavaEnumsWriting.json4sNative:·gc.churn.PS_Survivor_Space                     128  thrpt    5        0.194 ±       0.261  MB/sec
[info] ArrayOfJavaEnumsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5        7.306 ±       9.909    B/op
[info] ArrayOfJavaEnumsWriting.json4sNative:·gc.count                                       128  thrpt    5       20.000                counts
[info] ArrayOfJavaEnumsWriting.json4sNative:·gc.time                                        128  thrpt    5       10.000                    ms
[info] ArrayOfLocalDateTimesReading.json4sJackson                                           128  thrpt    5    11212.038 ±     149.317   ops/s
[info] ArrayOfLocalDateTimesReading.json4sJackson:·gc.alloc.rate                            128  thrpt    5     2886.726 ±      38.475  MB/sec
[info] ArrayOfLocalDateTimesReading.json4sJackson:·gc.alloc.rate.norm                       128  thrpt    5   270025.016 ±       3.866    B/op
[info] ArrayOfLocalDateTimesReading.json4sJackson:·gc.churn.PS_Eden_Space                   128  thrpt    5     2917.171 ±    1321.858  MB/sec
[info] ArrayOfLocalDateTimesReading.json4sJackson:·gc.churn.PS_Eden_Space.norm              128  thrpt    5   272907.146 ±  124789.788    B/op
[info] ArrayOfLocalDateTimesReading.json4sJackson:·gc.churn.PS_Survivor_Space               128  thrpt    5        0.050 ±       0.108  MB/sec
[info] ArrayOfLocalDateTimesReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm          128  thrpt    5        4.670 ±      10.006    B/op
[info] ArrayOfLocalDateTimesReading.json4sJackson:·gc.count                                 128  thrpt    5       19.000                counts
[info] ArrayOfLocalDateTimesReading.json4sJackson:·gc.time                                  128  thrpt    5       10.000                    ms
[info] ArrayOfLocalDateTimesReading.json4sNative                                            128  thrpt    5    10939.206 ±      29.709   ops/s
[info] ArrayOfLocalDateTimesReading.json4sNative:·gc.alloc.rate                             128  thrpt    5     2823.037 ±       7.585  MB/sec
[info] ArrayOfLocalDateTimesReading.json4sNative:·gc.alloc.rate.norm                        128  thrpt    5   270657.288 ±       4.092    B/op
[info] ArrayOfLocalDateTimesReading.json4sNative:·gc.churn.PS_Eden_Space                    128  thrpt    5     2917.059 ±    1322.015  MB/sec
[info] ArrayOfLocalDateTimesReading.json4sNative:·gc.churn.PS_Eden_Space.norm               128  thrpt    5   279674.180 ±  126835.027    B/op
[info] ArrayOfLocalDateTimesReading.json4sNative:·gc.churn.PS_Survivor_Space                128  thrpt    5        0.119 ±       0.355  MB/sec
[info] ArrayOfLocalDateTimesReading.json4sNative:·gc.churn.PS_Survivor_Space.norm           128  thrpt    5       11.382 ±      34.027    B/op
[info] ArrayOfLocalDateTimesReading.json4sNative:·gc.count                                  128  thrpt    5       19.000                counts
[info] ArrayOfLocalDateTimesReading.json4sNative:·gc.time                                   128  thrpt    5       12.000                    ms
[info] ArrayOfLocalDateTimesWriting.json4sJackson                                           128  thrpt    5    15863.663 ±     343.797   ops/s
[info] ArrayOfLocalDateTimesWriting.json4sJackson:·gc.alloc.rate                            128  thrpt    5     4211.346 ±      91.458  MB/sec
[info] ArrayOfLocalDateTimesWriting.json4sJackson:·gc.alloc.rate.norm                       128  thrpt    5   278417.367 ±       3.519    B/op
[info] ArrayOfLocalDateTimesWriting.json4sJackson:·gc.churn.PS_Eden_Space                   128  thrpt    5     4299.061 ±    1619.192  MB/sec
[info] ArrayOfLocalDateTimesWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm              128  thrpt    5   284249.145 ±  108445.942    B/op
[info] ArrayOfLocalDateTimesWriting.json4sJackson:·gc.churn.PS_Survivor_Space               128  thrpt    5        0.162 ±       0.300  MB/sec
[info] ArrayOfLocalDateTimesWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm          128  thrpt    5       10.735 ±      19.780    B/op
[info] ArrayOfLocalDateTimesWriting.json4sJackson:·gc.count                                 128  thrpt    5       28.000                counts
[info] ArrayOfLocalDateTimesWriting.json4sJackson:·gc.time                                  128  thrpt    5       13.000                    ms
[info] ArrayOfLocalDateTimesWriting.json4sNative                                            128  thrpt    5     9135.143 ±     156.971   ops/s
[info] ArrayOfLocalDateTimesWriting.json4sNative:·gc.alloc.rate                             128  thrpt    5     2449.072 ±      42.107  MB/sec
[info] ArrayOfLocalDateTimesWriting.json4sNative:·gc.alloc.rate.norm                        128  thrpt    5   281176.720 ±       0.148    B/op
[info] ArrayOfLocalDateTimesWriting.json4sNative:·gc.churn.PS_Eden_Space                    128  thrpt    5     2302.886 ±       0.417  MB/sec
[info] ArrayOfLocalDateTimesWriting.json4sNative:·gc.churn.PS_Eden_Space.norm               128  thrpt    5   264397.338 ±    4511.200    B/op
[info] ArrayOfLocalDateTimesWriting.json4sNative:·gc.churn.PS_Survivor_Space                128  thrpt    5        0.119 ±       0.477  MB/sec
[info] ArrayOfLocalDateTimesWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm           128  thrpt    5       13.620 ±      54.671    B/op
[info] ArrayOfLocalDateTimesWriting.json4sNative:·gc.count                                  128  thrpt    5       15.000                counts
[info] ArrayOfLocalDateTimesWriting.json4sNative:·gc.time                                   128  thrpt    5        8.000                    ms
[info] ArrayOfLocalDatesReading.json4sJackson                                               128  thrpt    5    24217.923 ±     106.478   ops/s
[info] ArrayOfLocalDatesReading.json4sJackson:·gc.alloc.rate                                128  thrpt    5     2610.640 ±      11.521  MB/sec
[info] ArrayOfLocalDatesReading.json4sJackson:·gc.alloc.rate.norm                           128  thrpt    5   113059.730 ±       2.327    B/op
[info] ArrayOfLocalDatesReading.json4sJackson:·gc.churn.PS_Eden_Space                       128  thrpt    5     2610.078 ±    1618.842  MB/sec
[info] ArrayOfLocalDatesReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                  128  thrpt    5   113040.110 ±   70254.849    B/op
[info] ArrayOfLocalDatesReading.json4sJackson:·gc.churn.PS_Survivor_Space                   128  thrpt    5        0.144 ±       0.161  MB/sec
[info] ArrayOfLocalDatesReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm              128  thrpt    5        6.224 ±       7.003    B/op
[info] ArrayOfLocalDatesReading.json4sJackson:·gc.count                                     128  thrpt    5       17.000                counts
[info] ArrayOfLocalDatesReading.json4sJackson:·gc.time                                      128  thrpt    5        9.000                    ms
[info] ArrayOfLocalDatesReading.json4sNative                                                128  thrpt    5    22634.831 ±      47.890   ops/s
[info] ArrayOfLocalDatesReading.json4sNative:·gc.alloc.rate                                 128  thrpt    5     2660.524 ±       6.112  MB/sec
[info] ArrayOfLocalDatesReading.json4sNative:·gc.alloc.rate.norm                            128  thrpt    5   123276.020 ±       2.473    B/op
[info] ArrayOfLocalDatesReading.json4sNative:·gc.churn.PS_Eden_Space                        128  thrpt    5     2610.136 ±    1619.023  MB/sec
[info] ArrayOfLocalDatesReading.json4sNative:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5   120947.693 ±   75219.298    B/op
[info] ArrayOfLocalDatesReading.json4sNative:·gc.churn.PS_Survivor_Space                    128  thrpt    5        0.075 ±       0.108  MB/sec
[info] ArrayOfLocalDatesReading.json4sNative:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5        3.473 ±       4.981    B/op
[info] ArrayOfLocalDatesReading.json4sNative:·gc.count                                      128  thrpt    5       17.000                counts
[info] ArrayOfLocalDatesReading.json4sNative:·gc.time                                       128  thrpt    5        9.000                    ms
[info] ArrayOfLocalDatesWriting.json4sJackson                                               128  thrpt    5    22101.367 ±     258.159   ops/s
[info] ArrayOfLocalDatesWriting.json4sJackson:·gc.alloc.rate                                128  thrpt    5     4997.373 ±      58.290  MB/sec
[info] ArrayOfLocalDatesWriting.json4sJackson:·gc.alloc.rate.norm                           128  thrpt    5   237135.676 ±       2.473    B/op
[info] ArrayOfLocalDatesWriting.json4sJackson:·gc.churn.PS_Eden_Space                       128  thrpt    5     4913.288 ±    1619.358  MB/sec
[info] ArrayOfLocalDatesWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                  128  thrpt    5   233146.485 ±   76847.530    B/op
[info] ArrayOfLocalDatesWriting.json4sJackson:·gc.churn.PS_Survivor_Space                   128  thrpt    5        0.231 ±       0.302  MB/sec
[info] ArrayOfLocalDatesWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm              128  thrpt    5       10.967 ±      14.301    B/op
[info] ArrayOfLocalDatesWriting.json4sJackson:·gc.count                                     128  thrpt    5       32.000                counts
[info] ArrayOfLocalDatesWriting.json4sJackson:·gc.time                                      128  thrpt    5       15.000                    ms
[info] ArrayOfLocalDatesWriting.json4sNative                                                128  thrpt    5    15014.887 ±     102.748   ops/s
[info] ArrayOfLocalDatesWriting.json4sNative:·gc.alloc.rate                                 128  thrpt    5     3412.061 ±      23.285  MB/sec
[info] ArrayOfLocalDatesWriting.json4sNative:·gc.alloc.rate.norm                            128  thrpt    5   238343.776 ±       3.714    B/op
[info] ArrayOfLocalDatesWriting.json4sNative:·gc.churn.PS_Eden_Space                        128  thrpt    5     3377.783 ±    1619.007  MB/sec
[info] ArrayOfLocalDatesWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5   235961.315 ±  113563.278    B/op
[info] ArrayOfLocalDatesWriting.json4sNative:·gc.churn.PS_Survivor_Space                    128  thrpt    5        0.119 ±       0.215  MB/sec
[info] ArrayOfLocalDatesWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5        8.296 ±      15.069    B/op
[info] ArrayOfLocalDatesWriting.json4sNative:·gc.count                                      128  thrpt    5       22.000                counts
[info] ArrayOfLocalDatesWriting.json4sNative:·gc.time                                       128  thrpt    5       11.000                    ms
[info] ArrayOfLocalTimesReading.json4sJackson                                               128  thrpt    5    15407.912 ±     150.854   ops/s
[info] ArrayOfLocalTimesReading.json4sJackson:·gc.alloc.rate                                128  thrpt    5     3080.309 ±      30.316  MB/sec
[info] ArrayOfLocalTimesReading.json4sJackson:·gc.alloc.rate.norm                           128  thrpt    5   209670.892 ±       0.091    B/op
[info] ArrayOfLocalTimesReading.json4sJackson:·gc.churn.PS_Eden_Space                       128  thrpt    5     3070.645 ±       0.317  MB/sec
[info] ArrayOfLocalTimesReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                  128  thrpt    5   209014.123 ±    2043.670    B/op
[info] ArrayOfLocalTimesReading.json4sJackson:·gc.churn.PS_Survivor_Space                   128  thrpt    5        0.081 ±       0.325  MB/sec
[info] ArrayOfLocalTimesReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm              128  thrpt    5        5.530 ±      22.133    B/op
[info] ArrayOfLocalTimesReading.json4sJackson:·gc.count                                     128  thrpt    5       20.000                counts
[info] ArrayOfLocalTimesReading.json4sJackson:·gc.time                                      128  thrpt    5       11.000                    ms
[info] ArrayOfLocalTimesReading.json4sNative                                                128  thrpt    5    14985.643 ±      49.810   ops/s
[info] ArrayOfLocalTimesReading.json4sNative:·gc.alloc.rate                                 128  thrpt    5     3147.320 ±      10.490  MB/sec
[info] ArrayOfLocalTimesReading.json4sNative:·gc.alloc.rate.norm                            128  thrpt    5   220271.492 ±       3.050    B/op
[info] ArrayOfLocalTimesReading.json4sNative:·gc.churn.PS_Eden_Space                        128  thrpt    5     3224.109 ±    1322.276  MB/sec
[info] ArrayOfLocalTimesReading.json4sNative:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5   225651.390 ±   92831.110    B/op
[info] ArrayOfLocalTimesReading.json4sNative:·gc.churn.PS_Survivor_Space                    128  thrpt    5        0.194 ±       0.157  MB/sec
[info] ArrayOfLocalTimesReading.json4sNative:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5       13.554 ±      10.979    B/op
[info] ArrayOfLocalTimesReading.json4sNative:·gc.count                                      128  thrpt    5       21.000                counts
[info] ArrayOfLocalTimesReading.json4sNative:·gc.time                                       128  thrpt    5       11.000                    ms
[info] ArrayOfLocalTimesWriting.json4sJackson                                               128  thrpt    5    20119.438 ±     137.528   ops/s
[info] ArrayOfLocalTimesWriting.json4sJackson:·gc.alloc.rate                                128  thrpt    5     4353.743 ±      29.900  MB/sec
[info] ArrayOfLocalTimesWriting.json4sJackson:·gc.alloc.rate.norm                           128  thrpt    5   226959.384 ±       2.807    B/op
[info] ArrayOfLocalTimesWriting.json4sJackson:·gc.churn.PS_Eden_Space                       128  thrpt    5     4298.876 ±    1619.554  MB/sec
[info] ArrayOfLocalTimesWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                  128  thrpt    5   224088.229 ±   83895.146    B/op
[info] ArrayOfLocalTimesWriting.json4sJackson:·gc.churn.PS_Survivor_Space                   128  thrpt    5        0.194 ±       0.311  MB/sec
[info] ArrayOfLocalTimesWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm              128  thrpt    5       10.093 ±      16.194    B/op
[info] ArrayOfLocalTimesWriting.json4sJackson:·gc.count                                     128  thrpt    5       28.000                counts
[info] ArrayOfLocalTimesWriting.json4sJackson:·gc.time                                      128  thrpt    5       15.000                    ms
[info] ArrayOfLocalTimesWriting.json4sNative                                                128  thrpt    5    13328.772 ±     240.823   ops/s
[info] ArrayOfLocalTimesWriting.json4sNative:·gc.alloc.rate                                 128  thrpt    5     2899.763 ±      52.672  MB/sec
[info] ArrayOfLocalTimesWriting.json4sNative:·gc.alloc.rate.norm                            128  thrpt    5   228167.567 ±       3.359    B/op
[info] ArrayOfLocalTimesWriting.json4sNative:·gc.churn.PS_Eden_Space                        128  thrpt    5     2916.878 ±    1321.675  MB/sec
[info] ArrayOfLocalTimesWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5   229466.027 ±  102266.137    B/op
[info] ArrayOfLocalTimesWriting.json4sNative:·gc.churn.PS_Survivor_Space                    128  thrpt    5        0.150 ±       0.274  MB/sec
[info] ArrayOfLocalTimesWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5       11.801 ±      21.601    B/op
[info] ArrayOfLocalTimesWriting.json4sNative:·gc.count                                      128  thrpt    5       19.000                counts
[info] ArrayOfLocalTimesWriting.json4sNative:·gc.time                                       128  thrpt    5       10.000                    ms
[info] ArrayOfLongsReading.json4sJackson                                                    128  thrpt    5    46137.661 ±    1066.702   ops/s
[info] ArrayOfLongsReading.json4sJackson:·gc.alloc.rate                                     128  thrpt    5     2228.462 ±      51.517  MB/sec
[info] ArrayOfLongsReading.json4sJackson:·gc.alloc.rate.norm                                128  thrpt    5    50657.761 ±       0.284    B/op
[info] ArrayOfLongsReading.json4sJackson:·gc.churn.PS_Eden_Space                            128  thrpt    5     2149.467 ±    1321.929  MB/sec
[info] ArrayOfLongsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5    48881.314 ±   30492.802    B/op
[info] ArrayOfLongsReading.json4sJackson:·gc.churn.PS_Survivor_Space                        128  thrpt    5        1.597 ±      13.212  MB/sec
[info] ArrayOfLongsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5       36.123 ±     298.798    B/op
[info] ArrayOfLongsReading.json4sJackson:·gc.count                                          128  thrpt    5       14.000                counts
[info] ArrayOfLongsReading.json4sJackson:·gc.time                                           128  thrpt    5        9.000                    ms
[info] ArrayOfLongsReading.json4sNative                                                     128  thrpt    5    39916.304 ±     233.473   ops/s
[info] ArrayOfLongsReading.json4sNative:·gc.alloc.rate                                      128  thrpt    5     2628.972 ±      15.229  MB/sec
[info] ArrayOfLongsReading.json4sNative:·gc.alloc.rate.norm                                 128  thrpt    5    69074.279 ±       1.386    B/op
[info] ArrayOfLongsReading.json4sNative:·gc.churn.PS_Eden_Space                             128  thrpt    5     2610.221 ±    1619.088  MB/sec
[info] ArrayOfLongsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                        128  thrpt    5    68575.523 ±   42345.415    B/op
[info] ArrayOfLongsReading.json4sNative:·gc.churn.PS_Survivor_Space                         128  thrpt    5        0.150 ±       0.323  MB/sec
[info] ArrayOfLongsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                    128  thrpt    5        3.939 ±       8.472    B/op
[info] ArrayOfLongsReading.json4sNative:·gc.count                                           128  thrpt    5       17.000                counts
[info] ArrayOfLongsReading.json4sNative:·gc.time                                            128  thrpt    5       10.000                    ms
[info] ArrayOfLongsWriting.json4sJackson                                                    128  thrpt    5    19497.572 ±     451.194   ops/s
[info] ArrayOfLongsWriting.json4sJackson:·gc.alloc.rate                                     128  thrpt    5     5395.265 ±     125.357  MB/sec
[info] ArrayOfLongsWriting.json4sJackson:·gc.alloc.rate.norm                                128  thrpt    5   290217.513 ±       0.250    B/op
[info] ArrayOfLongsWriting.json4sJackson:·gc.churn.PS_Eden_Space                            128  thrpt    5     5373.756 ±       1.539  MB/sec
[info] ArrayOfLongsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5   289068.888 ±    6667.347    B/op
[info] ArrayOfLongsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                        128  thrpt    5        0.187 ±       0.147  MB/sec
[info] ArrayOfLongsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5       10.090 ±       8.167    B/op
[info] ArrayOfLongsWriting.json4sJackson:·gc.count                                          128  thrpt    5       35.000                counts
[info] ArrayOfLongsWriting.json4sJackson:·gc.time                                           128  thrpt    5       21.000                    ms
[info] ArrayOfLongsWriting.json4sNative                                                     128  thrpt    5    21909.872 ±     374.383   ops/s
[info] ArrayOfLongsWriting.json4sNative:·gc.alloc.rate                                      128  thrpt    5     4894.940 ±      83.778  MB/sec
[info] ArrayOfLongsWriting.json4sNative:·gc.alloc.rate.norm                                 128  thrpt    5   234303.744 ±       2.519    B/op
[info] ArrayOfLongsWriting.json4sNative:·gc.churn.PS_Eden_Space                             128  thrpt    5     4913.591 ±    1618.965  MB/sec
[info] ArrayOfLongsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                        128  thrpt    5   235190.077 ±   77016.149    B/op
[info] ArrayOfLongsWriting.json4sNative:·gc.churn.PS_Survivor_Space                         128  thrpt    5        0.162 ±       0.344  MB/sec
[info] ArrayOfLongsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                    128  thrpt    5        7.767 ±      16.351    B/op
[info] ArrayOfLongsWriting.json4sNative:·gc.count                                           128  thrpt    5       32.000                counts
[info] ArrayOfLongsWriting.json4sNative:·gc.time                                            128  thrpt    5       15.000                    ms
[info] ArrayOfMonthDaysReading.json4sJackson                                                128  thrpt    5    22932.673 ±     439.001   ops/s
[info] ArrayOfMonthDaysReading.json4sJackson:·gc.alloc.rate                                 128  thrpt    5     2396.539 ±      45.807  MB/sec
[info] ArrayOfMonthDaysReading.json4sJackson:·gc.alloc.rate.norm                            128  thrpt    5   109604.005 ±       2.847    B/op
[info] ArrayOfMonthDaysReading.json4sJackson:·gc.churn.PS_Eden_Space                        128  thrpt    5     2456.576 ±    1322.297  MB/sec
[info] ArrayOfMonthDaysReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5   112350.299 ±   60441.684    B/op
[info] ArrayOfMonthDaysReading.json4sJackson:·gc.churn.PS_Survivor_Space                    128  thrpt    5        1.599 ±      13.296  MB/sec
[info] ArrayOfMonthDaysReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5       73.212 ±     608.839    B/op
[info] ArrayOfMonthDaysReading.json4sJackson:·gc.count                                      128  thrpt    5       16.000                counts
[info] ArrayOfMonthDaysReading.json4sJackson:·gc.time                                       128  thrpt    5       11.000                    ms
[info] ArrayOfMonthDaysReading.json4sNative                                                 128  thrpt    5    21770.745 ±     118.868   ops/s
[info] ArrayOfMonthDaysReading.json4sNative:·gc.alloc.rate                                  128  thrpt    5     2483.301 ±      13.364  MB/sec
[info] ArrayOfMonthDaysReading.json4sNative:·gc.alloc.rate.norm                             128  thrpt    5   119636.510 ±       4.905    B/op
[info] ArrayOfMonthDaysReading.json4sNative:·gc.churn.PS_Eden_Space                         128  thrpt    5     2609.971 ±    1619.023  MB/sec
[info] ArrayOfMonthDaysReading.json4sNative:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5   125746.085 ±   78220.553    B/op
[info] ArrayOfMonthDaysReading.json4sNative:·gc.churn.PS_Survivor_Space                     128  thrpt    5        1.395 ±      11.075  MB/sec
[info] ArrayOfMonthDaysReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5       67.352 ±     534.816    B/op
[info] ArrayOfMonthDaysReading.json4sNative:·gc.count                                       128  thrpt    5       17.000                counts
[info] ArrayOfMonthDaysReading.json4sNative:·gc.time                                        128  thrpt    5       10.000                    ms
[info] ArrayOfMonthDaysWriting.json4sJackson                                                128  thrpt    5    25285.340 ±     350.452   ops/s
[info] ArrayOfMonthDaysWriting.json4sJackson:·gc.alloc.rate                                 128  thrpt    5     4908.469 ±      67.866  MB/sec
[info] ArrayOfMonthDaysWriting.json4sJackson:·gc.alloc.rate.norm                            128  thrpt    5   203598.709 ±       2.245    B/op
[info] ArrayOfMonthDaysWriting.json4sJackson:·gc.churn.PS_Eden_Space                        128  thrpt    5     4912.996 ±    1619.238  MB/sec
[info] ArrayOfMonthDaysWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5   203796.901 ±   67697.635    B/op
[info] ArrayOfMonthDaysWriting.json4sJackson:·gc.churn.PS_Survivor_Space                    128  thrpt    5        0.162 ±       0.311  MB/sec
[info] ArrayOfMonthDaysWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5        6.730 ±      12.850    B/op
[info] ArrayOfMonthDaysWriting.json4sJackson:·gc.count                                      128  thrpt    5       32.000                counts
[info] ArrayOfMonthDaysWriting.json4sJackson:·gc.time                                       128  thrpt    5       16.000                    ms
[info] ArrayOfMonthDaysWriting.json4sNative                                                 128  thrpt    5    18165.427 ±     809.574   ops/s
[info] ArrayOfMonthDaysWriting.json4sNative:·gc.alloc.rate                                  128  thrpt    5     3547.340 ±     157.932  MB/sec
[info] ArrayOfMonthDaysWriting.json4sNative:·gc.alloc.rate.norm                             128  thrpt    5   204806.724 ±       3.044    B/op
[info] ArrayOfMonthDaysWriting.json4sNative:·gc.churn.PS_Eden_Space                         128  thrpt    5     3531.252 ±    1619.447  MB/sec
[info] ArrayOfMonthDaysWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5   203830.672 ±   91201.619    B/op
[info] ArrayOfMonthDaysWriting.json4sNative:·gc.churn.PS_Survivor_Space                     128  thrpt    5        0.119 ±       0.157  MB/sec
[info] ArrayOfMonthDaysWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5        6.855 ±       9.117    B/op
[info] ArrayOfMonthDaysWriting.json4sNative:·gc.count                                       128  thrpt    5       23.000                counts
[info] ArrayOfMonthDaysWriting.json4sNative:·gc.time                                        128  thrpt    5       12.000                    ms
[info] ArrayOfOffsetDateTimesReading.json4sJackson                                          128  thrpt    5     8407.792 ±      83.795   ops/s
[info] ArrayOfOffsetDateTimesReading.json4sJackson:·gc.alloc.rate                           128  thrpt    5     2562.979 ±      25.393  MB/sec
[info] ArrayOfOffsetDateTimesReading.json4sJackson:·gc.alloc.rate.norm                      128  thrpt    5   319699.570 ±      12.289    B/op
[info] ArrayOfOffsetDateTimesReading.json4sJackson:·gc.churn.PS_Eden_Space                  128  thrpt    5     2610.097 ±    1618.971  MB/sec
[info] ArrayOfOffsetDateTimesReading.json4sJackson:·gc.churn.PS_Eden_Space.norm             128  thrpt    5   325564.767 ±  201536.260    B/op
[info] ArrayOfOffsetDateTimesReading.json4sJackson:·gc.churn.PS_Survivor_Space              128  thrpt    5        1.653 ±      13.493  MB/sec
[info] ArrayOfOffsetDateTimesReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm         128  thrpt    5      206.689 ±    1687.632    B/op
[info] ArrayOfOffsetDateTimesReading.json4sJackson:·gc.count                                128  thrpt    5       17.000                counts
[info] ArrayOfOffsetDateTimesReading.json4sJackson:·gc.time                                 128  thrpt    5        9.000                    ms
[info] ArrayOfOffsetDateTimesReading.json4sNative                                           128  thrpt    5     7771.430 ±     244.181   ops/s
[info] ArrayOfOffsetDateTimesReading.json4sNative:·gc.alloc.rate                            128  thrpt    5     2452.371 ±      76.815  MB/sec
[info] ArrayOfOffsetDateTimesReading.json4sNative:·gc.alloc.rate.norm                       128  thrpt    5   330955.905 ±       8.524    B/op
[info] ArrayOfOffsetDateTimesReading.json4sNative:·gc.churn.PS_Eden_Space                   128  thrpt    5     2456.199 ±    1320.084  MB/sec
[info] ArrayOfOffsetDateTimesReading.json4sNative:·gc.churn.PS_Eden_Space.norm              128  thrpt    5   331784.224 ±  190212.447    B/op
[info] ArrayOfOffsetDateTimesReading.json4sNative:·gc.churn.PS_Survivor_Space               128  thrpt    5        1.409 ±      10.859  MB/sec
[info] ArrayOfOffsetDateTimesReading.json4sNative:·gc.churn.PS_Survivor_Space.norm          128  thrpt    5      189.574 ±    1459.604    B/op
[info] ArrayOfOffsetDateTimesReading.json4sNative:·gc.count                                 128  thrpt    5       16.000                counts
[info] ArrayOfOffsetDateTimesReading.json4sNative:·gc.time                                  128  thrpt    5        7.000                    ms
[info] ArrayOfOffsetDateTimesWriting.json4sJackson                                          128  thrpt    5    15395.202 ±     221.403   ops/s
[info] ArrayOfOffsetDateTimesWriting.json4sJackson:·gc.alloc.rate                           128  thrpt    5     4135.073 ±      59.365  MB/sec
[info] ArrayOfOffsetDateTimesWriting.json4sJackson:·gc.alloc.rate.norm                      128  thrpt    5   281705.309 ±       3.649    B/op
[info] ArrayOfOffsetDateTimesWriting.json4sJackson:·gc.churn.PS_Eden_Space                  128  thrpt    5     4145.296 ±    1618.741  MB/sec
[info] ArrayOfOffsetDateTimesWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm             128  thrpt    5   282430.880 ±  111628.521    B/op
[info] ArrayOfOffsetDateTimesWriting.json4sJackson:·gc.churn.PS_Survivor_Space              128  thrpt    5        0.206 ±       0.314  MB/sec
[info] ArrayOfOffsetDateTimesWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm         128  thrpt    5       14.030 ±      21.179    B/op
[info] ArrayOfOffsetDateTimesWriting.json4sJackson:·gc.count                                128  thrpt    5       27.000                counts
[info] ArrayOfOffsetDateTimesWriting.json4sJackson:·gc.time                                 128  thrpt    5       12.000                    ms
[info] ArrayOfOffsetDateTimesWriting.json4sNative                                           128  thrpt    5     7996.377 ±     198.268   ops/s
[info] ArrayOfOffsetDateTimesWriting.json4sNative:·gc.alloc.rate                            128  thrpt    5     2192.341 ±      54.264  MB/sec
[info] ArrayOfOffsetDateTimesWriting.json4sNative:·gc.alloc.rate.norm                       128  thrpt    5   287538.173 ±      10.643    B/op
[info] ArrayOfOffsetDateTimesWriting.json4sNative:·gc.churn.PS_Eden_Space                   128  thrpt    5     2149.455 ±    1321.924  MB/sec
[info] ArrayOfOffsetDateTimesWriting.json4sNative:·gc.churn.PS_Eden_Space.norm              128  thrpt    5   282057.571 ±  176681.729    B/op
[info] ArrayOfOffsetDateTimesWriting.json4sNative:·gc.churn.PS_Survivor_Space               128  thrpt    5        1.345 ±      10.711  MB/sec
[info] ArrayOfOffsetDateTimesWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm          128  thrpt    5      177.677 ±    1415.565    B/op
[info] ArrayOfOffsetDateTimesWriting.json4sNative:·gc.count                                 128  thrpt    5       14.000                counts
[info] ArrayOfOffsetDateTimesWriting.json4sNative:·gc.time                                  128  thrpt    5        9.000                    ms
[info] ArrayOfOffsetTimesReading.json4sJackson                                              128  thrpt    5    12773.101 ±     189.785   ops/s
[info] ArrayOfOffsetTimesReading.json4sJackson:·gc.alloc.rate                               128  thrpt    5     2874.688 ±      42.627  MB/sec
[info] ArrayOfOffsetTimesReading.json4sJackson:·gc.alloc.rate.norm                          128  thrpt    5   236039.900 ±       3.543    B/op
[info] ArrayOfOffsetTimesReading.json4sJackson:·gc.churn.PS_Eden_Space                      128  thrpt    5     2917.033 ±    1321.869  MB/sec
[info] ArrayOfOffsetTimesReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                 128  thrpt    5   239594.067 ±  111119.502    B/op
[info] ArrayOfOffsetTimesReading.json4sJackson:·gc.churn.PS_Survivor_Space                  128  thrpt    5        0.119 ±       0.355  MB/sec
[info] ArrayOfOffsetTimesReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm             128  thrpt    5        9.757 ±      29.211    B/op
[info] ArrayOfOffsetTimesReading.json4sJackson:·gc.count                                    128  thrpt    5       19.000                counts
[info] ArrayOfOffsetTimesReading.json4sJackson:·gc.time                                     128  thrpt    5       10.000                    ms
[info] ArrayOfOffsetTimesReading.json4sNative                                               128  thrpt    5    12376.564 ±     289.788   ops/s
[info] ArrayOfOffsetTimesReading.json4sNative:·gc.alloc.rate                                128  thrpt    5     2909.956 ±      68.130  MB/sec
[info] ArrayOfOffsetTimesReading.json4sNative:·gc.alloc.rate.norm                           128  thrpt    5   246600.217 ±       3.852    B/op
[info] ArrayOfOffsetTimesReading.json4sNative:·gc.churn.PS_Eden_Space                       128  thrpt    5     2917.021 ±    1322.226  MB/sec
[info] ArrayOfOffsetTimesReading.json4sNative:·gc.churn.PS_Eden_Space.norm                  128  thrpt    5   247310.742 ±  115725.345    B/op
[info] ArrayOfOffsetTimesReading.json4sNative:·gc.churn.PS_Survivor_Space                   128  thrpt    5        0.137 ±       0.234  MB/sec
[info] ArrayOfOffsetTimesReading.json4sNative:·gc.churn.PS_Survivor_Space.norm              128  thrpt    5       11.628 ±      19.640    B/op
[info] ArrayOfOffsetTimesReading.json4sNative:·gc.count                                     128  thrpt    5       19.000                counts
[info] ArrayOfOffsetTimesReading.json4sNative:·gc.time                                      128  thrpt    5       10.000                    ms
[info] ArrayOfOffsetTimesWriting.json4sJackson                                              128  thrpt    5    19594.809 ±     480.756   ops/s
[info] ArrayOfOffsetTimesWriting.json4sJackson:·gc.alloc.rate                               128  thrpt    5     4243.771 ±     104.196  MB/sec
[info] ArrayOfOffsetTimesWriting.json4sJackson:·gc.alloc.rate.norm                          128  thrpt    5   227135.601 ±       2.933    B/op
[info] ArrayOfOffsetTimesWriting.json4sJackson:·gc.churn.PS_Eden_Space                      128  thrpt    5     4299.231 ±    1619.133  MB/sec
[info] ArrayOfOffsetTimesWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                 128  thrpt    5   230189.671 ±   90452.247    B/op
[info] ArrayOfOffsetTimesWriting.json4sJackson:·gc.churn.PS_Survivor_Space                  128  thrpt    5        0.237 ±       0.430  MB/sec
[info] ArrayOfOffsetTimesWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm             128  thrpt    5       12.687 ±      22.767    B/op
[info] ArrayOfOffsetTimesWriting.json4sJackson:·gc.count                                    128  thrpt    5       28.000                counts
[info] ArrayOfOffsetTimesWriting.json4sJackson:·gc.time                                     128  thrpt    5       12.000                    ms
[info] ArrayOfOffsetTimesWriting.json4sNative                                               128  thrpt    5    11638.228 ±     124.081   ops/s
[info] ArrayOfOffsetTimesWriting.json4sNative:·gc.alloc.rate                                128  thrpt    5     2585.235 ±      27.616  MB/sec
[info] ArrayOfOffsetTimesWriting.json4sNative:·gc.alloc.rate.norm                           128  thrpt    5   232967.761 ±       4.756    B/op
[info] ArrayOfOffsetTimesWriting.json4sNative:·gc.churn.PS_Eden_Space                       128  thrpt    5     2610.036 ±    1619.081  MB/sec
[info] ArrayOfOffsetTimesWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                  128  thrpt    5   235177.191 ±  145065.927    B/op
[info] ArrayOfOffsetTimesWriting.json4sNative:·gc.churn.PS_Survivor_Space                   128  thrpt    5        0.119 ±       0.299  MB/sec
[info] ArrayOfOffsetTimesWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm              128  thrpt    5       10.699 ±      26.968    B/op
[info] ArrayOfOffsetTimesWriting.json4sNative:·gc.count                                     128  thrpt    5       17.000                counts
[info] ArrayOfOffsetTimesWriting.json4sNative:·gc.time                                      128  thrpt    5        8.000                    ms
[info] ArrayOfPeriodsReading.json4sJackson                                                  128  thrpt    5    15430.052 ±     215.408   ops/s
[info] ArrayOfPeriodsReading.json4sJackson:·gc.alloc.rate                                   128  thrpt    5     1273.429 ±      17.872  MB/sec
[info] ArrayOfPeriodsReading.json4sJackson:·gc.alloc.rate.norm                              128  thrpt    5    86555.557 ±       5.368    B/op
[info] ArrayOfPeriodsReading.json4sJackson:·gc.churn.PS_Eden_Space                          128  thrpt    5     1381.768 ±    1321.941  MB/sec
[info] ArrayOfPeriodsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5    93875.648 ±   89282.967    B/op
[info] ArrayOfPeriodsReading.json4sJackson:·gc.churn.PS_Survivor_Space                      128  thrpt    5        1.560 ±      13.218  MB/sec
[info] ArrayOfPeriodsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5      105.729 ±     896.037    B/op
[info] ArrayOfPeriodsReading.json4sJackson:·gc.count                                        128  thrpt    5        9.000                counts
[info] ArrayOfPeriodsReading.json4sJackson:·gc.time                                         128  thrpt    5       16.000                    ms
[info] ArrayOfPeriodsReading.json4sNative                                                   128  thrpt    5    14842.730 ±      98.210   ops/s
[info] ArrayOfPeriodsReading.json4sNative:·gc.alloc.rate                                    128  thrpt    5     1375.760 ±       9.272  MB/sec
[info] ArrayOfPeriodsReading.json4sNative:·gc.alloc.rate.norm                               128  thrpt    5    97211.726 ±       5.629    B/op
[info] ArrayOfPeriodsReading.json4sNative:·gc.churn.PS_Eden_Space                           128  thrpt    5     1381.781 ±    1321.835  MB/sec
[info] ArrayOfPeriodsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5    97667.138 ±   93785.986    B/op
[info] ArrayOfPeriodsReading.json4sNative:·gc.churn.PS_Survivor_Space                       128  thrpt    5        1.310 ±      10.918  MB/sec
[info] ArrayOfPeriodsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5       92.525 ±     770.906    B/op
[info] ArrayOfPeriodsReading.json4sNative:·gc.count                                         128  thrpt    5        9.000                counts
[info] ArrayOfPeriodsReading.json4sNative:·gc.time                                          128  thrpt    5       11.000                    ms
[info] ArrayOfPeriodsWriting.json4sJackson                                                  128  thrpt    5    23670.836 ±     635.376   ops/s
[info] ArrayOfPeriodsWriting.json4sJackson:·gc.alloc.rate                                   128  thrpt    5     4407.414 ±     119.028  MB/sec
[info] ArrayOfPeriodsWriting.json4sJackson:·gc.alloc.rate.norm                              128  thrpt    5   195286.278 ±       2.457    B/op
[info] ArrayOfPeriodsWriting.json4sJackson:·gc.churn.PS_Eden_Space                          128  thrpt    5     4298.861 ±    1619.281  MB/sec
[info] ArrayOfPeriodsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5   190552.049 ±   75064.097    B/op
[info] ArrayOfPeriodsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                      128  thrpt    5        0.137 ±       0.314  MB/sec
[info] ArrayOfPeriodsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5        6.087 ±      13.914    B/op
[info] ArrayOfPeriodsWriting.json4sJackson:·gc.count                                        128  thrpt    5       28.000                counts
[info] ArrayOfPeriodsWriting.json4sJackson:·gc.time                                         128  thrpt    5       15.000                    ms
[info] ArrayOfPeriodsWriting.json4sNative                                                   128  thrpt    5    12329.947 ±     142.462   ops/s
[info] ArrayOfPeriodsWriting.json4sNative:·gc.alloc.rate                                    128  thrpt    5     2364.339 ±      27.148  MB/sec
[info] ArrayOfPeriodsWriting.json4sNative:·gc.alloc.rate.norm                               128  thrpt    5   201119.026 ±       4.906    B/op
[info] ArrayOfPeriodsWriting.json4sNative:·gc.churn.PS_Eden_Space                           128  thrpt    5     2302.949 ±       0.331  MB/sec
[info] ArrayOfPeriodsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5   195898.360 ±    2240.392    B/op
[info] ArrayOfPeriodsWriting.json4sNative:·gc.churn.PS_Survivor_Space                       128  thrpt    5        1.332 ±      10.733  MB/sec
[info] ArrayOfPeriodsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5      113.834 ±     917.562    B/op
[info] ArrayOfPeriodsWriting.json4sNative:·gc.count                                         128  thrpt    5       15.000                counts
[info] ArrayOfPeriodsWriting.json4sNative:·gc.time                                          128  thrpt    5        9.000                    ms
[info] ArrayOfShortsReading.json4sJackson                                                   128  thrpt    5    51791.192 ±     956.615   ops/s
[info] ArrayOfShortsReading.json4sJackson:·gc.alloc.rate                                    128  thrpt    5     1875.432 ±      34.615  MB/sec
[info] ArrayOfShortsReading.json4sJackson:·gc.alloc.rate.norm                               128  thrpt    5    37977.468 ±       0.994    B/op
[info] ArrayOfShortsReading.json4sJackson:·gc.churn.PS_Eden_Space                           128  thrpt    5     1996.047 ±    1619.074  MB/sec
[info] ArrayOfShortsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5    40418.570 ±   32752.380    B/op
[info] ArrayOfShortsReading.json4sJackson:·gc.churn.PS_Survivor_Space                       128  thrpt    5        1.572 ±      13.175  MB/sec
[info] ArrayOfShortsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5       31.944 ±     267.835    B/op
[info] ArrayOfShortsReading.json4sJackson:·gc.count                                         128  thrpt    5       13.000                counts
[info] ArrayOfShortsReading.json4sJackson:·gc.time                                          128  thrpt    5       13.000                    ms
[info] ArrayOfShortsReading.json4sNative                                                    128  thrpt    5    50233.741 ±     210.051   ops/s
[info] ArrayOfShortsReading.json4sNative:·gc.alloc.rate                                     128  thrpt    5     2640.129 ±      11.012  MB/sec
[info] ArrayOfShortsReading.json4sNative:·gc.alloc.rate.norm                                128  thrpt    5    55121.811 ±       1.113    B/op
[info] ArrayOfShortsReading.json4sNative:·gc.churn.PS_Eden_Space                            128  thrpt    5     2610.083 ±    1619.124  MB/sec
[info] ArrayOfShortsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5    54500.184 ±   33983.725    B/op
[info] ArrayOfShortsReading.json4sNative:·gc.churn.PS_Survivor_Space                        128  thrpt    5        0.106 ±       0.219  MB/sec
[info] ArrayOfShortsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5        2.218 ±       4.571    B/op
[info] ArrayOfShortsReading.json4sNative:·gc.count                                          128  thrpt    5       17.000                counts
[info] ArrayOfShortsReading.json4sNative:·gc.time                                           128  thrpt    5        8.000                    ms
[info] ArrayOfShortsWriting.json4sJackson                                                   128  thrpt    5    21026.413 ±     491.478   ops/s
[info] ArrayOfShortsWriting.json4sJackson:·gc.alloc.rate                                    128  thrpt    5     5088.935 ±     118.807  MB/sec
[info] ArrayOfShortsWriting.json4sJackson:·gc.alloc.rate.norm                               128  thrpt    5   253840.313 ±       2.515    B/op
[info] ArrayOfShortsWriting.json4sJackson:·gc.churn.PS_Eden_Space                           128  thrpt    5     5066.496 ±    1619.325  MB/sec
[info] ArrayOfShortsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5   252679.109 ±   78184.857    B/op
[info] ArrayOfShortsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                       128  thrpt    5        0.294 ±       0.522  MB/sec
[info] ArrayOfShortsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5       14.641 ±      25.942    B/op
[info] ArrayOfShortsWriting.json4sJackson:·gc.count                                         128  thrpt    5       33.000                counts
[info] ArrayOfShortsWriting.json4sJackson:·gc.time                                          128  thrpt    5       14.000                    ms
[info] ArrayOfShortsWriting.json4sNative                                                    128  thrpt    5    23214.005 ±     172.669   ops/s
[info] ArrayOfShortsWriting.json4sNative:·gc.alloc.rate                                     128  thrpt    5     4942.142 ±      36.725  MB/sec
[info] ArrayOfShortsWriting.json4sNative:·gc.alloc.rate.norm                                128  thrpt    5   223287.309 ±       2.483    B/op
[info] ArrayOfShortsWriting.json4sNative:·gc.churn.PS_Eden_Space                            128  thrpt    5     4913.025 ±    1619.212  MB/sec
[info] ArrayOfShortsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5   221984.884 ±   73889.843    B/op
[info] ArrayOfShortsWriting.json4sNative:·gc.churn.PS_Survivor_Space                        128  thrpt    5        0.219 ±       0.510  MB/sec
[info] ArrayOfShortsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5        9.883 ±      23.106    B/op
[info] ArrayOfShortsWriting.json4sNative:·gc.count                                          128  thrpt    5       32.000                counts
[info] ArrayOfShortsWriting.json4sNative:·gc.time                                           128  thrpt    5       18.000                    ms
[info] ArrayOfUUIDsReading.json4sJackson                                                    128  thrpt    5    40841.865 ±     310.901   ops/s
[info] ArrayOfUUIDsReading.json4sJackson:·gc.alloc.rate                                     128  thrpt    5     2378.906 ±      18.229  MB/sec
[info] ArrayOfUUIDsReading.json4sJackson:·gc.alloc.rate.norm                                128  thrpt    5    61090.249 ±       1.608    B/op
[info] ArrayOfUUIDsReading.json4sJackson:·gc.churn.PS_Eden_Space                            128  thrpt    5     2456.520 ±    1322.451  MB/sec
[info] ArrayOfUUIDsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5    63079.240 ±   33786.841    B/op
[info] ArrayOfUUIDsReading.json4sJackson:·gc.churn.PS_Survivor_Space                        128  thrpt    5        1.615 ±      13.104  MB/sec
[info] ArrayOfUUIDsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5       41.604 ±     337.620    B/op
[info] ArrayOfUUIDsReading.json4sJackson:·gc.count                                          128  thrpt    5       16.000                counts
[info] ArrayOfUUIDsReading.json4sJackson:·gc.time                                           128  thrpt    5       10.000                    ms
[info] ArrayOfUUIDsReading.json4sNative                                                     128  thrpt    5    31113.025 ±     627.677   ops/s
[info] ArrayOfUUIDsReading.json4sNative:·gc.alloc.rate                                      128  thrpt    5     2145.735 ±      43.245  MB/sec
[info] ArrayOfUUIDsReading.json4sNative:·gc.alloc.rate.norm                                 128  thrpt    5    72330.631 ±       2.706    B/op
[info] ArrayOfUUIDsReading.json4sNative:·gc.churn.PS_Eden_Space                             128  thrpt    5     2149.458 ±    1322.087  MB/sec
[info] ArrayOfUUIDsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                        128  thrpt    5    72465.728 ±   44783.637    B/op
[info] ArrayOfUUIDsReading.json4sNative:·gc.churn.PS_Survivor_Space                         128  thrpt    5        1.364 ±      10.810  MB/sec
[info] ArrayOfUUIDsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                    128  thrpt    5       46.088 ±     365.528    B/op
[info] ArrayOfUUIDsReading.json4sNative:·gc.count                                           128  thrpt    5       14.000                counts
[info] ArrayOfUUIDsReading.json4sNative:·gc.time                                            128  thrpt    5       10.000                    ms
[info] ArrayOfUUIDsWriting.json4sJackson                                                    128  thrpt    5    28376.776 ±     441.512   ops/s
[info] ArrayOfUUIDsWriting.json4sJackson:·gc.alloc.rate                                     128  thrpt    5     4933.651 ±      77.240  MB/sec
[info] ArrayOfUUIDsWriting.json4sJackson:·gc.alloc.rate.norm                                128  thrpt    5   182349.979 ±       2.004    B/op
[info] ArrayOfUUIDsWriting.json4sJackson:·gc.churn.PS_Eden_Space                            128  thrpt    5     4913.056 ±    1619.181  MB/sec
[info] ArrayOfUUIDsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5   181611.316 ±   61069.249    B/op
[info] ArrayOfUUIDsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                        128  thrpt    5        0.187 ±       0.531  MB/sec
[info] ArrayOfUUIDsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5        6.932 ±      19.715    B/op
[info] ArrayOfUUIDsWriting.json4sJackson:·gc.count                                          128  thrpt    5       32.000                counts
[info] ArrayOfUUIDsWriting.json4sJackson:·gc.time                                           128  thrpt    5       17.000                    ms
[info] ArrayOfUUIDsWriting.json4sNative                                                     128  thrpt    5     9078.517 ±      36.692   ops/s
[info] ArrayOfUUIDsWriting.json4sNative:·gc.alloc.rate                                      128  thrpt    5     1708.834 ±       6.800  MB/sec
[info] ArrayOfUUIDsWriting.json4sNative:·gc.alloc.rate.norm                                 128  thrpt    5   197415.225 ±       7.283    B/op
[info] ArrayOfUUIDsWriting.json4sNative:·gc.churn.PS_Eden_Space                             128  thrpt    5     1688.753 ±    1321.520  MB/sec
[info] ArrayOfUUIDsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                        128  thrpt    5   195087.203 ±  152420.096    B/op
[info] ArrayOfUUIDsWriting.json4sNative:·gc.churn.PS_Survivor_Space                         128  thrpt    5        1.293 ±      10.778  MB/sec
[info] ArrayOfUUIDsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                    128  thrpt    5      149.556 ±    1246.733    B/op
[info] ArrayOfUUIDsWriting.json4sNative:·gc.count                                           128  thrpt    5       11.000                counts
[info] ArrayOfUUIDsWriting.json4sNative:·gc.time                                            128  thrpt    5        9.000                    ms
[info] ArrayOfYearMonthsReading.json4sJackson                                               128  thrpt    5    23982.800 ±     626.735   ops/s
[info] ArrayOfYearMonthsReading.json4sJackson:·gc.alloc.rate                                128  thrpt    5     2576.504 ±      67.411  MB/sec
[info] ArrayOfYearMonthsReading.json4sJackson:·gc.alloc.rate.norm                           128  thrpt    5   112675.546 ±       1.897    B/op
[info] ArrayOfYearMonthsReading.json4sJackson:·gc.churn.PS_Eden_Space                       128  thrpt    5     2456.511 ±    1322.058  MB/sec
[info] ArrayOfYearMonthsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                  128  thrpt    5   107438.896 ±   58160.976    B/op
[info] ArrayOfYearMonthsReading.json4sJackson:·gc.churn.PS_Survivor_Space                   128  thrpt    5        0.062 ±       0.241  MB/sec
[info] ArrayOfYearMonthsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm              128  thrpt    5        2.740 ±      10.557    B/op
[info] ArrayOfYearMonthsReading.json4sJackson:·gc.count                                     128  thrpt    5       16.000                counts
[info] ArrayOfYearMonthsReading.json4sJackson:·gc.time                                      128  thrpt    5       10.000                    ms
[info] ArrayOfYearMonthsReading.json4sNative                                                128  thrpt    5    23455.501 ±      82.238   ops/s
[info] ArrayOfYearMonthsReading.json4sNative:·gc.alloc.rate                                 128  thrpt    5     2744.185 ±       9.663  MB/sec
[info] ArrayOfYearMonthsReading.json4sNative:·gc.alloc.rate.norm                            128  thrpt    5   122708.106 ±       2.410    B/op
[info] ArrayOfYearMonthsReading.json4sNative:·gc.churn.PS_Eden_Space                        128  thrpt    5     2763.651 ±    1619.130  MB/sec
[info] ArrayOfYearMonthsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5   123587.925 ±   72678.415    B/op
[info] ArrayOfYearMonthsReading.json4sNative:·gc.churn.PS_Survivor_Space                    128  thrpt    5        0.150 ±       0.287  MB/sec
[info] ArrayOfYearMonthsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5        6.706 ±      12.849    B/op
[info] ArrayOfYearMonthsReading.json4sNative:·gc.count                                      128  thrpt    5       18.000                counts
[info] ArrayOfYearMonthsReading.json4sNative:·gc.time                                       128  thrpt    5        9.000                    ms
[info] ArrayOfYearMonthsWriting.json4sJackson                                               128  thrpt    5    32664.598 ±     450.357   ops/s
[info] ArrayOfYearMonthsWriting.json4sJackson:·gc.alloc.rate                                128  thrpt    5     5033.309 ±      69.369  MB/sec
[info] ArrayOfYearMonthsWriting.json4sJackson:·gc.alloc.rate.norm                           128  thrpt    5   161613.355 ±       1.715    B/op
[info] ArrayOfYearMonthsWriting.json4sJackson:·gc.churn.PS_Eden_Space                       128  thrpt    5     5066.437 ±    1618.784  MB/sec
[info] ArrayOfYearMonthsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                  128  thrpt    5   162668.916 ±   51476.164    B/op
[info] ArrayOfYearMonthsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                   128  thrpt    5        0.206 ±       0.264  MB/sec
[info] ArrayOfYearMonthsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm              128  thrpt    5        6.624 ±       8.520    B/op
[info] ArrayOfYearMonthsWriting.json4sJackson:·gc.count                                     128  thrpt    5       33.000                counts
[info] ArrayOfYearMonthsWriting.json4sJackson:·gc.time                                      128  thrpt    5       15.000                    ms
[info] ArrayOfYearMonthsWriting.json4sNative                                                128  thrpt    5    21043.295 ±     304.105   ops/s
[info] ArrayOfYearMonthsWriting.json4sNative:·gc.alloc.rate                                 128  thrpt    5     3266.879 ±      47.050  MB/sec
[info] ArrayOfYearMonthsWriting.json4sNative:·gc.alloc.rate.norm                            128  thrpt    5   162821.295 ±       2.133    B/op
[info] ArrayOfYearMonthsWriting.json4sNative:·gc.churn.PS_Eden_Space                        128  thrpt    5     3224.134 ±    1321.917  MB/sec
[info] ArrayOfYearMonthsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5   160684.073 ±   65475.400    B/op
[info] ArrayOfYearMonthsWriting.json4sNative:·gc.churn.PS_Survivor_Space                    128  thrpt    5        0.156 ±       0.241  MB/sec
[info] ArrayOfYearMonthsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5        7.786 ±      12.000    B/op
[info] ArrayOfYearMonthsWriting.json4sNative:·gc.count                                      128  thrpt    5       21.000                counts
[info] ArrayOfYearMonthsWriting.json4sNative:·gc.time                                       128  thrpt    5       11.000                    ms
[info] ArrayOfYearsReading.json4sJackson                                                    128  thrpt    5    27356.600 ±     225.242   ops/s
[info] ArrayOfYearsReading.json4sJackson:·gc.alloc.rate                                     128  thrpt    5     2793.802 ±      23.031  MB/sec
[info] ArrayOfYearsReading.json4sJackson:·gc.alloc.rate.norm                                128  thrpt    5   107107.502 ±       2.091    B/op
[info] ArrayOfYearsReading.json4sJackson:·gc.churn.PS_Eden_Space                            128  thrpt    5     2763.700 ±    1619.035  MB/sec
[info] ArrayOfYearsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5   105981.091 ±   62883.349    B/op
[info] ArrayOfYearsReading.json4sJackson:·gc.churn.PS_Survivor_Space                        128  thrpt    5        0.087 ±       0.198  MB/sec
[info] ArrayOfYearsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5        3.353 ±       7.579    B/op
[info] ArrayOfYearsReading.json4sJackson:·gc.count                                          128  thrpt    5       18.000                counts
[info] ArrayOfYearsReading.json4sJackson:·gc.time                                           128  thrpt    5       10.000                    ms
[info] ArrayOfYearsReading.json4sNative                                                     128  thrpt    5    26421.834 ±     171.618   ops/s
[info] ArrayOfYearsReading.json4sNative:·gc.alloc.rate                                      128  thrpt    5     2951.660 ±      19.304  MB/sec
[info] ArrayOfYearsReading.json4sNative:·gc.alloc.rate.norm                                 128  thrpt    5   117163.845 ±       1.745    B/op
[info] ArrayOfYearsReading.json4sNative:·gc.churn.PS_Eden_Space                             128  thrpt    5     2917.233 ±    1321.620  MB/sec
[info] ArrayOfYearsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                        128  thrpt    5   115799.232 ±   52524.266    B/op
[info] ArrayOfYearsReading.json4sNative:·gc.churn.PS_Survivor_Space                         128  thrpt    5        0.137 ±       0.347  MB/sec
[info] ArrayOfYearsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                    128  thrpt    5        5.454 ±      13.731    B/op
[info] ArrayOfYearsReading.json4sNative:·gc.count                                           128  thrpt    5       19.000                counts
[info] ArrayOfYearsReading.json4sNative:·gc.time                                            128  thrpt    5       10.000                    ms
[info] ArrayOfYearsWriting.json4sJackson                                                    128  thrpt    5    33954.725 ±    1580.436   ops/s
[info] ArrayOfYearsWriting.json4sJackson:·gc.alloc.rate                                     128  thrpt    5     5240.569 ±     243.958  MB/sec
[info] ArrayOfYearsWriting.json4sJackson:·gc.alloc.rate.norm                                128  thrpt    5   161869.308 ±       1.526    B/op
[info] ArrayOfYearsWriting.json4sJackson:·gc.churn.PS_Eden_Space                            128  thrpt    5     5220.347 ±    1322.869  MB/sec
[info] ArrayOfYearsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5   161336.787 ±   46066.333    B/op
[info] ArrayOfYearsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                        128  thrpt    5        0.162 ±       0.334  MB/sec
[info] ArrayOfYearsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5        5.022 ±      10.389    B/op
[info] ArrayOfYearsWriting.json4sJackson:·gc.count                                          128  thrpt    5       34.000                counts
[info] ArrayOfYearsWriting.json4sJackson:·gc.time                                           128  thrpt    5       17.000                    ms
[info] ArrayOfYearsWriting.json4sNative                                                     128  thrpt    5    23919.314 ±     112.804   ops/s
[info] ArrayOfYearsWriting.json4sNative:·gc.alloc.rate                                      128  thrpt    5     3666.191 ±      16.933  MB/sec
[info] ArrayOfYearsWriting.json4sNative:·gc.alloc.rate.norm                                 128  thrpt    5   160757.108 ±       2.320    B/op
[info] ArrayOfYearsWriting.json4sNative:·gc.churn.PS_Eden_Space                             128  thrpt    5     3531.175 ±    1619.037  MB/sec
[info] ArrayOfYearsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                        128  thrpt    5   154849.065 ±   71460.481    B/op
[info] ArrayOfYearsWriting.json4sNative:·gc.churn.PS_Survivor_Space                         128  thrpt    5        0.194 ±       0.610  MB/sec
[info] ArrayOfYearsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                    128  thrpt    5        8.492 ±      26.720    B/op
[info] ArrayOfYearsWriting.json4sNative:·gc.count                                           128  thrpt    5       23.000                counts
[info] ArrayOfYearsWriting.json4sNative:·gc.time                                            128  thrpt    5       13.000                    ms
[info] ArrayOfZoneIdsReading.json4sJackson                                                  128  thrpt    5    43508.384 ±    2521.858   ops/s
[info] ArrayOfZoneIdsReading.json4sJackson:·gc.alloc.rate                                   128  thrpt    5     2477.204 ±     143.423  MB/sec
[info] ArrayOfZoneIdsReading.json4sJackson:·gc.alloc.rate.norm                              128  thrpt    5    59714.112 ±       1.525    B/op
[info] ArrayOfZoneIdsReading.json4sJackson:·gc.churn.PS_Eden_Space                          128  thrpt    5     2456.679 ±    1322.821  MB/sec
[info] ArrayOfZoneIdsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5    59305.801 ±   35050.137    B/op
[info] ArrayOfZoneIdsReading.json4sJackson:·gc.churn.PS_Survivor_Space                      128  thrpt    5        1.699 ±      14.293  MB/sec
[info] ArrayOfZoneIdsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5       40.598 ±     341.456    B/op
[info] ArrayOfZoneIdsReading.json4sJackson:·gc.count                                        128  thrpt    5       16.000                counts
[info] ArrayOfZoneIdsReading.json4sJackson:·gc.time                                         128  thrpt    5        8.000                    ms
[info] ArrayOfZoneIdsReading.json4sNative                                                   128  thrpt    5    39969.002 ±     551.502   ops/s
[info] ArrayOfZoneIdsReading.json4sNative:·gc.alloc.rate                                    128  thrpt    5     2668.115 ±      36.691  MB/sec
[info] ArrayOfZoneIdsReading.json4sNative:·gc.alloc.rate.norm                               128  thrpt    5    70010.410 ±       1.430    B/op
[info] ArrayOfZoneIdsReading.json4sNative:·gc.churn.PS_Eden_Space                           128  thrpt    5     2763.670 ±    1619.008  MB/sec
[info] ArrayOfZoneIdsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5    72540.600 ±   43151.219    B/op
[info] ArrayOfZoneIdsReading.json4sNative:·gc.churn.PS_Survivor_Space                       128  thrpt    5        0.100 ±       0.469  MB/sec
[info] ArrayOfZoneIdsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5        2.619 ±      12.272    B/op
[info] ArrayOfZoneIdsReading.json4sNative:·gc.count                                         128  thrpt    5       18.000                counts
[info] ArrayOfZoneIdsReading.json4sNative:·gc.time                                          128  thrpt    5       10.000                    ms
[info] ArrayOfZoneIdsWriting.json4sJackson                                                  128  thrpt    5    39636.594 ±     389.548   ops/s
[info] ArrayOfZoneIdsWriting.json4sJackson:·gc.alloc.rate                                   128  thrpt    5     5017.574 ±      48.982  MB/sec
[info] ArrayOfZoneIdsWriting.json4sJackson:·gc.alloc.rate.norm                              128  thrpt    5   132764.414 ±       1.434    B/op
[info] ArrayOfZoneIdsWriting.json4sJackson:·gc.churn.PS_Eden_Space                          128  thrpt    5     5066.885 ±    1618.573  MB/sec
[info] ArrayOfZoneIdsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5   134071.060 ±   42916.042    B/op
[info] ArrayOfZoneIdsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                      128  thrpt    5        0.156 ±       0.190  MB/sec
[info] ArrayOfZoneIdsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5        4.132 ±       5.011    B/op
[info] ArrayOfZoneIdsWriting.json4sJackson:·gc.count                                        128  thrpt    5       33.000                counts
[info] ArrayOfZoneIdsWriting.json4sJackson:·gc.time                                         128  thrpt    5       15.000                    ms
[info] ArrayOfZoneIdsWriting.json4sNative                                                   128  thrpt    5    19526.101 ±     475.096   ops/s
[info] ArrayOfZoneIdsWriting.json4sNative:·gc.alloc.rate                                    128  thrpt    5     2494.201 ±      60.704  MB/sec
[info] ArrayOfZoneIdsWriting.json4sNative:·gc.alloc.rate.norm                               128  thrpt    5   133972.359 ±       2.398    B/op
[info] ArrayOfZoneIdsWriting.json4sNative:·gc.churn.PS_Eden_Space                           128  thrpt    5     2456.488 ±    1321.575  MB/sec
[info] ArrayOfZoneIdsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5   132013.774 ±   73596.542    B/op
[info] ArrayOfZoneIdsWriting.json4sNative:·gc.churn.PS_Survivor_Space                       128  thrpt    5        0.175 ±       0.346  MB/sec
[info] ArrayOfZoneIdsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5        9.415 ±      18.824    B/op
[info] ArrayOfZoneIdsWriting.json4sNative:·gc.count                                         128  thrpt    5       16.000                counts
[info] ArrayOfZoneIdsWriting.json4sNative:·gc.time                                          128  thrpt    5        8.000                    ms
[info] ArrayOfZoneOffsetsReading.json4sJackson                                              128  thrpt    5    53115.281 ±    1904.361   ops/s
[info] ArrayOfZoneOffsetsReading.json4sJackson:·gc.alloc.rate                               128  thrpt    5     2480.444 ±      88.660  MB/sec
[info] ArrayOfZoneOffsetsReading.json4sJackson:·gc.alloc.rate.norm                          128  thrpt    5    48977.730 ±       1.248    B/op
[info] ArrayOfZoneOffsetsReading.json4sJackson:·gc.churn.PS_Eden_Space                      128  thrpt    5     2456.588 ±    1322.150  MB/sec
[info] ArrayOfZoneOffsetsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                 128  thrpt    5    48484.141 ±   25088.801    B/op
[info] ArrayOfZoneOffsetsReading.json4sJackson:·gc.churn.PS_Survivor_Space                  128  thrpt    5        1.644 ±      13.082  MB/sec
[info] ArrayOfZoneOffsetsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm             128  thrpt    5       32.796 ±     261.321    B/op
[info] ArrayOfZoneOffsetsReading.json4sJackson:·gc.count                                    128  thrpt    5       16.000                counts
[info] ArrayOfZoneOffsetsReading.json4sJackson:·gc.time                                     128  thrpt    5        9.000                    ms
[info] ArrayOfZoneOffsetsReading.json4sNative                                               128  thrpt    5    49404.827 ±     126.713   ops/s
[info] ArrayOfZoneOffsetsReading.json4sNative:·gc.alloc.rate                                128  thrpt    5     2792.453 ±       7.129  MB/sec
[info] ArrayOfZoneOffsetsReading.json4sNative:·gc.alloc.rate.norm                           128  thrpt    5    59281.949 ±       1.144    B/op
[info] ArrayOfZoneOffsetsReading.json4sNative:·gc.churn.PS_Eden_Space                       128  thrpt    5     2763.534 ±    1618.722  MB/sec
[info] ArrayOfZoneOffsetsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                  128  thrpt    5    58669.689 ±   34414.173    B/op
[info] ArrayOfZoneOffsetsReading.json4sNative:·gc.churn.PS_Survivor_Space                   128  thrpt    5        0.194 ±       0.393  MB/sec
[info] ArrayOfZoneOffsetsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm              128  thrpt    5        4.111 ±       8.348    B/op
[info] ArrayOfZoneOffsetsReading.json4sNative:·gc.count                                     128  thrpt    5       18.000                counts
[info] ArrayOfZoneOffsetsReading.json4sNative:·gc.time                                      128  thrpt    5       10.000                    ms
[info] ArrayOfZoneOffsetsWriting.json4sJackson                                              128  thrpt    5    43340.380 ±    1462.842   ops/s
[info] ArrayOfZoneOffsetsWriting.json4sJackson:·gc.alloc.rate                               128  thrpt    5     5100.571 ±     172.331  MB/sec
[info] ArrayOfZoneOffsetsWriting.json4sJackson:·gc.alloc.rate.norm                          128  thrpt    5   123436.036 ±       1.236    B/op
[info] ArrayOfZoneOffsetsWriting.json4sJackson:·gc.churn.PS_Eden_Space                      128  thrpt    5     5066.452 ±    1619.755  MB/sec
[info] ArrayOfZoneOffsetsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                 128  thrpt    5   122577.249 ±   37046.250    B/op
[info] ArrayOfZoneOffsetsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                  128  thrpt    5        0.181 ±       0.231  MB/sec
[info] ArrayOfZoneOffsetsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm             128  thrpt    5        4.388 ±       5.638    B/op
[info] ArrayOfZoneOffsetsWriting.json4sJackson:·gc.count                                    128  thrpt    5       33.000                counts
[info] ArrayOfZoneOffsetsWriting.json4sJackson:·gc.time                                     128  thrpt    5       16.000                    ms
[info] ArrayOfZoneOffsetsWriting.json4sNative                                               128  thrpt    5    27080.932 ±     734.305   ops/s
[info] ArrayOfZoneOffsetsWriting.json4sNative:·gc.alloc.rate                                128  thrpt    5     3158.497 ±      85.660  MB/sec
[info] ArrayOfZoneOffsetsWriting.json4sNative:·gc.alloc.rate.norm                           128  thrpt    5   122324.114 ±       1.586    B/op
[info] ArrayOfZoneOffsetsWriting.json4sNative:·gc.churn.PS_Eden_Space                       128  thrpt    5     3224.163 ±    1321.589  MB/sec
[info] ArrayOfZoneOffsetsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                  128  thrpt    5   124820.246 ±   48555.903    B/op
[info] ArrayOfZoneOffsetsWriting.json4sNative:·gc.churn.PS_Survivor_Space                   128  thrpt    5        0.100 ±       0.198  MB/sec
[info] ArrayOfZoneOffsetsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm              128  thrpt    5        3.879 ±       7.782    B/op
[info] ArrayOfZoneOffsetsWriting.json4sNative:·gc.count                                     128  thrpt    5       21.000                counts
[info] ArrayOfZoneOffsetsWriting.json4sNative:·gc.time                                      128  thrpt    5       10.000                    ms
[info] ArrayOfZonedDateTimesReading.json4sJackson                                           128  thrpt    5     5977.332 ±     163.170   ops/s
[info] ArrayOfZonedDateTimesReading.json4sJackson:·gc.alloc.rate                            128  thrpt    5     2328.501 ±      63.275  MB/sec
[info] ArrayOfZonedDateTimesReading.json4sJackson:·gc.alloc.rate.norm                       128  thrpt    5   408574.490 ±      10.279    B/op
[info] ArrayOfZonedDateTimesReading.json4sJackson:·gc.churn.PS_Eden_Space                   128  thrpt    5     2302.892 ±       0.736  MB/sec
[info] ArrayOfZonedDateTimesReading.json4sJackson:·gc.churn.PS_Eden_Space.norm              128  thrpt    5   404097.190 ±   11041.323    B/op
[info] ArrayOfZonedDateTimesReading.json4sJackson:·gc.churn.PS_Survivor_Space               128  thrpt    5        1.765 ±      14.603  MB/sec
[info] ArrayOfZonedDateTimesReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm          128  thrpt    5      312.366 ±    2585.029    B/op
[info] ArrayOfZonedDateTimesReading.json4sJackson:·gc.count                                 128  thrpt    5       15.000                counts
[info] ArrayOfZonedDateTimesReading.json4sJackson:·gc.time                                  128  thrpt    5       12.000                    ms
[info] ArrayOfZonedDateTimesReading.json4sNative                                            128  thrpt    5     5655.117 ±      15.484   ops/s
[info] ArrayOfZonedDateTimesReading.json4sNative:·gc.alloc.rate                             128  thrpt    5     2265.918 ±       6.048  MB/sec
[info] ArrayOfZonedDateTimesReading.json4sNative:·gc.alloc.rate.norm                        128  thrpt    5   420238.492 ±      15.053    B/op
[info] ArrayOfZonedDateTimesReading.json4sNative:·gc.churn.PS_Eden_Space                    128  thrpt    5     2149.383 ±    1322.104  MB/sec
[info] ArrayOfZonedDateTimesReading.json4sNative:·gc.churn.PS_Eden_Space.norm               128  thrpt    5   398651.567 ±  245807.198    B/op
[info] ArrayOfZonedDateTimesReading.json4sNative:·gc.churn.PS_Survivor_Space                128  thrpt    5        1.479 ±      12.334  MB/sec
[info] ArrayOfZonedDateTimesReading.json4sNative:·gc.churn.PS_Survivor_Space.norm           128  thrpt    5      274.544 ±    2289.319    B/op
[info] ArrayOfZonedDateTimesReading.json4sNative:·gc.count                                  128  thrpt    5       14.000                counts
[info] ArrayOfZonedDateTimesReading.json4sNative:·gc.time                                   128  thrpt    5       10.000                    ms
[info] ArrayOfZonedDateTimesWriting.json4sJackson                                           128  thrpt    5    17091.403 ±     179.914   ops/s
[info] ArrayOfZonedDateTimesWriting.json4sJackson:·gc.alloc.rate                            128  thrpt    5     4023.280 ±      42.466  MB/sec
[info] ArrayOfZonedDateTimesWriting.json4sJackson:·gc.alloc.rate.norm                       128  thrpt    5   246888.075 ±       2.578    B/op
[info] ArrayOfZonedDateTimesWriting.json4sJackson:·gc.churn.PS_Eden_Space                   128  thrpt    5     3991.815 ±    1321.906  MB/sec
[info] ArrayOfZonedDateTimesWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm              128  thrpt    5   244938.983 ±   79921.083    B/op
[info] ArrayOfZonedDateTimesWriting.json4sJackson:·gc.churn.PS_Survivor_Space               128  thrpt    5        0.125 ±       0.190  MB/sec
[info] ArrayOfZonedDateTimesWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm          128  thrpt    5        7.665 ±      11.664    B/op
[info] ArrayOfZonedDateTimesWriting.json4sJackson:·gc.count                                 128  thrpt    5       26.000                counts
[info] ArrayOfZonedDateTimesWriting.json4sJackson:·gc.time                                  128  thrpt    5       13.000                    ms
[info] ArrayOfZonedDateTimesWriting.json4sNative                                            128  thrpt    5     6822.443 ±      51.472   ops/s
[info] ArrayOfZonedDateTimesWriting.json4sNative:·gc.alloc.rate                             128  thrpt    5     1704.019 ±      12.897  MB/sec
[info] ArrayOfZonedDateTimesWriting.json4sNative:·gc.alloc.rate.norm                        128  thrpt    5   261953.615 ±       9.681    B/op
[info] ArrayOfZonedDateTimesWriting.json4sNative:·gc.churn.PS_Eden_Space                    128  thrpt    5     1688.823 ±    1322.157  MB/sec
[info] ArrayOfZonedDateTimesWriting.json4sNative:·gc.churn.PS_Eden_Space.norm               128  thrpt    5   259652.438 ±  204285.543    B/op
[info] ArrayOfZonedDateTimesWriting.json4sNative:·gc.churn.PS_Survivor_Space                128  thrpt    5        1.428 ±      12.029  MB/sec
[info] ArrayOfZonedDateTimesWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm           128  thrpt    5      219.415 ±    1848.593    B/op
[info] ArrayOfZonedDateTimesWriting.json4sNative:·gc.count                                  128  thrpt    5       11.000                counts
[info] ArrayOfZonedDateTimesWriting.json4sNative:·gc.time                                   128  thrpt    5       11.000                    ms
[info] ArraySeqOfBooleansWriting.json4sJackson                                              128  thrpt    5    23974.672 ±     881.029   ops/s
[info] ArraySeqOfBooleansWriting.json4sJackson:·gc.alloc.rate                               128  thrpt    5     5071.855 ±     186.198  MB/sec
[info] ArraySeqOfBooleansWriting.json4sJackson:·gc.alloc.rate.norm                          128  thrpt    5   221871.293 ±       2.399    B/op
[info] ArraySeqOfBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space                      128  thrpt    5     5066.710 ±    1619.709  MB/sec
[info] ArraySeqOfBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                 128  thrpt    5   221681.406 ±   72428.618    B/op
[info] ArraySeqOfBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space                  128  thrpt    5        0.169 ±       0.137  MB/sec
[info] ArraySeqOfBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm             128  thrpt    5        7.385 ±       6.185    B/op
[info] ArraySeqOfBooleansWriting.json4sJackson:·gc.count                                    128  thrpt    5       33.000                counts
[info] ArraySeqOfBooleansWriting.json4sJackson:·gc.time                                     128  thrpt    5       17.000                    ms
[info] ArraySeqOfBooleansWriting.json4sNative                                               128  thrpt    5    23554.015 ±     612.085   ops/s
[info] ArraySeqOfBooleansWriting.json4sNative:·gc.alloc.rate                                128  thrpt    5     4958.040 ±     128.931  MB/sec
[info] ArraySeqOfBooleansWriting.json4sNative:·gc.alloc.rate.norm                           128  thrpt    5   220759.200 ±       2.285    B/op
[info] ArraySeqOfBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space                       128  thrpt    5     4913.233 ±    1618.644  MB/sec
[info] ArraySeqOfBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                  128  thrpt    5   218712.402 ±   68778.339    B/op
[info] ArraySeqOfBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space                   128  thrpt    5        0.181 ±       0.344  MB/sec
[info] ArraySeqOfBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm              128  thrpt    5        8.061 ±      15.345    B/op
[info] ArraySeqOfBooleansWriting.json4sNative:·gc.count                                     128  thrpt    5       32.000                counts
[info] ArraySeqOfBooleansWriting.json4sNative:·gc.time                                      128  thrpt    5       16.000                    ms
[info] Base64Reading.json4sJackson                                                          128  thrpt    5  2251423.037 ±   28350.335   ops/s
[info] Base64Reading.json4sJackson:·gc.alloc.rate                                           128  thrpt    5     3812.595 ±      47.676  MB/sec
[info] Base64Reading.json4sJackson:·gc.alloc.rate.norm                                      128  thrpt    5     1776.059 ±       0.001    B/op
[info] Base64Reading.json4sJackson:·gc.churn.PS_Eden_Space                                  128  thrpt    5     3838.415 ±       0.417  MB/sec
[info] Base64Reading.json4sJackson:·gc.churn.PS_Eden_Space.norm                             128  thrpt    5     1788.102 ±      22.399    B/op
[info] Base64Reading.json4sJackson:·gc.churn.PS_Survivor_Space                              128  thrpt    5        0.094 ±       0.307  MB/sec
[info] Base64Reading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                         128  thrpt    5        0.044 ±       0.144    B/op
[info] Base64Reading.json4sJackson:·gc.count                                                128  thrpt    5       25.000                counts
[info] Base64Reading.json4sJackson:·gc.time                                                 128  thrpt    5       12.000                    ms
[info] Base64Writing.json4sJackson                                                          128  thrpt    5  3881487.919 ±  168070.206   ops/s
[info] Base64Writing.json4sJackson:·gc.alloc.rate                                           128  thrpt    5     4914.948 ±     212.308  MB/sec
[info] Base64Writing.json4sJackson:·gc.alloc.rate.norm                                      128  thrpt    5     1328.044 ±       0.014    B/op
[info] Base64Writing.json4sJackson:·gc.churn.PS_Eden_Space                                  128  thrpt    5     4913.142 ±    1618.291  MB/sec
[info] Base64Writing.json4sJackson:·gc.churn.PS_Eden_Space.norm                             128  thrpt    5     1327.464 ±     428.151    B/op
[info] Base64Writing.json4sJackson:·gc.churn.PS_Survivor_Space                              128  thrpt    5        0.200 ±       0.347  MB/sec
[info] Base64Writing.json4sJackson:·gc.churn.PS_Survivor_Space.norm                         128  thrpt    5        0.054 ±       0.092    B/op
[info] Base64Writing.json4sJackson:·gc.count                                                128  thrpt    5       32.000                counts
[info] Base64Writing.json4sJackson:·gc.time                                                 128  thrpt    5       16.000                    ms
[info] Base64Writing.json4sNative                                                           128  thrpt    5   340772.200 ±     839.707   ops/s
[info] Base64Writing.json4sNative:·gc.alloc.rate                                            128  thrpt    5      532.856 ±       1.314  MB/sec
[info] Base64Writing.json4sNative:·gc.alloc.rate.norm                                       128  thrpt    5     1640.063 ±       0.134    B/op
[info] Base64Writing.json4sNative:·gc.churn.PS_Eden_Space                                   128  thrpt    5      614.106 ±    1321.909  MB/sec
[info] Base64Writing.json4sNative:·gc.churn.PS_Eden_Space.norm                              128  thrpt    5     1890.658 ±    4069.785    B/op
[info] Base64Writing.json4sNative:·gc.churn.PS_Survivor_Space                               128  thrpt    5        0.008 ±       0.049  MB/sec
[info] Base64Writing.json4sNative:·gc.churn.PS_Survivor_Space.norm                          128  thrpt    5        0.025 ±       0.152    B/op
[info] Base64Writing.json4sNative:·gc.count                                                 128  thrpt    5        4.000                counts
[info] Base64Writing.json4sNative:·gc.time                                                  128  thrpt    5        6.000                    ms
[info] BigDecimalReading.json4sJackson                                                      128  thrpt    5   952106.058 ±    8484.497   ops/s
[info] BigDecimalReading.json4sJackson:·gc.alloc.rate                                       128  thrpt    5     1844.703 ±      16.592  MB/sec
[info] BigDecimalReading.json4sJackson:·gc.alloc.rate.norm                                  128  thrpt    5     2032.074 ±       0.108    B/op
[info] BigDecimalReading.json4sJackson:·gc.churn.PS_Eden_Space                              128  thrpt    5     1842.508 ±    1619.385  MB/sec
[info] BigDecimalReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                         128  thrpt    5     2029.808 ±    1787.250    B/op
[info] BigDecimalReading.json4sJackson:·gc.churn.PS_Survivor_Space                          128  thrpt    5        1.588 ±      13.272  MB/sec
[info] BigDecimalReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                     128  thrpt    5        1.746 ±      14.586    B/op
[info] BigDecimalReading.json4sJackson:·gc.count                                            128  thrpt    5       12.000                counts
[info] BigDecimalReading.json4sJackson:·gc.time                                             128  thrpt    5       12.000                    ms
[info] BigDecimalWriting.json4sNative                                                       128  thrpt    5   597354.635 ±    6800.884   ops/s
[info] BigDecimalWriting.json4sNative:·gc.alloc.rate                                        128  thrpt    5     3512.971 ±      40.051  MB/sec
[info] BigDecimalWriting.json4sNative:·gc.alloc.rate.norm                                   128  thrpt    5     6168.205 ±       0.094    B/op
[info] BigDecimalWriting.json4sNative:·gc.churn.PS_Eden_Space                               128  thrpt    5     3531.107 ±    1618.986  MB/sec
[info] BigDecimalWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                          128  thrpt    5     6199.194 ±    2808.720    B/op
[info] BigDecimalWriting.json4sNative:·gc.churn.PS_Survivor_Space                           128  thrpt    5        0.181 ±       0.403  MB/sec
[info] BigDecimalWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                      128  thrpt    5        0.318 ±       0.707    B/op
[info] BigDecimalWriting.json4sNative:·gc.count                                             128  thrpt    5       23.000                counts
[info] BigDecimalWriting.json4sNative:·gc.time                                              128  thrpt    5       11.000                    ms
[info] BigIntReading.json4sJackson                                                          128  thrpt    5   973992.497 ±   12670.795   ops/s
[info] BigIntReading.json4sJackson:·gc.alloc.rate                                           128  thrpt    5     1827.636 ±      23.518  MB/sec
[info] BigIntReading.json4sJackson:·gc.alloc.rate.norm                                      128  thrpt    5     1968.073 ±       0.108    B/op
[info] BigIntReading.json4sJackson:·gc.churn.PS_Eden_Space                                  128  thrpt    5     1842.373 ±    1619.198  MB/sec
[info] BigIntReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                             128  thrpt    5     1985.057 ±    1768.740    B/op
[info] BigIntReading.json4sJackson:·gc.churn.PS_Survivor_Space                              128  thrpt    5        1.609 ±      13.062  MB/sec
[info] BigIntReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                         128  thrpt    5        1.740 ±      14.129    B/op
[info] BigIntReading.json4sJackson:·gc.count                                                128  thrpt    5       12.000                counts
[info] BigIntReading.json4sJackson:·gc.time                                                 128  thrpt    5       13.000                    ms
[info] BigIntWriting.json4sJackson                                                          128  thrpt    5   579893.039 ±   10588.474   ops/s
[info] BigIntWriting.json4sJackson:·gc.alloc.rate                                           128  thrpt    5     3467.610 ±      63.572  MB/sec
[info] BigIntWriting.json4sJackson:·gc.alloc.rate.norm                                      128  thrpt    5     6272.210 ±       0.099    B/op
[info] BigIntWriting.json4sJackson:·gc.churn.PS_Eden_Space                                  128  thrpt    5     3531.098 ±    1620.361  MB/sec
[info] BigIntWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                             128  thrpt    5     6388.794 ±    2995.455    B/op
[info] BigIntWriting.json4sJackson:·gc.churn.PS_Survivor_Space                              128  thrpt    5        0.119 ±       0.461  MB/sec
[info] BigIntWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                         128  thrpt    5        0.215 ±       0.840    B/op
[info] BigIntWriting.json4sJackson:·gc.count                                                128  thrpt    5       23.000                counts
[info] BigIntWriting.json4sJackson:·gc.time                                                 128  thrpt    5       11.000                    ms
[info] BigIntWriting.json4sNative                                                           128  thrpt    5   598801.371 ±    3171.326   ops/s
[info] BigIntWriting.json4sNative:·gc.alloc.rate                                            128  thrpt    5     3484.968 ±      18.087  MB/sec
[info] BigIntWriting.json4sNative:·gc.alloc.rate.norm                                       128  thrpt    5     6104.195 ±       0.092    B/op
[info] BigIntWriting.json4sNative:·gc.churn.PS_Eden_Space                                   128  thrpt    5     3377.632 ±    1618.995  MB/sec
[info] BigIntWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                              128  thrpt    5     5916.069 ±    2830.738    B/op
[info] BigIntWriting.json4sNative:·gc.churn.PS_Survivor_Space                               128  thrpt    5        0.187 ±       0.408  MB/sec
[info] BigIntWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                          128  thrpt    5        0.328 ±       0.714    B/op
[info] BigIntWriting.json4sNative:·gc.count                                                 128  thrpt    5       22.000                counts
[info] BigIntWriting.json4sNative:·gc.time                                                  128  thrpt    5       12.000                    ms
[info] ExtractFieldsReading.json4sJackson                                                   128  thrpt    5    27670.758 ±     674.412   ops/s
[info] ExtractFieldsReading.json4sJackson:·gc.alloc.rate                                    128  thrpt    5     1618.744 ±      39.609  MB/sec
[info] ExtractFieldsReading.json4sJackson:·gc.alloc.rate.norm                               128  thrpt    5    61354.175 ±       2.156    B/op
[info] ExtractFieldsReading.json4sJackson:·gc.churn.PS_Eden_Space                           128  thrpt    5     1535.346 ±       0.139  MB/sec
[info] ExtractFieldsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5    58195.060 ±    1422.020    B/op
[info] ExtractFieldsReading.json4sJackson:·gc.churn.PS_Survivor_Space                       128  thrpt    5        1.646 ±      13.935  MB/sec
[info] ExtractFieldsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5       62.468 ±     528.868    B/op
[info] ExtractFieldsReading.json4sJackson:·gc.count                                         128  thrpt    5       10.000                counts
[info] ExtractFieldsReading.json4sJackson:·gc.time                                          128  thrpt    5       13.000                    ms
[info] ExtractFieldsReading.json4sNative                                                    128  thrpt    5    20679.038 ±     102.281   ops/s
[info] ExtractFieldsReading.json4sNative:·gc.alloc.rate                                     128  thrpt    5     3881.541 ±      18.999  MB/sec
[info] ExtractFieldsReading.json4sNative:·gc.alloc.rate.norm                                128  thrpt    5   196862.465 ±       0.097    B/op
[info] ExtractFieldsReading.json4sNative:·gc.churn.PS_Eden_Space                            128  thrpt    5     3838.439 ±       0.856  MB/sec
[info] ExtractFieldsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5   194676.701 ±     962.766    B/op
[info] ExtractFieldsReading.json4sNative:·gc.churn.PS_Survivor_Space                        128  thrpt    5        0.144 ±       0.264  MB/sec
[info] ExtractFieldsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5        7.287 ±      13.345    B/op
[info] ExtractFieldsReading.json4sNative:·gc.count                                          128  thrpt    5       25.000                counts
[info] ExtractFieldsReading.json4sNative:·gc.time                                           128  thrpt    5       12.000                    ms
[info] GitHubActionsAPIReading.json4sJackson                                                N/A  thrpt    5    69981.308 ±     804.060   ops/s
[info] GitHubActionsAPIReading.json4sJackson:·gc.alloc.rate                                 N/A  thrpt    5     2180.671 ±      25.069  MB/sec
[info] GitHubActionsAPIReading.json4sJackson:·gc.alloc.rate.norm                            N/A  thrpt    5    32681.161 ±       1.197    B/op
[info] GitHubActionsAPIReading.json4sJackson:·gc.churn.PS_Eden_Space                        N/A  thrpt    5     2149.615 ±    1322.170  MB/sec
[info] GitHubActionsAPIReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                   N/A  thrpt    5    32211.237 ±   19706.729    B/op
[info] GitHubActionsAPIReading.json4sJackson:·gc.churn.PS_Survivor_Space                    N/A  thrpt    5        1.709 ±      14.249  MB/sec
[info] GitHubActionsAPIReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm               N/A  thrpt    5       25.688 ±     214.177    B/op
[info] GitHubActionsAPIReading.json4sJackson:·gc.count                                      N/A  thrpt    5       14.000                counts
[info] GitHubActionsAPIReading.json4sJackson:·gc.time                                       N/A  thrpt    5       13.000                    ms
[info] GitHubActionsAPIReading.json4sNative                                                 N/A  thrpt    5    64210.235 ±     551.208   ops/s
[info] GitHubActionsAPIReading.json4sNative:·gc.alloc.rate                                  N/A  thrpt    5     2416.181 ±      20.783  MB/sec
[info] GitHubActionsAPIReading.json4sNative:·gc.alloc.rate.norm                             N/A  thrpt    5    39465.440 ±       1.011    B/op
[info] GitHubActionsAPIReading.json4sNative:·gc.churn.PS_Eden_Space                         N/A  thrpt    5     2456.666 ±    1322.236  MB/sec
[info] GitHubActionsAPIReading.json4sNative:·gc.churn.PS_Eden_Space.norm                    N/A  thrpt    5    40126.946 ±   21602.724    B/op
[info] GitHubActionsAPIReading.json4sNative:·gc.churn.PS_Survivor_Space                     N/A  thrpt    5        1.449 ±      11.606  MB/sec
[info] GitHubActionsAPIReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                N/A  thrpt    5       23.639 ±     189.271    B/op
[info] GitHubActionsAPIReading.json4sNative:·gc.count                                       N/A  thrpt    5       16.000                counts
[info] GitHubActionsAPIReading.json4sNative:·gc.time                                        N/A  thrpt    5       11.000                    ms
[info] GitHubActionsAPIWriting.json4sJackson                                                N/A  thrpt    5    47964.289 ±     395.834   ops/s
[info] GitHubActionsAPIWriting.json4sJackson:·gc.alloc.rate                                 N/A  thrpt    5     3582.491 ±      29.602  MB/sec
[info] GitHubActionsAPIWriting.json4sJackson:·gc.alloc.rate.norm                            N/A  thrpt    5    78338.547 ±       1.137    B/op
[info] GitHubActionsAPIWriting.json4sJackson:·gc.churn.PS_Eden_Space                        N/A  thrpt    5     3531.195 ±    1619.303  MB/sec
[info] GitHubActionsAPIWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                   N/A  thrpt    5    77210.814 ±   35170.868    B/op
[info] GitHubActionsAPIWriting.json4sJackson:·gc.churn.PS_Survivor_Space                    N/A  thrpt    5        0.125 ±       0.351  MB/sec
[info] GitHubActionsAPIWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm               N/A  thrpt    5        2.733 ±       7.687    B/op
[info] GitHubActionsAPIWriting.json4sJackson:·gc.count                                      N/A  thrpt    5       23.000                counts
[info] GitHubActionsAPIWriting.json4sJackson:·gc.time                                       N/A  thrpt    5       11.000                    ms
[info] GitHubActionsAPIWriting.json4sNative                                                 N/A  thrpt    5    29005.882 ±     445.088   ops/s
[info] GitHubActionsAPIWriting.json4sNative:·gc.alloc.rate                                  N/A  thrpt    5     2143.347 ±      32.860  MB/sec
[info] GitHubActionsAPIWriting.json4sNative:·gc.alloc.rate.norm                             N/A  thrpt    5    77498.803 ±       2.911    B/op
[info] GitHubActionsAPIWriting.json4sNative:·gc.churn.PS_Eden_Space                         N/A  thrpt    5     2149.492 ±    1322.306  MB/sec
[info] GitHubActionsAPIWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                    N/A  thrpt    5    77727.017 ±   47948.330    B/op
[info] GitHubActionsAPIWriting.json4sNative:·gc.churn.PS_Survivor_Space                     N/A  thrpt    5        1.402 ±      11.336  MB/sec
[info] GitHubActionsAPIWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                N/A  thrpt    5       51.000 ±     412.450    B/op
[info] GitHubActionsAPIWriting.json4sNative:·gc.count                                       N/A  thrpt    5       14.000                counts
[info] GitHubActionsAPIWriting.json4sNative:·gc.time                                        N/A  thrpt    5       11.000                    ms
[info] GoogleMapsAPIPrettyPrinting.json4sNative                                             N/A  thrpt    5     1369.018 ±      48.358   ops/s
[info] GoogleMapsAPIPrettyPrinting.json4sNative:·gc.alloc.rate                              N/A  thrpt    5     3236.668 ±     114.304  MB/sec
[info] GoogleMapsAPIPrettyPrinting.json4sNative:·gc.alloc.rate.norm                         N/A  thrpt    5  2479657.341 ±      31.899    B/op
[info] GoogleMapsAPIPrettyPrinting.json4sNative:·gc.churn.PS_Eden_Space                     N/A  thrpt    5     3222.529 ±    1321.620  MB/sec
[info] GoogleMapsAPIPrettyPrinting.json4sNative:·gc.churn.PS_Eden_Space.norm                N/A  thrpt    5  2468295.282 ±  979679.085    B/op
[info] GoogleMapsAPIPrettyPrinting.json4sNative:·gc.churn.PS_Survivor_Space                 N/A  thrpt    5        0.201 ±       0.483  MB/sec
[info] GoogleMapsAPIPrettyPrinting.json4sNative:·gc.churn.PS_Survivor_Space.norm            N/A  thrpt    5      154.393 ±     370.229    B/op
[info] GoogleMapsAPIPrettyPrinting.json4sNative:·gc.count                                   N/A  thrpt    5       21.000                counts
[info] GoogleMapsAPIPrettyPrinting.json4sNative:·gc.time                                    N/A  thrpt    5       12.000                    ms
[info] GoogleMapsAPIReading.json4sJackson                                                   N/A  thrpt    5     3506.948 ±      56.212   ops/s
[info] GoogleMapsAPIReading.json4sJackson:·gc.alloc.rate                                    N/A  thrpt    5     2388.200 ±      38.091  MB/sec
[info] GoogleMapsAPIReading.json4sJackson:·gc.alloc.rate.norm                               N/A  thrpt    5   714200.703 ±      17.265    B/op
[info] GoogleMapsAPIReading.json4sJackson:·gc.churn.PS_Eden_Space                           N/A  thrpt    5     2302.759 ±       0.771  MB/sec
[info] GoogleMapsAPIReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                      N/A  thrpt    5   688658.840 ±   11089.969    B/op
[info] GoogleMapsAPIReading.json4sJackson:·gc.churn.PS_Survivor_Space                       N/A  thrpt    5        1.736 ±      14.481  MB/sec
[info] GoogleMapsAPIReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                  N/A  thrpt    5      521.992 ±    4353.990    B/op
[info] GoogleMapsAPIReading.json4sJackson:·gc.count                                         N/A  thrpt    5       15.000                counts
[info] GoogleMapsAPIReading.json4sJackson:·gc.time                                          N/A  thrpt    5       10.000                    ms
[info] GoogleMapsAPIReading.json4sNative                                                    N/A  thrpt    5     3132.603 ±      21.427   ops/s
[info] GoogleMapsAPIReading.json4sNative:·gc.alloc.rate                                     N/A  thrpt    5     2630.568 ±      18.116  MB/sec
[info] GoogleMapsAPIReading.json4sNative:·gc.alloc.rate.norm                                N/A  thrpt    5   880749.044 ±      18.247    B/op
[info] GoogleMapsAPIReading.json4sNative:·gc.churn.PS_Eden_Space                            N/A  thrpt    5     2609.527 ±    1617.923  MB/sec
[info] GoogleMapsAPIReading.json4sNative:·gc.churn.PS_Eden_Space.norm                       N/A  thrpt    5   873823.301 ±  545423.785    B/op
[info] GoogleMapsAPIReading.json4sNative:·gc.churn.PS_Survivor_Space                        N/A  thrpt    5        0.107 ±       0.112  MB/sec
[info] GoogleMapsAPIReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                   N/A  thrpt    5       35.972 ±      37.513    B/op
[info] GoogleMapsAPIReading.json4sNative:·gc.count                                          N/A  thrpt    5       17.000                counts
[info] GoogleMapsAPIReading.json4sNative:·gc.time                                           N/A  thrpt    5        9.000                    ms
[info] GoogleMapsAPIWriting.json4sJackson                                                   N/A  thrpt    5     1887.438 ±      79.594   ops/s
[info] GoogleMapsAPIWriting.json4sJackson:·gc.alloc.rate                                    N/A  thrpt    5     4265.955 ±     180.282  MB/sec
[info] GoogleMapsAPIWriting.json4sJackson:·gc.alloc.rate.norm                               N/A  thrpt    5  2370494.710 ±      31.448    B/op
[info] GoogleMapsAPIWriting.json4sJackson:·gc.churn.PS_Eden_Space                           N/A  thrpt    5     4297.190 ±    1617.727  MB/sec
[info] GoogleMapsAPIWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                      N/A  thrpt    5  2389234.549 ±  956824.599    B/op
[info] GoogleMapsAPIWriting.json4sJackson:·gc.churn.PS_Survivor_Space                       N/A  thrpt    5        0.112 ±       0.568  MB/sec
[info] GoogleMapsAPIWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                  N/A  thrpt    5       61.778 ±     308.754    B/op
[info] GoogleMapsAPIWriting.json4sJackson:·gc.count                                         N/A  thrpt    5       28.000                counts
[info] GoogleMapsAPIWriting.json4sJackson:·gc.time                                          N/A  thrpt    5       15.000                    ms
[info] GoogleMapsAPIWriting.json4sNative                                                    N/A  thrpt    5     1599.958 ±      23.391   ops/s
[info] GoogleMapsAPIWriting.json4sNative:·gc.alloc.rate                                     N/A  thrpt    5     3537.049 ±      51.591  MB/sec
[info] GoogleMapsAPIWriting.json4sNative:·gc.alloc.rate.norm                                N/A  thrpt    5  2318620.342 ±      35.199    B/op
[info] GoogleMapsAPIWriting.json4sNative:·gc.churn.PS_Eden_Space                            N/A  thrpt    5     3530.614 ±    1619.575  MB/sec
[info] GoogleMapsAPIWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                       N/A  thrpt    5  2314278.516 ± 1056500.809    B/op
[info] GoogleMapsAPIWriting.json4sNative:·gc.churn.PS_Survivor_Space                        N/A  thrpt    5        0.106 ±       0.201  MB/sec
[info] GoogleMapsAPIWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                   N/A  thrpt    5       69.607 ±     132.174    B/op
[info] GoogleMapsAPIWriting.json4sNative:·gc.count                                          N/A  thrpt    5       23.000                counts
[info] GoogleMapsAPIWriting.json4sNative:·gc.time                                           N/A  thrpt    5       12.000                    ms
[info] IntMapOfBooleansWriting.json4sJackson                                                128  thrpt    5    22599.964 ±     198.367   ops/s
[info] IntMapOfBooleansWriting.json4sJackson:·gc.alloc.rate                                 128  thrpt    5     4842.075 ±      42.815  MB/sec
[info] IntMapOfBooleansWriting.json4sJackson:·gc.alloc.rate.norm                            128  thrpt    5   224711.273 ±       2.116    B/op
[info] IntMapOfBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space                        128  thrpt    5     4759.426 ±    1321.596  MB/sec
[info] IntMapOfBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5   220897.652 ±   62887.597    B/op
[info] IntMapOfBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space                    128  thrpt    5        0.187 ±       0.390  MB/sec
[info] IntMapOfBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5        8.696 ±      18.061    B/op
[info] IntMapOfBooleansWriting.json4sJackson:·gc.count                                      128  thrpt    5       31.000                counts
[info] IntMapOfBooleansWriting.json4sJackson:·gc.time                                       128  thrpt    5       14.000                    ms
[info] IntMapOfBooleansWriting.json4sNative                                                 128  thrpt    5    17780.494 ±     117.781   ops/s
[info] IntMapOfBooleansWriting.json4sNative:·gc.alloc.rate                                  128  thrpt    5     3817.551 ±      25.481  MB/sec
[info] IntMapOfBooleansWriting.json4sNative:·gc.alloc.rate.norm                             128  thrpt    5   225183.465 ±       0.098    B/op
[info] IntMapOfBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space                         128  thrpt    5     3838.226 ±       0.599  MB/sec
[info] IntMapOfBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5   226403.521 ±    1498.340    B/op
[info] IntMapOfBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space                     128  thrpt    5        0.131 ±       0.393  MB/sec
[info] IntMapOfBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5        7.732 ±      23.164    B/op
[info] IntMapOfBooleansWriting.json4sNative:·gc.count                                       128  thrpt    5       25.000                counts
[info] IntMapOfBooleansWriting.json4sNative:·gc.time                                        128  thrpt    5       13.000                    ms
[info] IntReading.json4sJackson                                                             N/A  thrpt    5  4214318.455 ±   76415.577   ops/s
[info] IntReading.json4sJackson:·gc.alloc.rate                                              N/A  thrpt    5     3696.728 ±      67.113  MB/sec
[info] IntReading.json4sJackson:·gc.alloc.rate.norm                                         N/A  thrpt    5      920.030 ±       0.011    B/op
[info] IntReading.json4sJackson:·gc.churn.PS_Eden_Space                                     N/A  thrpt    5     3684.719 ±    1322.214  MB/sec
[info] IntReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                                N/A  thrpt    5      916.935 ±     323.923    B/op
[info] IntReading.json4sJackson:·gc.churn.PS_Survivor_Space                                 N/A  thrpt    5        0.137 ±       0.219  MB/sec
[info] IntReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                            N/A  thrpt    5        0.034 ±       0.055    B/op
[info] IntReading.json4sJackson:·gc.count                                                   N/A  thrpt    5       24.000                counts
[info] IntReading.json4sJackson:·gc.time                                                    N/A  thrpt    5       12.000                    ms
[info] IntWriting.json4sJackson                                                             N/A  thrpt    5  2260650.633 ±   66717.785   ops/s
[info] IntWriting.json4sJackson:·gc.alloc.rate                                              N/A  thrpt    5     5466.323 ±     161.775  MB/sec
[info] IntWriting.json4sJackson:·gc.alloc.rate.norm                                         N/A  thrpt    5     2536.084 ±       0.019    B/op
[info] IntWriting.json4sJackson:·gc.churn.PS_Eden_Space                                     N/A  thrpt    5     5527.269 ±    1321.879  MB/sec
[info] IntWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                                N/A  thrpt    5     2563.955 ±     572.463    B/op
[info] IntWriting.json4sJackson:·gc.churn.PS_Survivor_Space                                 N/A  thrpt    5        0.231 ±       0.218  MB/sec
[info] IntWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                            N/A  thrpt    5        0.107 ±       0.103    B/op
[info] IntWriting.json4sJackson:·gc.count                                                   N/A  thrpt    5       36.000                counts
[info] IntWriting.json4sJackson:·gc.time                                                    N/A  thrpt    5       16.000                    ms
[info] IntWriting.json4sNative                                                              N/A  thrpt    5  2777153.197 ±   87399.415   ops/s
[info] IntWriting.json4sNative:·gc.alloc.rate                                               N/A  thrpt    5     5190.014 ±     162.858  MB/sec
[info] IntWriting.json4sNative:·gc.alloc.rate.norm                                          N/A  thrpt    5     1960.065 ±       0.017    B/op
[info] IntWriting.json4sNative:·gc.churn.PS_Eden_Space                                      N/A  thrpt    5     5220.107 ±    1322.345  MB/sec
[info] IntWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                                 N/A  thrpt    5     1971.747 ±     517.290    B/op
[info] IntWriting.json4sNative:·gc.churn.PS_Survivor_Space                                  N/A  thrpt    5        0.156 ±       0.225  MB/sec
[info] IntWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                             N/A  thrpt    5        0.059 ±       0.084    B/op
[info] IntWriting.json4sNative:·gc.count                                                    N/A  thrpt    5       34.000                counts
[info] IntWriting.json4sNative:·gc.time                                                     N/A  thrpt    5       17.000                    ms
[info] ListOfBooleansReading.json4sJackson                                                  128  thrpt    5    99564.143 ±    4848.938   ops/s
[info] ListOfBooleansReading.json4sJackson:·gc.alloc.rate                                   128  thrpt    5     1621.423 ±      78.998  MB/sec
[info] ListOfBooleansReading.json4sJackson:·gc.alloc.rate.norm                              128  thrpt    5    17080.604 ±       0.583    B/op
[info] ListOfBooleansReading.json4sJackson:·gc.churn.PS_Eden_Space                          128  thrpt    5     1535.329 ±       0.264  MB/sec
[info] ListOfBooleansReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5    16175.754 ±     795.787    B/op
[info] ListOfBooleansReading.json4sJackson:·gc.churn.PS_Survivor_Space                      128  thrpt    5        1.564 ±      13.161  MB/sec
[info] ListOfBooleansReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5       16.355 ±     137.528    B/op
[info] ListOfBooleansReading.json4sJackson:·gc.count                                        128  thrpt    5       10.000                counts
[info] ListOfBooleansReading.json4sJackson:·gc.time                                         128  thrpt    5       14.000                    ms
[info] ListOfBooleansReading.json4sNative                                                   128  thrpt    5    97651.942 ±    2570.440   ops/s
[info] ListOfBooleansReading.json4sNative:·gc.alloc.rate                                    128  thrpt    5     2523.718 ±      66.662  MB/sec
[info] ListOfBooleansReading.json4sNative:·gc.alloc.rate.norm                               128  thrpt    5    27104.877 ±       0.444    B/op
[info] ListOfBooleansReading.json4sNative:·gc.churn.PS_Eden_Space                           128  thrpt    5     2456.540 ±    1322.181  MB/sec
[info] ListOfBooleansReading.json4sNative:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5    26368.257 ±   13547.794    B/op
[info] ListOfBooleansReading.json4sNative:·gc.churn.PS_Survivor_Space                       128  thrpt    5        0.150 ±       0.261  MB/sec
[info] ListOfBooleansReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5        1.611 ±       2.803    B/op
[info] ListOfBooleansReading.json4sNative:·gc.count                                         128  thrpt    5       16.000                counts
[info] ListOfBooleansReading.json4sNative:·gc.time                                          128  thrpt    5        8.000                    ms
[info] ListOfBooleansWriting.json4sJackson                                                  128  thrpt    5    24267.406 ±     660.126   ops/s
[info] ListOfBooleansWriting.json4sJackson:·gc.alloc.rate                                   128  thrpt    5     5132.775 ±     139.531  MB/sec
[info] ListOfBooleansWriting.json4sJackson:·gc.alloc.rate.norm                              128  thrpt    5   221839.219 ±       2.275    B/op
[info] ListOfBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space                          128  thrpt    5     5066.361 ±    1619.334  MB/sec
[info] ListOfBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                     128  thrpt    5   219016.383 ±   72377.201    B/op
[info] ListOfBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space                      128  thrpt    5        0.187 ±       0.307  MB/sec
[info] ListOfBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                 128  thrpt    5        8.091 ±      13.061    B/op
[info] ListOfBooleansWriting.json4sJackson:·gc.count                                        128  thrpt    5       33.000                counts
[info] ListOfBooleansWriting.json4sJackson:·gc.time                                         128  thrpt    5       16.000                    ms
[info] ListOfBooleansWriting.json4sNative                                                   128  thrpt    5    23278.231 ±     553.772   ops/s
[info] ListOfBooleansWriting.json4sNative:·gc.alloc.rate                                    128  thrpt    5     4899.053 ±     115.927  MB/sec
[info] ListOfBooleansWriting.json4sNative:·gc.alloc.rate.norm                               128  thrpt    5   220727.286 ±       2.284    B/op
[info] ListOfBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space                           128  thrpt    5     4913.119 ±    1618.434  MB/sec
[info] ListOfBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5   221312.864 ±   69850.886    B/op
[info] ListOfBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space                       128  thrpt    5        0.269 ±       0.549  MB/sec
[info] ListOfBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5       12.078 ±      24.600    B/op
[info] ListOfBooleansWriting.json4sNative:·gc.count                                         128  thrpt    5       32.000                counts
[info] ListOfBooleansWriting.json4sNative:·gc.time                                          128  thrpt    5       17.000                    ms
[info] MapOfIntsToBooleansReading.json4sJackson                                             128  thrpt    5    58368.290 ±     586.012   ops/s
[info] MapOfIntsToBooleansReading.json4sJackson:·gc.alloc.rate                              128  thrpt    5     2038.232 ±      20.520  MB/sec
[info] MapOfIntsToBooleansReading.json4sJackson:·gc.alloc.rate.norm                         128  thrpt    5    36625.395 ±       1.447    B/op
[info] MapOfIntsToBooleansReading.json4sJackson:·gc.churn.PS_Eden_Space                     128  thrpt    5     2149.443 ±    1321.905  MB/sec
[info] MapOfIntsToBooleansReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                128  thrpt    5    38622.707 ±   23727.212    B/op
[info] MapOfIntsToBooleansReading.json4sJackson:·gc.churn.PS_Survivor_Space                 128  thrpt    5        1.606 ±      13.015  MB/sec
[info] MapOfIntsToBooleansReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm            128  thrpt    5       28.831 ±     233.699    B/op
[info] MapOfIntsToBooleansReading.json4sJackson:·gc.count                                   128  thrpt    5       14.000                counts
[info] MapOfIntsToBooleansReading.json4sJackson:·gc.time                                    128  thrpt    5       12.000                    ms
[info] MapOfIntsToBooleansReading.json4sNative                                              128  thrpt    5    52588.798 ±    1472.621   ops/s
[info] MapOfIntsToBooleansReading.json4sNative:·gc.alloc.rate                               128  thrpt    5     3138.112 ±      88.113  MB/sec
[info] MapOfIntsToBooleansReading.json4sNative:·gc.alloc.rate.norm                          128  thrpt    5    62586.134 ±       0.837    B/op
[info] MapOfIntsToBooleansReading.json4sNative:·gc.churn.PS_Eden_Space                      128  thrpt    5     3224.180 ±    1322.382  MB/sec
[info] MapOfIntsToBooleansReading.json4sNative:·gc.churn.PS_Eden_Space.norm                 128  thrpt    5    64288.342 ±   25540.964    B/op
[info] MapOfIntsToBooleansReading.json4sNative:·gc.churn.PS_Survivor_Space                  128  thrpt    5        0.087 ±       0.157  MB/sec
[info] MapOfIntsToBooleansReading.json4sNative:·gc.churn.PS_Survivor_Space.norm             128  thrpt    5        1.746 ±       3.141    B/op
[info] MapOfIntsToBooleansReading.json4sNative:·gc.count                                    128  thrpt    5       21.000                counts
[info] MapOfIntsToBooleansReading.json4sNative:·gc.time                                     128  thrpt    5       12.000                    ms
[info] MapOfIntsToBooleansWriting.json4sJackson                                             128  thrpt    5    23071.381 ±     771.127   ops/s
[info] MapOfIntsToBooleansWriting.json4sJackson:·gc.alloc.rate                              128  thrpt    5     4846.781 ±     161.598  MB/sec
[info] MapOfIntsToBooleansWriting.json4sJackson:·gc.alloc.rate.norm                         128  thrpt    5   220319.123 ±       2.020    B/op
[info] MapOfIntsToBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space                     128  thrpt    5     4759.688 ±    1321.905  MB/sec
[info] MapOfIntsToBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                128  thrpt    5   216365.640 ±   59950.371    B/op
[info] MapOfIntsToBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space                 128  thrpt    5        0.175 ±       0.066  MB/sec
[info] MapOfIntsToBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm            128  thrpt    5        7.955 ±       3.132    B/op
[info] MapOfIntsToBooleansWriting.json4sJackson:·gc.count                                   128  thrpt    5       31.000                counts
[info] MapOfIntsToBooleansWriting.json4sJackson:·gc.time                                    128  thrpt    5       13.000                    ms
[info] MapOfIntsToBooleansWriting.json4sNative                                              128  thrpt    5    17939.283 ±     600.894   ops/s
[info] MapOfIntsToBooleansWriting.json4sNative:·gc.alloc.rate                               128  thrpt    5     3776.608 ±     126.449  MB/sec
[info] MapOfIntsToBooleansWriting.json4sNative:·gc.alloc.rate.norm                          128  thrpt    5   220791.398 ±       0.259    B/op
[info] MapOfIntsToBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space                      128  thrpt    5     3838.407 ±       0.636  MB/sec
[info] MapOfIntsToBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                 128  thrpt    5   224417.963 ±    7533.443    B/op
[info] MapOfIntsToBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space                  128  thrpt    5        0.137 ±       0.347  MB/sec
[info] MapOfIntsToBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm             128  thrpt    5        8.045 ±      20.379    B/op
[info] MapOfIntsToBooleansWriting.json4sNative:·gc.count                                    128  thrpt    5       25.000                counts
[info] MapOfIntsToBooleansWriting.json4sNative:·gc.time                                     128  thrpt    5       13.000                    ms
[info] MissingRequiredFieldsReading.json4sJackson                                           N/A  thrpt    5   236203.908 ±    6174.821   ops/s
[info] MissingRequiredFieldsReading.json4sJackson:·gc.alloc.rate                            N/A  thrpt    5     1160.298 ±      30.232  MB/sec
[info] MissingRequiredFieldsReading.json4sJackson:·gc.alloc.rate.norm                       N/A  thrpt    5     5152.159 ±       0.237    B/op
[info] MissingRequiredFieldsReading.json4sJackson:·gc.churn.PS_Eden_Space                   N/A  thrpt    5     1074.781 ±    1619.227  MB/sec
[info] MissingRequiredFieldsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm              N/A  thrpt    5     4775.071 ±    7226.183    B/op
[info] MissingRequiredFieldsReading.json4sJackson:·gc.churn.PS_Survivor_Space               N/A  thrpt    5        0.021 ±       0.098  MB/sec
[info] MissingRequiredFieldsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm          N/A  thrpt    5        0.093 ±       0.432    B/op
[info] MissingRequiredFieldsReading.json4sJackson:·gc.count                                 N/A  thrpt    5        7.000                counts
[info] MissingRequiredFieldsReading.json4sJackson:·gc.time                                  N/A  thrpt    5       14.000                    ms
[info] MissingRequiredFieldsReading.json4sNative                                            N/A  thrpt    5   193655.124 ±    1728.536   ops/s
[info] MissingRequiredFieldsReading.json4sNative:·gc.alloc.rate                             N/A  thrpt    5      914.354 ±       8.131  MB/sec
[info] MissingRequiredFieldsReading.json4sNative:·gc.alloc.rate.norm                        N/A  thrpt    5     4952.168 ±       0.247    B/op
[info] MissingRequiredFieldsReading.json4sNative:·gc.churn.PS_Eden_Space                    N/A  thrpt    5      921.185 ±    1321.990  MB/sec
[info] MissingRequiredFieldsReading.json4sNative:·gc.churn.PS_Eden_Space.norm               N/A  thrpt    5     4991.778 ±    7210.226    B/op
[info] MissingRequiredFieldsReading.json4sNative:·gc.churn.PS_Survivor_Space                N/A  thrpt    5        0.020 ±       0.117  MB/sec
[info] MissingRequiredFieldsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm           N/A  thrpt    5        0.106 ±       0.633    B/op
[info] MissingRequiredFieldsReading.json4sNative:·gc.count                                  N/A  thrpt    5        6.000                counts
[info] MissingRequiredFieldsReading.json4sNative:·gc.time                                   N/A  thrpt    5       10.000                    ms
[info] MutableLongMapOfBooleansWriting.json4sJackson                                        128  thrpt    5    18933.492 ±    1270.189   ops/s
[info] MutableLongMapOfBooleansWriting.json4sJackson:·gc.alloc.rate                         128  thrpt    5     4408.921 ±     296.226  MB/sec
[info] MutableLongMapOfBooleansWriting.json4sJackson:·gc.alloc.rate.norm                    128  thrpt    5   244232.124 ±       2.334    B/op
[info] MutableLongMapOfBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space                128  thrpt    5     4452.353 ±    1322.190  MB/sec
[info] MutableLongMapOfBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm           128  thrpt    5   246615.177 ±   70520.105    B/op
[info] MutableLongMapOfBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space            128  thrpt    5        0.319 ±       0.688  MB/sec
[info] MutableLongMapOfBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm       128  thrpt    5       17.673 ±      37.962    B/op
[info] MutableLongMapOfBooleansWriting.json4sJackson:·gc.count                              128  thrpt    5       29.000                counts
[info] MutableLongMapOfBooleansWriting.json4sJackson:·gc.time                               128  thrpt    5       13.000                    ms
[info] MutableLongMapOfBooleansWriting.json4sNative                                         128  thrpt    5    13939.473 ±     159.265   ops/s
[info] MutableLongMapOfBooleansWriting.json4sNative:·gc.alloc.rate                          128  thrpt    5     3309.898 ±      37.967  MB/sec
[info] MutableLongMapOfBooleansWriting.json4sNative:·gc.alloc.rate.norm                     128  thrpt    5   249040.373 ±       3.905    B/op
[info] MutableLongMapOfBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space                 128  thrpt    5     3377.699 ±    1619.000  MB/sec
[info] MutableLongMapOfBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space.norm            128  thrpt    5   254102.276 ±  120175.046    B/op
[info] MutableLongMapOfBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space             128  thrpt    5        0.119 ±       0.311  MB/sec
[info] MutableLongMapOfBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm        128  thrpt    5        8.918 ±      23.272    B/op
[info] MutableLongMapOfBooleansWriting.json4sNative:·gc.count                               128  thrpt    5       22.000                counts
[info] MutableLongMapOfBooleansWriting.json4sNative:·gc.time                                128  thrpt    5       12.000                    ms
[info] MutableMapOfIntsToBooleansReading.json4sJackson                                      128  thrpt    5    69393.395 ±    5941.091   ops/s
[info] MutableMapOfIntsToBooleansReading.json4sJackson:·gc.alloc.rate                       128  thrpt    5     1758.490 ±     150.558  MB/sec
[info] MutableMapOfIntsToBooleansReading.json4sJackson:·gc.alloc.rate.norm                  128  thrpt    5    26576.938 ±       1.422    B/op
[info] MutableMapOfIntsToBooleansReading.json4sJackson:·gc.churn.PS_Eden_Space              128  thrpt    5     1688.890 ±    1321.935  MB/sec
[info] MutableMapOfIntsToBooleansReading.json4sJackson:·gc.churn.PS_Eden_Space.norm         128  thrpt    5    25467.986 ±   18015.806    B/op
[info] MutableMapOfIntsToBooleansReading.json4sJackson:·gc.churn.PS_Survivor_Space          128  thrpt    5        1.584 ±      13.212  MB/sec
[info] MutableMapOfIntsToBooleansReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm     128  thrpt    5       23.284 ±     193.944    B/op
[info] MutableMapOfIntsToBooleansReading.json4sJackson:·gc.count                            128  thrpt    5       11.000                counts
[info] MutableMapOfIntsToBooleansReading.json4sJackson:·gc.time                             128  thrpt    5       12.000                    ms
[info] MutableMapOfIntsToBooleansReading.json4sNative                                       128  thrpt    5    58372.648 ±    1246.610   ops/s
[info] MutableMapOfIntsToBooleansReading.json4sNative:·gc.alloc.rate                        128  thrpt    5     2927.096 ±      62.247  MB/sec
[info] MutableMapOfIntsToBooleansReading.json4sNative:·gc.alloc.rate.norm                   128  thrpt    5    52593.742 ±       0.774    B/op
[info] MutableMapOfIntsToBooleansReading.json4sNative:·gc.churn.PS_Eden_Space               128  thrpt    5     2917.074 ±    1322.202  MB/sec
[info] MutableMapOfIntsToBooleansReading.json4sNative:·gc.churn.PS_Eden_Space.norm          128  thrpt    5    52405.347 ±   23452.755    B/op
[info] MutableMapOfIntsToBooleansReading.json4sNative:·gc.churn.PS_Survivor_Space           128  thrpt    5        0.150 ±       0.178  MB/sec
[info] MutableMapOfIntsToBooleansReading.json4sNative:·gc.churn.PS_Survivor_Space.norm      128  thrpt    5        2.693 ±       3.167    B/op
[info] MutableMapOfIntsToBooleansReading.json4sNative:·gc.count                             128  thrpt    5       19.000                counts
[info] MutableMapOfIntsToBooleansReading.json4sNative:·gc.time                              128  thrpt    5       10.000                    ms
[info] MutableMapOfIntsToBooleansWriting.json4sJackson                                      128  thrpt    5    21974.000 ±     447.147   ops/s
[info] MutableMapOfIntsToBooleansWriting.json4sJackson:·gc.alloc.rate                       128  thrpt    5     4613.030 ±      93.838  MB/sec
[info] MutableMapOfIntsToBooleansWriting.json4sJackson:·gc.alloc.rate.norm                  128  thrpt    5   220191.241 ±       0.155    B/op
[info] MutableMapOfIntsToBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space              128  thrpt    5     4605.774 ±       0.869  MB/sec
[info] MutableMapOfIntsToBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm         128  thrpt    5   219849.838 ±    4509.142    B/op
[info] MutableMapOfIntsToBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space          128  thrpt    5        0.169 ±       0.470  MB/sec
[info] MutableMapOfIntsToBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm     128  thrpt    5        8.035 ±      22.372    B/op
[info] MutableMapOfIntsToBooleansWriting.json4sJackson:·gc.count                            128  thrpt    5       30.000                counts
[info] MutableMapOfIntsToBooleansWriting.json4sJackson:·gc.time                             128  thrpt    5       14.000                    ms
[info] MutableMapOfIntsToBooleansWriting.json4sNative                                       128  thrpt    5    17972.513 ±     570.394   ops/s
[info] MutableMapOfIntsToBooleansWriting.json4sNative:·gc.alloc.rate                        128  thrpt    5     3781.225 ±     119.809  MB/sec
[info] MutableMapOfIntsToBooleansWriting.json4sNative:·gc.alloc.rate.norm                   128  thrpt    5   220663.385 ±       0.301    B/op
[info] MutableMapOfIntsToBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space               128  thrpt    5     3838.184 ±       0.375  MB/sec
[info] MutableMapOfIntsToBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space.norm          128  thrpt    5   223999.651 ±    7159.104    B/op
[info] MutableMapOfIntsToBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space           128  thrpt    5        0.250 ±       0.361  MB/sec
[info] MutableMapOfIntsToBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm      128  thrpt    5       14.587 ±      21.074    B/op
[info] MutableMapOfIntsToBooleansWriting.json4sNative:·gc.count                             128  thrpt    5       25.000                counts
[info] MutableMapOfIntsToBooleansWriting.json4sNative:·gc.time                              128  thrpt    5       12.000                    ms
[info] MutableSetOfIntsReading.json4sJackson                                                128  thrpt    5    64817.506 ±     269.302   ops/s
[info] MutableSetOfIntsReading.json4sJackson:·gc.alloc.rate                                 128  thrpt    5     2527.966 ±      10.367  MB/sec
[info] MutableSetOfIntsReading.json4sJackson:·gc.alloc.rate.norm                            128  thrpt    5    40905.500 ±       0.977    B/op
[info] MutableSetOfIntsReading.json4sJackson:·gc.churn.PS_Eden_Space                        128  thrpt    5     2610.182 ±    1619.372  MB/sec
[info] MutableSetOfIntsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5    42235.784 ±   26200.408    B/op
[info] MutableSetOfIntsReading.json4sJackson:·gc.churn.PS_Survivor_Space                    128  thrpt    5        1.601 ±      13.248  MB/sec
[info] MutableSetOfIntsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5       25.942 ±     214.680    B/op
[info] MutableSetOfIntsReading.json4sJackson:·gc.count                                      128  thrpt    5       17.000                counts
[info] MutableSetOfIntsReading.json4sJackson:·gc.time                                       128  thrpt    5       10.000                    ms
[info] MutableSetOfIntsReading.json4sNative                                                 128  thrpt    5    58204.559 ±     331.538   ops/s
[info] MutableSetOfIntsReading.json4sNative:·gc.alloc.rate                                  128  thrpt    5     3156.208 ±      18.301  MB/sec
[info] MutableSetOfIntsReading.json4sNative:·gc.alloc.rate.norm                             128  thrpt    5    56873.928 ±       0.794    B/op
[info] MutableSetOfIntsReading.json4sNative:·gc.churn.PS_Eden_Space                         128  thrpt    5     3224.150 ±    1321.664  MB/sec
[info] MutableSetOfIntsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5    58105.022 ±   24162.439    B/op
[info] MutableSetOfIntsReading.json4sNative:·gc.churn.PS_Survivor_Space                     128  thrpt    5        0.087 ±       0.375  MB/sec
[info] MutableSetOfIntsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5        1.578 ±       6.768    B/op
[info] MutableSetOfIntsReading.json4sNative:·gc.count                                       128  thrpt    5       21.000                counts
[info] MutableSetOfIntsReading.json4sNative:·gc.time                                        128  thrpt    5       12.000                    ms
[info] MutableSetOfIntsWriting.json4sJackson                                                128  thrpt    5    21138.453 ±    1281.992   ops/s
[info] MutableSetOfIntsWriting.json4sJackson:·gc.alloc.rate                                 128  thrpt    5     4907.680 ±     297.394  MB/sec
[info] MutableSetOfIntsWriting.json4sJackson:·gc.alloc.rate.norm                            128  thrpt    5   243512.032 ±       2.831    B/op
[info] MutableSetOfIntsWriting.json4sJackson:·gc.churn.PS_Eden_Space                        128  thrpt    5     4912.861 ±    1619.055  MB/sec
[info] MutableSetOfIntsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5   243935.705 ±   88120.648    B/op
[info] MutableSetOfIntsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                    128  thrpt    5        0.219 ±       0.489  MB/sec
[info] MutableSetOfIntsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5       10.860 ±      24.437    B/op
[info] MutableSetOfIntsWriting.json4sJackson:·gc.count                                      128  thrpt    5       32.000                counts
[info] MutableSetOfIntsWriting.json4sJackson:·gc.time                                       128  thrpt    5       13.000                    ms
[info] MutableSetOfIntsWriting.json4sNative                                                 128  thrpt    5    24032.581 ±     249.765   ops/s
[info] MutableSetOfIntsWriting.json4sNative:·gc.alloc.rate                                  128  thrpt    5     4788.008 ±      49.492  MB/sec
[info] MutableSetOfIntsWriting.json4sNative:·gc.alloc.rate.norm                             128  thrpt    5   208950.840 ±       1.950    B/op
[info] MutableSetOfIntsWriting.json4sNative:·gc.churn.PS_Eden_Space                         128  thrpt    5     4759.781 ±    1322.078  MB/sec
[info] MutableSetOfIntsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5   207735.457 ±   58841.101    B/op
[info] MutableSetOfIntsWriting.json4sNative:·gc.churn.PS_Survivor_Space                     128  thrpt    5        0.125 ±       0.371  MB/sec
[info] MutableSetOfIntsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5        5.456 ±      16.217    B/op
[info] MutableSetOfIntsWriting.json4sNative:·gc.count                                       128  thrpt    5       31.000                counts
[info] MutableSetOfIntsWriting.json4sNative:·gc.time                                        128  thrpt    5       17.000                    ms
[info] NestedStructsReading.json4sJackson                                                   128  thrpt    5    16179.030 ±     437.337   ops/s
[info] NestedStructsReading.json4sJackson:·gc.alloc.rate                                    128  thrpt    5     2938.468 ±      79.518  MB/sec
[info] NestedStructsReading.json4sJackson:·gc.alloc.rate.norm                               128  thrpt    5   190486.232 ±       2.717    B/op
[info] NestedStructsReading.json4sJackson:·gc.churn.PS_Eden_Space                           128  thrpt    5     2917.081 ±    1321.941  MB/sec
[info] NestedStructsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5   189009.664 ±   82405.663    B/op
[info] NestedStructsReading.json4sJackson:·gc.churn.PS_Survivor_Space                       128  thrpt    5        0.087 ±       0.365  MB/sec
[info] NestedStructsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5        5.694 ±      23.768    B/op
[info] NestedStructsReading.json4sJackson:·gc.count                                         128  thrpt    5       19.000                counts
[info] NestedStructsReading.json4sJackson:·gc.time                                          128  thrpt    5        7.000                    ms
[info] NestedStructsReading.json4sNative                                                    128  thrpt    5    15557.291 ±     284.816   ops/s
[info] NestedStructsReading.json4sNative:·gc.alloc.rate                                     128  thrpt    5     3153.956 ±      57.289  MB/sec
[info] NestedStructsReading.json4sNative:·gc.alloc.rate.norm                                128  thrpt    5   212631.226 ±       3.084    B/op
[info] NestedStructsReading.json4sNative:·gc.churn.PS_Eden_Space                            128  thrpt    5     3224.049 ±    1321.925  MB/sec
[info] NestedStructsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5   217417.908 ±   92127.612    B/op
[info] NestedStructsReading.json4sNative:·gc.churn.PS_Survivor_Space                        128  thrpt    5        0.081 ±       0.249  MB/sec
[info] NestedStructsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5        5.480 ±      16.883    B/op
[info] NestedStructsReading.json4sNative:·gc.count                                          128  thrpt    5       21.000                counts
[info] NestedStructsReading.json4sNative:·gc.time                                           128  thrpt    5       10.000                    ms
[info] NestedStructsWriting.json4sJackson                                                   128  thrpt    5     6237.313 ±      29.384   ops/s
[info] NestedStructsWriting.json4sJackson:·gc.alloc.rate                                    128  thrpt    5     4891.869 ±      22.725  MB/sec
[info] NestedStructsWriting.json4sJackson:·gc.alloc.rate.norm                               128  thrpt    5   822555.192 ±       9.086    B/op
[info] NestedStructsWriting.json4sJackson:·gc.churn.PS_Eden_Space                           128  thrpt    5     4912.889 ±    1619.677  MB/sec
[info] NestedStructsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                      128  thrpt    5   826121.690 ±  274169.427    B/op
[info] NestedStructsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                       128  thrpt    5        0.144 ±       0.413  MB/sec
[info] NestedStructsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                  128  thrpt    5       24.160 ±      69.452    B/op
[info] NestedStructsWriting.json4sJackson:·gc.count                                         128  thrpt    5       32.000                counts
[info] NestedStructsWriting.json4sJackson:·gc.time                                          128  thrpt    5       15.000                    ms
[info] NestedStructsWriting.json4sNative                                                    128  thrpt    5     6152.360 ±      13.513   ops/s
[info] NestedStructsWriting.json4sNative:·gc.alloc.rate                                     128  thrpt    5     4746.400 ±      17.850  MB/sec
[info] NestedStructsWriting.json4sNative:·gc.alloc.rate.norm                                128  thrpt    5   809298.717 ±       7.335    B/op
[info] NestedStructsWriting.json4sNative:·gc.churn.PS_Eden_Space                            128  thrpt    5     4758.139 ±    1310.662  MB/sec
[info] NestedStructsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                       128  thrpt    5   811343.071 ±  226595.239    B/op
[info] NestedStructsWriting.json4sNative:·gc.churn.PS_Survivor_Space                        128  thrpt    5        0.225 ±       0.665  MB/sec
[info] NestedStructsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                   128  thrpt    5       38.343 ±     113.685    B/op
[info] NestedStructsWriting.json4sNative:·gc.count                                          128  thrpt    5       31.000                counts
[info] NestedStructsWriting.json4sNative:·gc.time                                           128  thrpt    5       15.000                    ms
[info] OpenRTBReading.json4sJackson                                                         N/A  thrpt    5    22832.705 ±     466.336   ops/s
[info] OpenRTBReading.json4sJackson:·gc.alloc.rate                                          N/A  thrpt    5     1554.619 ±      31.737  MB/sec
[info] OpenRTBReading.json4sJackson:·gc.alloc.rate.norm                                     N/A  thrpt    5    71410.635 ±       2.568    B/op
[info] OpenRTBReading.json4sJackson:·gc.churn.PS_Eden_Space                                 N/A  thrpt    5     1535.357 ±       0.447  MB/sec
[info] OpenRTBReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                            N/A  thrpt    5    70527.419 ±    1437.731    B/op
[info] OpenRTBReading.json4sJackson:·gc.churn.PS_Survivor_Space                             N/A  thrpt    5        1.802 ±      15.043  MB/sec
[info] OpenRTBReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                        N/A  thrpt    5       82.419 ±     688.025    B/op
[info] OpenRTBReading.json4sJackson:·gc.count                                               N/A  thrpt    5       10.000                counts
[info] OpenRTBReading.json4sJackson:·gc.time                                                N/A  thrpt    5       15.000                    ms
[info] OpenRTBReading.json4sNative                                                          N/A  thrpt    5    21344.701 ±     589.963   ops/s
[info] OpenRTBReading.json4sNative:·gc.alloc.rate                                           N/A  thrpt    5     1861.732 ±      51.402  MB/sec
[info] OpenRTBReading.json4sNative:·gc.alloc.rate.norm                                      N/A  thrpt    5    91483.340 ±       2.986    B/op
[info] OpenRTBReading.json4sNative:·gc.churn.PS_Eden_Space                                  N/A  thrpt    5     1842.306 ±    1618.613  MB/sec
[info] OpenRTBReading.json4sNative:·gc.churn.PS_Eden_Space.norm                             N/A  thrpt    5    90572.985 ±   80512.414    B/op
[info] OpenRTBReading.json4sNative:·gc.churn.PS_Survivor_Space                              N/A  thrpt    5        1.553 ±      12.469  MB/sec
[info] OpenRTBReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                         N/A  thrpt    5       76.531 ±     614.725    B/op
[info] OpenRTBReading.json4sNative:·gc.count                                                N/A  thrpt    5       12.000                counts
[info] OpenRTBReading.json4sNative:·gc.time                                                 N/A  thrpt    5       13.000                    ms
[info] PrimitivesReading.json4sJackson                                                      N/A  thrpt    5   434342.331 ±   11064.794   ops/s
[info] PrimitivesReading.json4sJackson:·gc.alloc.rate                                       N/A  thrpt    5     2570.917 ±      65.532  MB/sec
[info] PrimitivesReading.json4sJackson:·gc.alloc.rate.norm                                  N/A  thrpt    5     6208.224 ±       0.147    B/op
[info] PrimitivesReading.json4sJackson:·gc.churn.PS_Eden_Space                              N/A  thrpt    5     2609.969 ±    1619.380  MB/sec
[info] PrimitivesReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                         N/A  thrpt    5     6301.663 ±    3878.955    B/op
[info] PrimitivesReading.json4sJackson:·gc.churn.PS_Survivor_Space                          N/A  thrpt    5        1.743 ±      13.662  MB/sec
[info] PrimitivesReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                     N/A  thrpt    5        4.251 ±      33.364    B/op
[info] PrimitivesReading.json4sJackson:·gc.count                                            N/A  thrpt    5       17.000                counts
[info] PrimitivesReading.json4sJackson:·gc.time                                             N/A  thrpt    5        9.000                    ms
[info] PrimitivesReading.json4sNative                                                       N/A  thrpt    5   368527.560 ±    1016.764   ops/s
[info] PrimitivesReading.json4sNative:·gc.alloc.rate                                        N/A  thrpt    5     2853.167 ±       7.682  MB/sec
[info] PrimitivesReading.json4sNative:·gc.alloc.rate.norm                                   N/A  thrpt    5     8120.276 ±       0.125    B/op
[info] PrimitivesReading.json4sNative:·gc.churn.PS_Eden_Space                               N/A  thrpt    5     2917.033 ±    1321.670  MB/sec
[info] PrimitivesReading.json4sNative:·gc.churn.PS_Eden_Space.norm                          N/A  thrpt    5     8301.944 ±    3758.082    B/op
[info] PrimitivesReading.json4sNative:·gc.churn.PS_Survivor_Space                           N/A  thrpt    5        0.094 ±       0.318  MB/sec
[info] PrimitivesReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                      N/A  thrpt    5        0.267 ±       0.906    B/op
[info] PrimitivesReading.json4sNative:·gc.count                                             N/A  thrpt    5       19.000                counts
[info] PrimitivesReading.json4sNative:·gc.time                                              N/A  thrpt    5       10.000                    ms
[info] PrimitivesWriting.json4sJackson                                                      N/A  thrpt    5   212972.720 ±    8531.945   ops/s
[info] PrimitivesWriting.json4sJackson:·gc.alloc.rate                                       N/A  thrpt    5     4442.947 ±     178.252  MB/sec
[info] PrimitivesWriting.json4sJackson:·gc.alloc.rate.norm                                  N/A  thrpt    5    21880.698 ±       0.263    B/op
[info] PrimitivesWriting.json4sJackson:·gc.churn.PS_Eden_Space                              N/A  thrpt    5     4299.008 ±    1619.007  MB/sec
[info] PrimitivesWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                         N/A  thrpt    5    21174.573 ±    8059.783    B/op
[info] PrimitivesWriting.json4sJackson:·gc.churn.PS_Survivor_Space                          N/A  thrpt    5        0.150 ±       0.132  MB/sec
[info] PrimitivesWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                     N/A  thrpt    5        0.737 ±       0.631    B/op
[info] PrimitivesWriting.json4sJackson:·gc.count                                            N/A  thrpt    5       28.000                counts
[info] PrimitivesWriting.json4sJackson:·gc.time                                             N/A  thrpt    5       13.000                    ms
[info] PrimitivesWriting.json4sNative                                                       N/A  thrpt    5   205527.809 ±     767.174   ops/s
[info] PrimitivesWriting.json4sNative:·gc.alloc.rate                                        N/A  thrpt    5     4062.408 ±      15.198  MB/sec
[info] PrimitivesWriting.json4sNative:·gc.alloc.rate.norm                                   N/A  thrpt    5    20728.672 ±       0.220    B/op
[info] PrimitivesWriting.json4sNative:·gc.churn.PS_Eden_Space                               N/A  thrpt    5     3992.658 ±    1322.279  MB/sec
[info] PrimitivesWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                          N/A  thrpt    5    20373.479 ±    6790.749    B/op
[info] PrimitivesWriting.json4sNative:·gc.churn.PS_Survivor_Space                           N/A  thrpt    5        0.175 ±       0.500  MB/sec
[info] PrimitivesWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                      N/A  thrpt    5        0.893 ±       2.556    B/op
[info] PrimitivesWriting.json4sNative:·gc.count                                             N/A  thrpt    5       26.000                counts
[info] PrimitivesWriting.json4sNative:·gc.time                                              N/A  thrpt    5       12.000                    ms
[info] SetOfIntsReading.json4sJackson                                                       128  thrpt    5    54443.467 ±     400.474   ops/s
[info] SetOfIntsReading.json4sJackson:·gc.alloc.rate                                        128  thrpt    5     2495.484 ±      18.340  MB/sec
[info] SetOfIntsReading.json4sJackson:·gc.alloc.rate.norm                                   128  thrpt    5    48073.690 ±       1.213    B/op
[info] SetOfIntsReading.json4sJackson:·gc.churn.PS_Eden_Space                               128  thrpt    5     2456.526 ±    1322.136  MB/sec
[info] SetOfIntsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                          128  thrpt    5    47317.878 ±   25248.333    B/op
[info] SetOfIntsReading.json4sJackson:·gc.churn.PS_Survivor_Space                           128  thrpt    5        1.621 ±      13.151  MB/sec
[info] SetOfIntsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                      128  thrpt    5       31.242 ±     253.502    B/op
[info] SetOfIntsReading.json4sJackson:·gc.count                                             128  thrpt    5       16.000                counts
[info] SetOfIntsReading.json4sJackson:·gc.time                                              128  thrpt    5        9.000                    ms
[info] SetOfIntsReading.json4sNative                                                        128  thrpt    5    48368.056 ±    1209.009   ops/s
[info] SetOfIntsReading.json4sNative:·gc.alloc.rate                                         128  thrpt    5     2951.272 ±      74.081  MB/sec
[info] SetOfIntsReading.json4sNative:·gc.alloc.rate.norm                                    128  thrpt    5    63994.100 ±       0.943    B/op
[info] SetOfIntsReading.json4sNative:·gc.churn.PS_Eden_Space                                128  thrpt    5     2917.192 ±    1322.154  MB/sec
[info] SetOfIntsReading.json4sNative:·gc.churn.PS_Eden_Space.norm                           128  thrpt    5    63248.642 ±   28419.471    B/op
[info] SetOfIntsReading.json4sNative:·gc.churn.PS_Survivor_Space                            128  thrpt    5        0.069 ±       0.157  MB/sec
[info] SetOfIntsReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                       128  thrpt    5        1.491 ±       3.396    B/op
[info] SetOfIntsReading.json4sNative:·gc.count                                              128  thrpt    5       19.000                counts
[info] SetOfIntsReading.json4sNative:·gc.time                                               128  thrpt    5       11.000                    ms
[info] SetOfIntsWriting.json4sJackson                                                       128  thrpt    5    22431.491 ±     990.807   ops/s
[info] SetOfIntsWriting.json4sJackson:·gc.alloc.rate                                        128  thrpt    5     5210.923 ±     229.779  MB/sec
[info] SetOfIntsWriting.json4sJackson:·gc.alloc.rate.norm                                   128  thrpt    5   243639.789 ±       2.219    B/op
[info] SetOfIntsWriting.json4sJackson:·gc.churn.PS_Eden_Space                               128  thrpt    5     5066.592 ±    1620.056  MB/sec
[info] SetOfIntsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                          128  thrpt    5   236755.833 ±   66901.111    B/op
[info] SetOfIntsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                           128  thrpt    5        0.194 ±       0.375  MB/sec
[info] SetOfIntsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm                      128  thrpt    5        9.022 ±      17.138    B/op
[info] SetOfIntsWriting.json4sJackson:·gc.count                                             128  thrpt    5       33.000                counts
[info] SetOfIntsWriting.json4sJackson:·gc.time                                              128  thrpt    5       15.000                    ms
[info] SetOfIntsWriting.json4sNative                                                        128  thrpt    5    24602.022 ±     335.876   ops/s
[info] SetOfIntsWriting.json4sNative:·gc.alloc.rate                                         128  thrpt    5     4971.297 ±      68.621  MB/sec
[info] SetOfIntsWriting.json4sNative:·gc.alloc.rate.norm                                    128  thrpt    5   211934.892 ±       2.313    B/op
[info] SetOfIntsWriting.json4sNative:·gc.churn.PS_Eden_Space                                128  thrpt    5     4913.161 ±    1619.585  MB/sec
[info] SetOfIntsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                           128  thrpt    5   209463.608 ±   69390.781    B/op
[info] SetOfIntsWriting.json4sNative:·gc.churn.PS_Survivor_Space                            128  thrpt    5        0.162 ±       0.323  MB/sec
[info] SetOfIntsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                       128  thrpt    5        6.929 ±      13.798    B/op
[info] SetOfIntsWriting.json4sNative:·gc.count                                              128  thrpt    5       32.000                counts
[info] SetOfIntsWriting.json4sNative:·gc.time                                               128  thrpt    5       17.000                    ms
[info] StringOfAsciiCharsReading.json4sJackson                                              128  thrpt    5  3417303.781 ±    9816.850   ops/s
[info] StringOfAsciiCharsReading.json4sJackson:·gc.alloc.rate                               128  thrpt    5     3284.528 ±       9.201  MB/sec
[info] StringOfAsciiCharsReading.json4sJackson:·gc.alloc.rate.norm                          128  thrpt    5     1008.033 ±       0.014    B/op
[info] StringOfAsciiCharsReading.json4sJackson:·gc.churn.PS_Eden_Space                      128  thrpt    5     3224.312 ±    1322.201  MB/sec
[info] StringOfAsciiCharsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                 128  thrpt    5      989.538 ±     405.042    B/op
[info] StringOfAsciiCharsReading.json4sJackson:·gc.churn.PS_Survivor_Space                  128  thrpt    5        0.150 ±       0.445  MB/sec
[info] StringOfAsciiCharsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm             128  thrpt    5        0.046 ±       0.137    B/op
[info] StringOfAsciiCharsReading.json4sJackson:·gc.count                                    128  thrpt    5       21.000                counts
[info] StringOfAsciiCharsReading.json4sJackson:·gc.time                                     128  thrpt    5       11.000                    ms
[info] StringOfAsciiCharsWriting.json4sJackson                                              128  thrpt    5  2140521.056 ±   20644.561   ops/s
[info] StringOfAsciiCharsWriting.json4sJackson:·gc.alloc.rate                               128  thrpt    5     4979.747 ±      47.969  MB/sec
[info] StringOfAsciiCharsWriting.json4sJackson:·gc.alloc.rate.norm                          128  thrpt    5     2440.079 ±       0.026    B/op
[info] StringOfAsciiCharsWriting.json4sJackson:·gc.churn.PS_Eden_Space                      128  thrpt    5     4912.951 ±    1618.834  MB/sec
[info] StringOfAsciiCharsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                 128  thrpt    5     2407.684 ±     812.049    B/op
[info] StringOfAsciiCharsWriting.json4sJackson:·gc.churn.PS_Survivor_Space                  128  thrpt    5        0.181 ±       0.274  MB/sec
[info] StringOfAsciiCharsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm             128  thrpt    5        0.089 ±       0.134    B/op
[info] StringOfAsciiCharsWriting.json4sJackson:·gc.count                                    128  thrpt    5       32.000                counts
[info] StringOfAsciiCharsWriting.json4sJackson:·gc.time                                     128  thrpt    5       15.000                    ms
[info] StringOfAsciiCharsWriting.json4sNative                                               128  thrpt    5   414392.078 ±    3858.150   ops/s
[info] StringOfAsciiCharsWriting.json4sNative:·gc.alloc.rate                                128  thrpt    5      961.009 ±       8.887  MB/sec
[info] StringOfAsciiCharsWriting.json4sNative:·gc.alloc.rate.norm                           128  thrpt    5     2432.078 ±       0.111    B/op
[info] StringOfAsciiCharsWriting.json4sNative:·gc.churn.PS_Eden_Space                       128  thrpt    5      921.370 ±    1322.326  MB/sec
[info] StringOfAsciiCharsWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                  128  thrpt    5     2332.838 ±    3367.201    B/op
[info] StringOfAsciiCharsWriting.json4sNative:·gc.churn.PS_Survivor_Space                   128  thrpt    5        0.009 ±       0.073  MB/sec
[info] StringOfAsciiCharsWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm              128  thrpt    5        0.022 ±       0.186    B/op
[info] StringOfAsciiCharsWriting.json4sNative:·gc.count                                     128  thrpt    5        6.000                counts
[info] StringOfAsciiCharsWriting.json4sNative:·gc.time                                      128  thrpt    5        7.000                    ms
[info] StringOfEscapedCharsReading.json4sJackson                                            128  thrpt    5  1083023.747 ±   30085.067   ops/s
[info] StringOfEscapedCharsReading.json4sJackson:·gc.alloc.rate                             128  thrpt    5     1957.874 ±      54.613  MB/sec
[info] StringOfEscapedCharsReading.json4sJackson:·gc.alloc.rate.norm                        128  thrpt    5     1896.070 ±       0.046    B/op
[info] StringOfEscapedCharsReading.json4sJackson:·gc.churn.PS_Eden_Space                    128  thrpt    5     1995.788 ±    1618.462  MB/sec
[info] StringOfEscapedCharsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm               128  thrpt    5     1933.576 ±    1583.121    B/op
[info] StringOfEscapedCharsReading.json4sJackson:·gc.churn.PS_Survivor_Space                128  thrpt    5        1.616 ±      12.902  MB/sec
[info] StringOfEscapedCharsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm           128  thrpt    5        1.550 ±      12.372    B/op
[info] StringOfEscapedCharsReading.json4sJackson:·gc.count                                  128  thrpt    5       13.000                counts
[info] StringOfEscapedCharsReading.json4sJackson:·gc.time                                   128  thrpt    5       12.000                    ms
[info] StringOfNonAsciiCharsReading.json4sJackson                                           128  thrpt    5  1767289.211 ±   51871.666   ops/s
[info] StringOfNonAsciiCharsReading.json4sJackson:·gc.alloc.rate                            128  thrpt    5     4354.173 ±     127.419  MB/sec
[info] StringOfNonAsciiCharsReading.json4sJackson:·gc.alloc.rate.norm                       128  thrpt    5     2584.084 ±       0.030    B/op
[info] StringOfNonAsciiCharsReading.json4sJackson:·gc.churn.PS_Eden_Space                   128  thrpt    5     4299.085 ±    1619.213  MB/sec
[info] StringOfNonAsciiCharsReading.json4sJackson:·gc.churn.PS_Eden_Space.norm              128  thrpt    5     2551.247 ±     951.380    B/op
[info] StringOfNonAsciiCharsReading.json4sJackson:·gc.churn.PS_Survivor_Space               128  thrpt    5        0.187 ±       0.371  MB/sec
[info] StringOfNonAsciiCharsReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm          128  thrpt    5        0.111 ±       0.218    B/op
[info] StringOfNonAsciiCharsReading.json4sJackson:·gc.count                                 128  thrpt    5       28.000                counts
[info] StringOfNonAsciiCharsReading.json4sJackson:·gc.time                                  128  thrpt    5       14.000                    ms
[info] StringOfNonAsciiCharsWriting.json4sJackson                                           128  thrpt    5  1510298.220 ±   15856.985   ops/s
[info] StringOfNonAsciiCharsWriting.json4sJackson:·gc.alloc.rate                            128  thrpt    5     4873.038 ±      51.192  MB/sec
[info] StringOfNonAsciiCharsWriting.json4sJackson:·gc.alloc.rate.norm                       128  thrpt    5     3384.112 ±       0.037    B/op
[info] StringOfNonAsciiCharsWriting.json4sJackson:·gc.churn.PS_Eden_Space                   128  thrpt    5     4913.111 ±    1619.729  MB/sec
[info] StringOfNonAsciiCharsWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm              128  thrpt    5     3412.198 ±    1138.965    B/op
[info] StringOfNonAsciiCharsWriting.json4sJackson:·gc.churn.PS_Survivor_Space               128  thrpt    5        0.144 ±       0.161  MB/sec
[info] StringOfNonAsciiCharsWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm          128  thrpt    5        0.100 ±       0.113    B/op
[info] StringOfNonAsciiCharsWriting.json4sJackson:·gc.count                                 128  thrpt    5       32.000                counts
[info] StringOfNonAsciiCharsWriting.json4sJackson:·gc.time                                  128  thrpt    5       14.000                    ms
[info] TwitterAPIReading.json4sJackson                                                      N/A  thrpt    5     5810.612 ±      80.768   ops/s
[info] TwitterAPIReading.json4sJackson:·gc.alloc.rate                                       N/A  thrpt    5     1712.696 ±      23.655  MB/sec
[info] TwitterAPIReading.json4sJackson:·gc.alloc.rate.norm                                  N/A  thrpt    5   309131.276 ±      11.308    B/op
[info] TwitterAPIReading.json4sJackson:·gc.churn.PS_Eden_Space                              N/A  thrpt    5     1688.860 ±    1321.728  MB/sec
[info] TwitterAPIReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                         N/A  thrpt    5   304828.432 ±  238488.164    B/op
[info] TwitterAPIReading.json4sJackson:·gc.churn.PS_Survivor_Space                          N/A  thrpt    5        1.765 ±      14.731  MB/sec
[info] TwitterAPIReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm                     N/A  thrpt    5      319.465 ±    2666.303    B/op
[info] TwitterAPIReading.json4sJackson:·gc.count                                            N/A  thrpt    5       11.000                counts
[info] TwitterAPIReading.json4sJackson:·gc.time                                             N/A  thrpt    5       16.000                    ms
[info] TwitterAPIReading.json4sNative                                                       N/A  thrpt    5     5160.654 ±     142.612   ops/s
[info] TwitterAPIReading.json4sNative:·gc.alloc.rate                                        N/A  thrpt    5     1996.022 ±      54.895  MB/sec
[info] TwitterAPIReading.json4sNative:·gc.alloc.rate.norm                                   N/A  thrpt    5   405646.826 ±      18.958    B/op
[info] TwitterAPIReading.json4sNative:·gc.churn.PS_Eden_Space                               N/A  thrpt    5     1995.799 ±    1618.936  MB/sec
[info] TwitterAPIReading.json4sNative:·gc.churn.PS_Eden_Space.norm                          N/A  thrpt    5   405418.347 ±  325023.501    B/op
[info] TwitterAPIReading.json4sNative:·gc.churn.PS_Survivor_Space                           N/A  thrpt    5        1.565 ±      12.643  MB/sec
[info] TwitterAPIReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                      N/A  thrpt    5      320.552 ±    2591.072    B/op
[info] TwitterAPIReading.json4sNative:·gc.count                                             N/A  thrpt    5       13.000                counts
[info] TwitterAPIReading.json4sNative:·gc.time                                              N/A  thrpt    5       12.000                    ms
[info] VectorOfBooleansReading.json4sJackson                                                128  thrpt    5   104751.072 ±    2443.934   ops/s
[info] VectorOfBooleansReading.json4sJackson:·gc.alloc.rate                                 128  thrpt    5     1522.118 ±      35.602  MB/sec
[info] VectorOfBooleansReading.json4sJackson:·gc.alloc.rate.norm                            128  thrpt    5    15240.576 ±       0.560    B/op
[info] VectorOfBooleansReading.json4sJackson:·gc.churn.PS_Eden_Space                        128  thrpt    5     1535.281 ±       0.292  MB/sec
[info] VectorOfBooleansReading.json4sJackson:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5    15372.828 ±     360.841    B/op
[info] VectorOfBooleansReading.json4sJackson:·gc.churn.PS_Survivor_Space                    128  thrpt    5        1.601 ±      13.266  MB/sec
[info] VectorOfBooleansReading.json4sJackson:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5       16.000 ±     132.544    B/op
[info] VectorOfBooleansReading.json4sJackson:·gc.count                                      128  thrpt    5       10.000                counts
[info] VectorOfBooleansReading.json4sJackson:·gc.time                                       128  thrpt    5       13.000                    ms
[info] VectorOfBooleansReading.json4sNative                                                 128  thrpt    5    92148.267 ±    1687.682   ops/s
[info] VectorOfBooleansReading.json4sNative:·gc.alloc.rate                                  128  thrpt    5     2215.518 ±      40.491  MB/sec
[info] VectorOfBooleansReading.json4sNative:·gc.alloc.rate.norm                             128  thrpt    5    25216.889 ±       0.156    B/op
[info] VectorOfBooleansReading.json4sNative:·gc.churn.PS_Eden_Space                         128  thrpt    5     2149.476 ±    1321.808  MB/sec
[info] VectorOfBooleansReading.json4sNative:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5    24457.346 ±   14853.767    B/op
[info] VectorOfBooleansReading.json4sNative:·gc.churn.PS_Survivor_Space                     128  thrpt    5        1.383 ±      10.769  MB/sec
[info] VectorOfBooleansReading.json4sNative:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5       15.814 ±     123.175    B/op
[info] VectorOfBooleansReading.json4sNative:·gc.count                                       128  thrpt    5       14.000                counts
[info] VectorOfBooleansReading.json4sNative:·gc.time                                        128  thrpt    5        9.000                    ms
[info] VectorOfBooleansWriting.json4sJackson                                                128  thrpt    5    23955.153 ±     407.537   ops/s
[info] VectorOfBooleansWriting.json4sJackson:·gc.alloc.rate                                 128  thrpt    5     5068.593 ±      86.274  MB/sec
[info] VectorOfBooleansWriting.json4sJackson:·gc.alloc.rate.norm                            128  thrpt    5   221919.316 ±       2.505    B/op
[info] VectorOfBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space                        128  thrpt    5     5066.406 ±    1619.228  MB/sec
[info] VectorOfBooleansWriting.json4sJackson:·gc.churn.PS_Eden_Space.norm                   128  thrpt    5   221875.455 ±   73654.200    B/op
[info] VectorOfBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space                    128  thrpt    5        0.156 ±       0.241  MB/sec
[info] VectorOfBooleansWriting.json4sJackson:·gc.churn.PS_Survivor_Space.norm               128  thrpt    5        6.837 ±      10.532    B/op
[info] VectorOfBooleansWriting.json4sJackson:·gc.count                                      128  thrpt    5       33.000                counts
[info] VectorOfBooleansWriting.json4sJackson:·gc.time                                       128  thrpt    5       15.000                    ms
[info] VectorOfBooleansWriting.json4sNative                                                 128  thrpt    5    23954.389 ±     514.197   ops/s
[info] VectorOfBooleansWriting.json4sNative:·gc.alloc.rate                                  128  thrpt    5     5043.233 ±     108.337  MB/sec
[info] VectorOfBooleansWriting.json4sNative:·gc.alloc.rate.norm                             128  thrpt    5   220807.296 ±       2.281    B/op
[info] VectorOfBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space                         128  thrpt    5     5066.780 ±    1619.155  MB/sec
[info] VectorOfBooleansWriting.json4sNative:·gc.churn.PS_Eden_Space.norm                    128  thrpt    5   221800.168 ±   68574.264    B/op
[info] VectorOfBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space                     128  thrpt    5        0.156 ±       0.361  MB/sec
[info] VectorOfBooleansWriting.json4sNative:·gc.churn.PS_Survivor_Space.norm                128  thrpt    5        6.844 ±      15.916    B/op
[info] VectorOfBooleansWriting.json4sNative:·gc.count                                       128  thrpt    5       33.000                counts
[info] VectorOfBooleansWriting.json4sNative:·gc.time                                        128  thrpt    5       17.000                    ms
```

</details>