### PR TITLE
Fix scala 3.8 regression

### DIFF
--- a/jsoniter-scala-macros/shared/src/main/scala-3/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
+++ b/jsoniter-scala-macros/shared/src/main/scala-3/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
@@ -1286,9 +1286,12 @@ private class JsonCodecMakerInstance(cfg: CodecMakerConfig)(using Quotes) {
     val typeSymbol = tpe.typeSymbol
     typeSymbol.children.map { sym =>
       if (sym.isType) {
-        if (sym.name == "<local child>") // problem - we have no other way to find this other return the name
-          fail(s"Local child symbols are not supported, please consider change '${tpe.show}' or implement a " +
-            "custom implicitly accessible codec")
+        if (
+            sym.name == "<local child>" // scala 2 anonymous class anonymous class extending typeSymbol type
+            || sym == typeSymbol // scala 3 anonymous class extending typeSymbol type
+          )
+            fail(s"Local child symbols are not supported, please consider change '${tpe.show}' or implement a " +
+              "custom implicitly accessible codec")
         val nudeSubtype = sym.typeRef
         val tpeArgsFromChild = typeArgs(nudeSubtype.baseType(typeSymbol))
         nudeSubtype.memberType(sym.primaryConstructor) match


### PR DESCRIPTION
Starting with scala.3.8, standard library will now be compiled with scala 3, instead of reusing scala 2 artifacts. This means that the way certain symbols are represented will change.  For this project, we've run into an issue, where for:
```scala
sealed abstract class Infinite
val Undefined: Infinite = new Infinite {}
```
scala 2 would generate a `<local child>` symbol to assign to the child anonymous class, and scala 3 would intentionally reuse the parent symbol with the same goal - both behaviors are intended for pattern matcher to be able to give exhaustivity errors. 
In this fix here, we handle the scala 3 local child the same way we did for the scala 2 counterpart.
Related discussion: https://github.com/scala/scala3/issues/24598