### PR TITLE
Support a flag to enable always emitting the discriminator field

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.29.1-SNAPSHOT"
+ThisBuild / version := "2.30.0-SNAPSHOT"


### PR DESCRIPTION
## Summary
This PR adds the `alwaysEmitDiscriminator` flag to CodecMakerConfig in order to support always emitting the discriminator field for ADT leaf classes. This new flag has no effect on generated decoders, and it does not effect encoder generation for classes that are not members of ADTs. This new flag also should have no effect on codecs derived for the root of the ADT.

## Motivation
The motivation for this PR is the use case of transitioning an existing API from a different json library to jsoniter-scala, wherein previously the type discriminators of ADT leaf classes were always serialized by the prior json library and the clients have come to depend upon it.

As a simplified example, consider the following exemplary data model:

```scala
// The ADT
sealed trait Base
case class Foo(x: Int, y: String) extends Base
case class Bar(a: String, b: Double) extends Base

// Top level data models exposed by API
case class Alpha(foo: Foo)
case class Beta(bar: Bar)
case class Gamma(base: Base)
```

The default behavior of jsoniter derived codecs is to only serialize the type discriminators when they are strictly required -- that is if during derivation a value is statically known to be a concrete ADT Leaf type, the derived codecs neither serialize the type discriminator nor require it. Thus by default, the following json is generated for instances of `Alpha`, `Beta`, and `Gamma` respectively

```scala
Alpha(foo = Foo(x = 1, y = "a string"))
```
```json
{
  "foo": {
    "x": 1,
    "y": "a string"
  }
}
```

```scala
Beta(bar = Bar(a = "a string", b = 1.2))
```
```json
{
  "bar": {
     "a": "a string",
     "b": 1.2
   }
}
```

Note in this case the discriminator must be, and is, serialized
```scala
Gamma(base = Foo(x = 1, y = "a string"))
```
```json
{
  "base": {
    "type": "Foo",
    "x": 1,
    "y": "a string"
  }
}
```

This PR enables setting a new flag in the CodecMakerConfig, namely `CodecMakerConfig.withAlwaysEmitDiscriminator(true)`, which changes the behavior to always emit the discriminator regardless of whether or not it is strictly required based upon the statically known type.  Concretly, the 3 examples above would now become serialized like the following.

```json
{
  "foo": {
    "type": "Foo",
    "x": 1,
    "y": "a string"
  }
}
```
```json
{
  "bar": {
     "type": "Bar",
     "a": "a string",
     "b": 1.2
   }
}
```
```json
{
  "base": {
    "type": "Foo",
    "x": 1,
    "y": "a string"
  }
}
```

### Reading compatibility
Also note that while the serialized output above would be generated, the original json without the not-strictly-necessary discriminators would still successfully deserialize as expected.