### PR TITLE
Fix to remove needless allocations (performance)

### DIFF
--- a/jsoniter-scala-core/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
+++ b/jsoniter-scala-core/js/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
@@ -4051,7 +4051,9 @@ final class JsonReader private[jsoniter_scala](
       if (mark > 0) mark = 0
       tail = remaining
       head = newPos
-    } else growBuf()
+    } else {
+      if (tail > 0) growBuf()
+    }
     var len = buf.length - tail
     if (bbuf ne null) {
       len = Math.min(bbuf.remaining, len)

--- a/jsoniter-scala-core/jvm-native/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
+++ b/jsoniter-scala-core/jvm-native/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala
@@ -4506,7 +4506,9 @@ final class JsonReader private[jsoniter_scala](
       if (mark > 0) mark = 0
       tail = remaining
       head = newPos
-    } else growBuf()
+    } else {
+      if (tail > 0) growBuf()
+    }
     var len = buf.length - tail
     if (bbuf ne null) {
       len = Math.min(bbuf.remaining, len)


### PR DESCRIPTION
Before this fix, every decode operation would reallocate the `buf` Array. This is because at the start of read, pos=head=0.

Then, because we've grown the buffer, at the end of the read operation we'd allocate the array AGAIN to shrink it back because it is now larger than the preferred buffer size config!

The problem started with the commit:

f0ebbe1e7  Code clean up (Andriy Plokhotnyuk) 2020-01-02|

```diff
-      newPos
-    } else {
-      if (tail > 0) buf = java.util.Arrays.copyOf(buf, buf.length << 1)
-      pos
-    }
+    } else buf = java.util.Arrays.copyOf(buf, buf.length << 1)
```

This change restores the original check for the `tail > 0` which is used to indicate that the buffer is currently empty (start of the read operation) and we should not grow it.

Example of the allocation stacktrace before this is fixed:
<img width="2952" height="394" alt="2025-11-11T10:06:18,613828754+00:00" src="https://github.com/user-attachments/assets/72da8f26-4272-450b-b41b-a7584f456b18" />


Not adding the allocation stacktrace after because it's all nice and empty.