### PR TITLE
Sort ADT leaf classes in generated codec

### DIFF
--- a/jsoniter-scala-macros/shared/src/main/scala-2/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
+++ b/jsoniter-scala-macros/shared/src/main/scala-2/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
@@ -910,7 +910,8 @@ object JsonCodecMaker {
           else leafTpes
         }
 
-        val classes = collectRecursively(adtBaseTpe).distinct
+        val classes = collectRecursively(adtBaseTpe).distinct.sortBy(_.typeSymbol.fullName)
+
         if (classes.isEmpty) fail(s"Cannot find leaf classes for ADT base '$adtBaseTpe'. " +
           "Please add them or provide a custom implicitly accessible codec for the ADT base.")
         classes

--- a/jsoniter-scala-macros/shared/src/main/scala-3/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
+++ b/jsoniter-scala-macros/shared/src/main/scala-3/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
@@ -1071,7 +1071,7 @@ object JsonCodecMaker {
           if (isNonAbstractScalaClass(tpe)) leafTpes :+ tpe
           else leafTpes
 
-        val classes = collectRecursively(adtBaseTpe).distinct
+        val classes = collectRecursively(adtBaseTpe).distinct.sortBy(_.typeSymbol.fullName)
         if (classes.isEmpty) fail(s"Cannot find leaf classes for ADT base '${adtBaseTpe.show}'. " +
           "Please add them or provide a custom implicitly accessible codec for the ADT base.")
         classes


### PR DESCRIPTION
This PR sorts ADT leaf classes, so they are generated in a deterministic order.

Without this change generated codecs were non deterministic which lead to breaking remote cache based on hash of the output classfile.