### PR TITLE
adjust number handling

### DIFF
--- a/jsoniter-scala-upickle/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/upickle/VisitorDecoder.scala
+++ b/jsoniter-scala-upickle/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/upickle/VisitorDecoder.scala
@@ -91,8 +91,7 @@ object VisitorNumberReader {
         } else {
           val x = in.readBigInt(null)
           if (x.isValidLong) v.visitInt64(x.longValue, -1)
-          else v.visitString(x.toString(), -1) // see: ujson/JsVisitor.scala#L33
-          // alt: v.visitFloat64StringParts(x.toString(), -1, -1, -1)
+          else v.visitFloat64StringParts(x.toString(), -1, -1, -1)
         }
       } else {
         in.setMark()
@@ -104,8 +103,8 @@ object VisitorNumberReader {
           x
         } else {
           in.rollbackToMark()
-          v.visitString(new String(in.readRawValAsBytes(), StandardCharsets.US_ASCII), -1) // see: ujson/JsVisitor.scala#L33
-          // alt: v.visitFloat64StringParts(new String(in.readRaw...), -1, -1, -1)
+          val bytes = in.readRawValAsBytes()
+          v.visitFloat64ByteParts(bytes, 0, bytes.length, -1, -1, -1)
         }
       }
     }


### PR DESCRIPTION
This use better aligns with my use case of handling big numbers particularly without resorting to `visitString`. Also, stumbled on this use of `visitFloat64StringParts` [here](https://github.com/com-lihaoyi/upickle/blob/4.0.2/ujson/json4s/src/ujson/json4s/Json4sJson.scala).