### PR TITLE
chore: fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ When your input comes from the network or disks much more efficient ways are to 
 - byte arrays using `readFromArray`/`writeToArray`
 - byte sub-arrays using `readFromSubArray`/`writeToSubArray`
 - `java.nio.ByteBuffer` instances using `readFromByteBuffer`/`writeToByteBuffer`
-- `java.io.InputString`/`java.io.OutputStream` instances using `readFromStream`/`writeToStream`
+- `java.io.InputStream`/`java.io.OutputStream` instances using `readFromStream`/`writeToStream`
 
 Also, parsing from bytes will check `UTF-8` encoding and throw an error in case of malformed bytes.
 


### PR DESCRIPTION
Hey Andriy! We're using jsoniter-scala to `readFromStream`, saw a small typo here. Really nice feature (stopped some OOM issues, when using a different library with large files), thank you!