### PR TITLE
Codec derivation support for custom collection that implements a scala collection

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -220,6 +220,7 @@ lazy val `jsoniter-scala-macros` = crossProject(JVMPlatform, JSPlatform, NativeP
       )
       case _ => Seq()
     }) ++ Seq(
+      "dev.zio" %%% "zio" % "2.1.23" % Test,
       "com.epam.deltix" % "dfp" % "1.0.10" % Test,
       "org.scalatest" %%% "scalatest" % "3.2.19" % Test,
       "org.scala-lang.modules" %%% "scala-collection-compat" % "2.14.0" % Test

--- a/jsoniter-scala-macros/shared/src/main/scala-2/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
+++ b/jsoniter-scala-macros/shared/src/main/scala-2/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
@@ -744,9 +744,11 @@ object JsonCodecMaker {
 
       def isJavaEnum(tpe: Type): Boolean = tpe <:< typeOf[java.lang.Enum[?]]
 
-      def scalaCollectionCompanion(tpe: Type): Tree =
-        if (tpe.typeSymbol.fullName.startsWith("scala.collection.")) Ident(tpe.typeSymbol.companion)
+      def scalaCollectionCompanion(tpe: Type): Tree = {
+        def isScalaCollection(s: Symbol) = s.fullName.startsWith("scala.collection.")
+        if (isScalaCollection(tpe.typeSymbol) || tpe.baseClasses.exists(isScalaCollection)) Ident(tpe.typeSymbol.companion)
         else fail(s"Unsupported type '$tpe'. Please consider using a custom implicitly accessible codec for it.")
+      }
 
       def enumSymbol(tpe: Type): Symbol = tpe match {
         case TypeRef(SingleType(_, enumSymbol), _, _) => enumSymbol

--- a/jsoniter-scala-macros/shared/src/main/scala-3/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
+++ b/jsoniter-scala-macros/shared/src/main/scala-3/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
@@ -994,7 +994,8 @@ private class JsonCodecMakerInstance(cfg: CodecMakerConfig)(using Quotes) {
 
   private def scalaCollectionCompanion(tpe: TypeRepr): Term =
     val typeSymbol = tpe.typeSymbol
-    if (typeSymbol.fullName.startsWith("scala.collection.")) Ref(typeSymbol.companionModule)
+    def isScalaCollection(s: Symbol) = s.fullName.startsWith("scala.collection.") 
+    if (isScalaCollection(typeSymbol) || tpe.baseClasses.exists(isScalaCollection)) Ref(typeSymbol.companionModule)
     else fail(s"Unsupported type '${tpe.show}'. Please consider using a custom implicitly accessible codec for it.")
 
   private def scalaCollectionBuilder(tpe: TypeRepr, eTpe: TypeRepr): Term =

--- a/jsoniter-scala-macros/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMakerSpec.scala
+++ b/jsoniter-scala-macros/shared/src/test/scala/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMakerSpec.scala
@@ -1391,6 +1391,9 @@ class JsonCodecMakerSpec extends VerifyingSpec {
 
       verifySerDeser(myEventCodec, MyEvent(Props("John", 42)), """{"props":{"name":"John","age":42}}""")
     }
+    "serialize and deserialize a custom collection that implements a scala collection" in {
+      verifySerDeser(make[zio.Chunk[String]], zio.Chunk("VVV", "WWW"), """["VVV","WWW"]""")
+    }
     "serialize and deserialize case classes with value classes" in {
       case class ValueClassTypes(uid: UserId, oid: OrderId)
 


### PR DESCRIPTION
Hi, I was looking for a way to support codec derivation for custom collection types like `zio.Chunk` for example instead of creating custom codecs for each and ended up with this change.

I'm using it with this Google Cloud Platform client code [generator](https://github.com/rolang/google-rest-api-codegen) to generate client code for the zio ecosystem like [anyMindGroup/zio-gcp](https://github.com/anyMindGroup/zio-gcp) and would like to use `zio.Chunk` as default collection in that case. At the moment it generates a lot of additional code to add custom codecs, but if it was working out of the box, I could remove all of it, so it would be great :).

Not sure if it's ok to add `zio` as test dependency, but it was the easiest way to get a custom collection that works across different Scala versions for testing. If not I could try to implement some simple custom collection type for testing without introducing dependencies. 