### PR TITLE
Fix Scala 2.13 macro derivation for generic ADTs

### DIFF
--- a/jsoniter-scala-macros/shared/src/main/scala-2/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
+++ b/jsoniter-scala-macros/shared/src/main/scala-2/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala
@@ -1047,11 +1047,12 @@ object JsonCodecMaker {
                   case _ =>
                 }
               }
-              subTpe = subTpe.substituteTypes(typeParams, typeParams.map { typeParam =>
+              val resolvedTypeArgs = typeParams.map { typeParam =>
                 subTpeParamsToArgs.getOrElse(typeParam, typeParamsAndArgs.getOrElse(typeParam, fail {
                   s"Cannot resolve generic type(s) for '$subTpe'. Please provide a custom implicitly accessible codec for it."
                 }))
-              })
+              }
+              subTpe = appliedType(subTpe.typeConstructor, resolvedTypeArgs)
             }
             if (isSealedClass(subTpe)) collectRecursively(subTpe)
             else if (isValueClass(subTpe)) {

--- a/jsoniter-scala-macros/shared/src/test/scala-2/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMakerCompileTimeEvalSpec.scala
+++ b/jsoniter-scala-macros/shared/src/test/scala-2/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMakerCompileTimeEvalSpec.scala
@@ -25,6 +25,19 @@ import org.scalatest.exceptions.TestFailedException
 
 class JsonCodecMakerCompileTimeEvalSpec extends VerifyingSpec {
   "JsonCodecMaker.make" should {
+    "compile codecs for case classes with Either fields" in {
+      assertCompiles {
+        """import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+          |import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+          |
+          |case class Foo(value: Either[Int, String])
+          |
+          |object Foo {
+          |  implicit val codec: JsonValueCodec[Foo] = JsonCodecMaker.make[Foo]
+          |}
+          |""".stripMargin
+      }
+    }
     "don't generate codecs when a parameter of the 'make' call depends on not yet compiled code" in {
       assert(intercept[TestFailedException](assertCompiles {
         """object A {


### PR DESCRIPTION
The type parameter lists were empty, by applying the type the type
parameters are now available.

Fixes https://github.com/plokhotnyuk/jsoniter-scala/issues/1430