### PR TITLE
compat: ensure '.withRequireDiscriminatorFirst(false)' is set …

### DIFF
--- a/jsoniter-scala-macros/shared/src/main/scala-3/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
+++ b/jsoniter-scala-macros/shared/src/main/scala-3/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
@@ -704,6 +704,7 @@ object JsonCodecMaker {
 
     def makeOpenapiLike[A: Type](discriminatorFieldName: Expr[String])(using Quotes): Expr[JsonValueCodec[A]] =
       make(CodecMakerConfig.withTransientEmpty(false).withTransientDefault(false)
+        .withRequireDiscriminatorFirst(false)
         .withRequireCollectionFields(true).withAllowRecursiveTypes(true)
         .withDiscriminatorFieldName(Some(discriminatorFieldName.valueOrAbort)))
 
@@ -712,6 +713,7 @@ object JsonCodecMaker {
       make(
         CodecMakerConfig.withTransientEmpty(false).withTransientDefault(false)
           .withRequireCollectionFields(true).withAllowRecursiveTypes(true)
+          .withRequireDiscriminatorFirst(false)
           .withDiscriminatorFieldName(Some(discriminatorFieldName.valueOrAbort))
           .withAdtLeafClassNameMapper(ExprPartialFunctionWrapper(adtLeafClassNameMapper).apply.unlift
             .compose(PartialFunction.fromFunction(simpleClassName))))


### PR DESCRIPTION
…on relevant makeOpenapiLike methods in scala 3

My eternal migration from scala 2 to scala 3 on the project from hell (not this one, I mean a work thing) continues. A compatibility issue is herein presented: `.withRequireDiscriminatorFirst(false)` is the 'correct' setting for openapi compatibility, and is configured on the relevant methods for scala 2; however, it was missing from the corresponding scala 3 implementations.

My apologies for missing it the first time around.