### PR TITLE
Make scala-java-time-tzdb a test-only dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ supports Scala 2.11.
   codec derivation
 - No dependencies on extra libraries in _runtime_ excluding Scala's `scala-library` (all platforms) and
   `scala-java-time` (replacement of JDKs `java.time._` types for Scala.js and Scala Native)
+- On Scala.js and Scala Native platforms, if you need support for timezones besides `UTC` then you should follow the [scala-java-time documentation](https://cquiroz.github.io/scala-java-time/#time-zones) for adding a time zone database to your application.
 - Codecs and runtime configurations implement `java.io.Serializable` for easier usage in distributive computing
 - Support of shading to another package for locking on a particular released version
 - Patch versions are backward and forward compatible, minor versions are backward compatible

--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,10 @@ lazy val commonSettings = Seq(
 )
 
 lazy val jsSettings = Seq(
+  libraryDependencies ++= Seq(
+    "io.github.cquiroz" %%% "scala-java-time" % "2.5.0" % Test,
+    "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.5.0" % Test
+  ),
   scalaJSLinkerConfig ~= {
     _.withSemantics({
       _.optimized
@@ -63,6 +67,10 @@ lazy val jsSettings = Seq(
 )
 
 lazy val nativeSettings = Seq(
+  libraryDependencies ++= Seq(
+    "io.github.cquiroz" %%% "scala-java-time" % "2.5.0" % Test,
+    "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.5.0" % Test
+  ),
   //nativeMode := "release-full", // Uncomment and test with these options
   //nativeLTO := "thin",
   coverageEnabled := false // FIXME: Unexpected linking error
@@ -132,21 +140,9 @@ lazy val `jsoniter-scala-coreJVM` = `jsoniter-scala-core`.jvm
 
 lazy val `jsoniter-scala-coreJS` = `jsoniter-scala-core`.js
   .settings(jsSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "io.github.cquiroz" %%% "scala-java-time" % "2.5.0",
-      "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.5.0"
-    )
-  )
 
 lazy val `jsoniter-scala-coreNative` = `jsoniter-scala-core`.native
   .settings(nativeSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "io.github.cquiroz" %%% "scala-java-time" % "2.5.0",
-      "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.5.0"
-    )
-  )
 
 lazy val `jsoniter-scala-macros` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Full)

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,6 @@ lazy val commonSettings = Seq(
 
 lazy val jsSettings = Seq(
   libraryDependencies ++= Seq(
-    "io.github.cquiroz" %%% "scala-java-time" % "2.5.0" % Test,
     "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.5.0" % Test
   ),
   scalaJSLinkerConfig ~= {
@@ -68,7 +67,6 @@ lazy val jsSettings = Seq(
 
 lazy val nativeSettings = Seq(
   libraryDependencies ++= Seq(
-    "io.github.cquiroz" %%% "scala-java-time" % "2.5.0" % Test,
     "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.5.0" % Test
   ),
   //nativeMode := "release-full", // Uncomment and test with these options
@@ -133,6 +131,11 @@ lazy val `jsoniter-scala-core` = crossProject(JVMPlatform, JSPlatform, NativePla
       "org.scala-lang.modules" %%% "scala-collection-compat" % "2.9.0" % Test,
       "org.scalatestplus" %%% "scalacheck-1-17" % "3.2.14.0" % Test,
       "org.scalatest" %%% "scalatest" % "3.2.14" % Test
+    )
+  )
+  .platformsSettings(JSPlatform, NativePlatform)(
+    libraryDependencies ++= Seq(
+      "io.github.cquiroz" %%% "scala-java-time" % "2.5.0"
     )
   )
 


### PR DESCRIPTION
The TZDB "timezone database" is not needed for the core functionality of jsoniter-scala but it significantly increases the size of generated JS/Native code. This PR moves this dependency to `Test` scope, so that the `java.time`-related functionality can be tested, without forcing the dependency onto users.

For example, in @keynmol's Scala.js application, the TZDB is 33% of the JS size even though the application is not using `java.time` at all!

![image](https://user-images.githubusercontent.com/3119428/209325701-d70aa48e-2a85-49e1-b967-76f55ce89e12.png)

If users need `java.time` in JS or Native they can add the dependency themselves. Furthermore, instead of including the entire TZDB, they can create a custom TZDB that only contains the exact ones they need. https://github.com/cquiroz/sbt-tzdb