### PR TITLE
Generate a valid `Automatic-Module-Name` attribute

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,7 @@ lazy val noPublishSettings = Seq(
 )
 
 lazy val publishSettings = Seq(
-  packageOptions += Package.ManifestAttributes("Automatic-Module-Name" -> moduleName.value),
+  packageOptions += Package.ManifestAttributes("Automatic-Module-Name" -> moduleName.value.replace("-", ".")),
   mimaCheckDirection := {
     def isPatch: Boolean = {
       val Array(newMajor, newMinor, _) = version.value.split('.')


### PR DESCRIPTION
`jsoniter-scala-core` is not a valid Java identifier because of dashes in the name, making it impossible to import the module:
```
> jar --describe-module -f jsoniter-scala-core_2.13-2.28.5.jar
Unable to derive module descriptor for: jsoniter-scala-core_2.13-2.28.5.jar
Automatic-Module-Name: jsoniter-scala-core: Invalid module name: 'jsoniter-scala-core' is not a Java identifier
```

This change uses dots instead of dashes making it a valid Java identifier.